### PR TITLE
Prevent insta-death on LN walls

### DIFF
--- a/Quaver/src/GameState/Gameplay/ScoreManager.cs
+++ b/Quaver/src/GameState/Gameplay/ScoreManager.cs
@@ -180,11 +180,11 @@ namespace Quaver.GameState.Gameplay
         /// </summary>
         internal float[] HitWindowRelease { get; } =
         {
-            JudgeWindow.Marv * 1.25f,
-            JudgeWindow.Perf * 1.1f,
-            JudgeWindow.Great * 2.0f,
+            JudgeWindow.Marv * 1.5f,
+            JudgeWindow.Perf * 1.7f,
+            JudgeWindow.Great * 1.8f,
             JudgeWindow.Good * 2.0f,
-            JudgeWindow.Okay
+            JudgeWindow.Okay 
         };
 
         /// <summary>


### PR DESCRIPTION
Small change, but things like LN vibro and trills shouldn't kill you instantly now. Might still need tweaking.

```cs
internal float[] HitWindowRelease { get; } =
{
    JudgeWindow.Marv * 1.25f,
    JudgeWindow.Perf * 1.1f,
    JudgeWindow.Great * 2.0f,
    JudgeWindow.Good * 2.0f,
    JudgeWindow.Okay
};
```