### PR TITLE
Audio Offset Fix

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -171,7 +171,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             HitObjectManager.PlayObjectHitSounds(gameplayHitObject.Info);
 
             // Get Judgement and references
-            var time = (int) Ruleset.Screen.Timing.Time;
+            var time = (int)manager.CurrentAudioPosition;
             var hitDifference = gameplayHitObject.Info.StartTime - time;
             var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Press);
             var lane = gameplayHitObject.Info.Lane - 1;
@@ -201,7 +201,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Update Playfield
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
             playfield.Stage.ComboDisplay.MakeVisible();
-            playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - Ruleset.Screen.Timing.Time);
+            playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - manager.CurrentAudioPosition);
             playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
 
             // Update Object Pooling
@@ -237,7 +237,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Get judgement and references
             var lane = gameplayHitObject.Info.Lane - 1;
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
-            var hitDifference = manager.HeldLongNoteLanes[lane].Peek().Info.EndTime - (int) Ruleset.Screen.Timing.Time;
+            var hitDifference = (int)(manager.HeldLongNoteLanes[lane].Peek().Info.EndTime - manager.CurrentAudioPosition);
             var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Release);
 
             // Update animations
@@ -256,7 +256,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                         HitStatType.Hit,
                         KeyPressType.Release,
                         gameplayHitObject.Info,
-                        (int)Ruleset.Screen.Timing.Time,
+                        (int)manager.CurrentAudioPosition,
                         judgement,
                         hitDifference,
                         Ruleset.ScoreProcessor.Accuracy,
@@ -268,7 +268,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
                 // Update Playfield
                 playfield.Stage.ComboDisplay.MakeVisible();
-                playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.EndTime - (int) Ruleset.Screen.Timing.Time);
+                playfield.Stage.HitError.AddJudgement(judgement, (int)(gameplayHitObject.Info.EndTime - manager.CurrentAudioPosition));
                 playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
 
                 // If the player recieved an early miss or "okay",
@@ -291,7 +291,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     HitStatType.Hit,
                     KeyPressType.Release,
                     gameplayHitObject.Info,
-                    (int)Ruleset.Screen.Timing.Time,
+                    (int)manager.CurrentAudioPosition,
                     Judgement.Miss,
                     hitDifference,
                     Ruleset.ScoreProcessor.Accuracy,

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -185,7 +185,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     isHoldingAnyNotes = true;
                 }
 
-                return !(nextObject.StartTime - Ruleset.Screen.Timing.Time < GameplayAudioTiming.StartDelay + 5000) && !isHoldingAnyNotes;
+                return !(nextObject.StartTime - CurrentAudioPosition < GameplayAudioTiming.StartDelay + 5000) && !isHoldingAnyNotes;
             }
         }
 
@@ -318,7 +318,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Check to see if the player missed any active notes
             foreach (var lane in ActiveNoteLanes)
             {
-                while (lane.Count > 0 && (int)Ruleset.Screen.Timing.Time > lane.Peek().Info.StartTime + Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay])
+                while (lane.Count > 0 && CurrentAudioPosition > lane.Peek().Info.StartTime + Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay])
                 {
                     // Current hit object
                     var hitObject = lane.Dequeue();
@@ -374,7 +374,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Check to see if any LN releases were missed (Counts as an okay instead of a miss.)
             foreach (var lane in HeldLongNoteLanes)
             {
-                while (lane.Count > 0 && (int)Ruleset.Screen.Timing.Time > lane.Peek().Info.EndTime + window)
+                while (lane.Count > 0 && CurrentAudioPosition > lane.Peek().Info.EndTime + window)
                 {
                     // Current hit object
                     var hitObject = lane.Dequeue();
@@ -514,9 +514,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public void KillHoldPoolObject(GameplayHitObjectKeys gameplayHitObject)
         {
             // Change start time and LN size.
-            var time = Ruleset.Screen.Timing.Time;
-            gameplayHitObject.InitialTrackPosition = GetPositionFromTime(time);
-            gameplayHitObject.Info.StartTime = (int)time;
+            gameplayHitObject.InitialTrackPosition = GetPositionFromTime(CurrentAudioPosition);
+            gameplayHitObject.Info.StartTime = (int)CurrentAudioPosition;
             gameplayHitObject.CurrentlyBeingHeld = false;
             gameplayHitObject.UpdateLongNoteSize(gameplayHitObject.InitialTrackPosition);
             gameplayHitObject.Kill();


### PR DESCRIPTION
CurrentAudioPosition is now referenced instead of Timing.Time.
PR pertains to this issue: https://github.com/Swan/Quaver/issues/233