### PR TITLE
Include MonoGame

### DIFF
--- a/Quaver/MonoGame.Framework.dll.config
+++ b/Quaver/MonoGame.Framework.dll.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<dllmap dll="SDL2.dll" os="osx" target="libSDL2-2.0.0.dylib"/>
+	<dllmap dll="soft_oal.dll" os="osx" target="libopenal.1.dylib" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86" target="./x86/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86" target="./x86/libopenal.so.1" />
+	<dllmap dll="SDL2.dll" os="linux" cpu="x86-64" target="./x64/libSDL2-2.0.so.0"/>
+	<dllmap dll="soft_oal.dll" os="linux" cpu="x86-64" target="./x64/libopenal.so.1" />
+</configuration>

--- a/Quaver/Quaver.csproj
+++ b/Quaver/Quaver.csproj
@@ -222,8 +222,9 @@
       <HintPath>..\packages\ManagedBass.Fx.1.0.2\lib\portable-net45+MonoAndroid+uap\ManagedBass.Fx.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="MonoGame.Framework">
-      <HintPath>$(MonoGameInstallDirectory)\MonoGame\v3.0\Assemblies\DesktopGL\MonoGame.Framework.dll</HintPath>
+    <Reference Include="MonoGame.Framework, Version=3.6.0.1625, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoGame.Framework.DesktopGL.3.6.0.1625\lib\net40\MonoGame.Framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
@@ -278,11 +279,6 @@
       <Link>Lib\libopenal.1.dylib</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="C:\Program Files (x86)\MonoGame\v3.0\Assemblies\DesktopGL\MonoGame.Framework.dll.config">
-      <Link>MonoGame.Framework.dll.config</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
-    </None>
     <None Include="app.manifest" />
     <None Include="Lib\libopenal.so.1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -302,6 +298,7 @@
     <None Include="Lib\libbass_fx.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="MonoGame.Framework.dll.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Quaver/packages.config
+++ b/Quaver/packages.config
@@ -4,6 +4,7 @@
   <package id="HoLLy.osu.DatabaseReader" version="2.1.0" targetFramework="net45" />
   <package id="ManagedBass" version="2.0.2" targetFramework="net45" />
   <package id="ManagedBass.Fx" version="1.0.2" targetFramework="net45" />
+  <package id="MonoGame.Framework.DesktopGL" version="3.6.0.1625" targetFramework="net45" />
   <package id="NAudio" version="1.8.4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="osu.Shared" version="1.0.2" targetFramework="net45" />


### PR DESCRIPTION
Includes the MonoGame framework as a NuGet package so that developers don't have to manually download the framework