### PR TITLE
Fix okays breaking combo

### DIFF
--- a/Quaver/src/GameState/Gameplay/ScoreManager.cs
+++ b/Quaver/src/GameState/Gameplay/ScoreManager.cs
@@ -248,7 +248,7 @@ namespace Quaver.GameState.Gameplay
             RelativeAcc = Math.Max(RelativeAcc / (TotalJudgeCount * 100), -100);
 
             //If note is not pressed properly, update combo and multplier
-            if (index < 4)
+            if (index < 5)
             {
                 //Update Multiplier
                 if (index == 3)


### PR DESCRIPTION
Not a fan of how it was before. Misses should break combo. @staravia any reason why you think otherwise, since you implemented it this way?

