### PR TITLE
Rename "Default Skin" to "Skin Style"

### DIFF
--- a/Quaver.Shared/Config/ConfigHelper.cs
+++ b/Quaver.Shared/Config/ConfigHelper.cs
@@ -231,9 +231,9 @@ namespace Quaver.Shared.Config
         /// <param name="s"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static DefaultSkins ReadDefaultSkin(DefaultSkins defaultSkins, string newVal)
+        internal static SkinStyles ReadSkinStyle(SkinStyles defaultSkins, string newVal)
         {
-            return Enum.TryParse(newVal, out DefaultSkins newDefault) ? newDefault : defaultSkins;
+            return Enum.TryParse(newVal, out SkinStyles newDefault) ? newDefault : defaultSkins;
         }
 
         /// <summary>

--- a/Quaver.Shared/Config/ConfigHelper.cs
+++ b/Quaver.Shared/Config/ConfigHelper.cs
@@ -227,13 +227,13 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     Reads a DefaultSkin
         /// </summary>
-        /// <param name="defaultSkins"></param>
+        /// <param name="defaultStyle"></param>
         /// <param name="s"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static SkinStyles ReadSkinStyle(SkinStyles defaultSkins, string newVal)
+        internal static SkinStyles ReadSkinStyle(SkinStyles defaultStyle, string newVal)
         {
-            return Enum.TryParse(newVal, out SkinStyles newDefault) ? newDefault : defaultSkins;
+            return Enum.TryParse(newVal, out SkinStyles newDefault) ? newDefault : defaultStyle;
         }
 
         /// <summary>

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -27,7 +27,7 @@ namespace Quaver.Shared.Config
     public static class ConfigManager
     {
         /// <summary>
-        ///     These are all values that should never ben
+        ///     These are all values that should never been
         /// </summary>
         private static string _gameDirectory;
         internal static Bindable<string> GameDirectory { get; private set; }
@@ -379,7 +379,7 @@ namespace Quaver.Shared.Config
             DownScroll7K = ReadValue(@"DownScroll7K", true, data);
             GlobalAudioOffset = ReadInt(@"GlobalAudioOffset", 0, int.MinValue, int.MaxValue, data);
             Skin = ReadSpecialConfigType(SpecialConfigType.Skin, @"Skin", "", data);
-            SkinStyle = ReadValue(@"DefaultSkin", SkinStyles.Bar, data);
+            SkinStyle = ReadValue(@"SkinStyle", SkinStyles.Bar, data);
             Pitched = ReadValue(@"Pitched", true, data);
             ScoreboardVisible = ReadValue(@"ScoreboardVisible", true, data);
             AnimateJudgementCounter = ReadValue(@"AnimateJudgementCounter", true, data);
@@ -704,7 +704,7 @@ namespace Quaver.Shared.Config
     }
 
     /// <summary>
-    ///     Enum containing a number representation of the default skins we have available
+    ///     Enum containing a number representation of the skin styles we have available
     /// </summary>
     public enum SkinStyles
     {

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     The default skin that will be loaded if the skin property is blank
         /// </summary>
-        internal static Bindable<DefaultSkins> DefaultSkin { get; private set; }
+        internal static Bindable<SkinStyles> SkinStyle { get; private set; }
 
         /// <summary>
         ///     The master volume of the game.
@@ -379,7 +379,7 @@ namespace Quaver.Shared.Config
             DownScroll7K = ReadValue(@"DownScroll7K", true, data);
             GlobalAudioOffset = ReadInt(@"GlobalAudioOffset", 0, int.MinValue, int.MaxValue, data);
             Skin = ReadSpecialConfigType(SpecialConfigType.Skin, @"Skin", "", data);
-            DefaultSkin = ReadValue(@"DefaultSkin", DefaultSkins.Bar, data);
+            SkinStyle = ReadValue(@"DefaultSkin", SkinStyles.Bar, data);
             Pitched = ReadValue(@"Pitched", true, data);
             ScoreboardVisible = ReadValue(@"ScoreboardVisible", true, data);
             AnimateJudgementCounter = ReadValue(@"AnimateJudgementCounter", true, data);
@@ -449,7 +449,7 @@ namespace Quaver.Shared.Config
                     DownScroll7K.ValueChanged += AutoSaveConfiguration;
                     GlobalAudioOffset.ValueChanged += AutoSaveConfiguration;
                     Skin.ValueChanged += AutoSaveConfiguration;
-                    DefaultSkin.ValueChanged += AutoSaveConfiguration;
+                    SkinStyle.ValueChanged += AutoSaveConfiguration;
                     Pitched.ValueChanged += AutoSaveConfiguration;
                     ScoreboardVisible.ValueChanged += AutoSaveConfiguration;
                     AutoLoginToServer.ValueChanged += AutoSaveConfiguration;
@@ -494,7 +494,7 @@ namespace Quaver.Shared.Config
             // Attempt to parse the value and default it if it can't.
             try
             {
-                binded.Value = (T) converter.ConvertFromString(null, CultureInfo.InvariantCulture, ini[name]);
+                binded.Value = (T)converter.ConvertFromString(null, CultureInfo.InvariantCulture, ini[name]);
             }
             catch (Exception e)
             {
@@ -683,7 +683,7 @@ namespace Quaver.Shared.Config
             try
             {
                 using (var inputStream = File.Open(sFilename, FileMode.Open, FileAccess.Read, FileShare.None))
-                    return ( inputStream.Length > 0 );
+                    return (inputStream.Length > 0);
             }
             catch (Exception)
             {
@@ -706,7 +706,7 @@ namespace Quaver.Shared.Config
     /// <summary>
     ///     Enum containing a number representation of the default skins we have available
     /// </summary>
-    public enum DefaultSkins
+    public enum SkinStyles
     {
         Bar,
         Arrow

--- a/Quaver.Shared/Screens/Settings/Elements/SettingsSkinStyle.cs
+++ b/Quaver.Shared/Screens/Settings/Elements/SettingsSkinStyle.cs
@@ -12,14 +12,14 @@ using Quaver.Shared.Config;
 
 namespace Quaver.Shared.Screens.Settings.Elements
 {
-    public class SettingsDefaultSkin : SettingsHorizontalSelector
+    public class SettingsSkinStyle : SettingsHorizontalSelector
     {
         /// <inheritdoc />
         /// <summary>
         /// </summary>
         /// <param name="dialog"></param>
         /// <param name="name"></param>
-        public SettingsDefaultSkin(SettingsDialog dialog, string name)
+        public SettingsSkinStyle(SettingsDialog dialog, string name)
             : base(dialog, name, GetSelectorElements(), (val, i) => OnChange(dialog, val, i), GetSelectedIndex())
         {
         }
@@ -27,7 +27,7 @@ namespace Quaver.Shared.Screens.Settings.Elements
         /// <summary>
         /// </summary>
         /// <returns></returns>
-        private static List<string> GetSelectorElements() => Enum.GetNames(typeof(DefaultSkins)).ToList();
+        private static List<string> GetSelectorElements() => Enum.GetNames(typeof(SkinStyles)).ToList();
 
         /// <summary>
         /// </summary>
@@ -35,12 +35,12 @@ namespace Quaver.Shared.Screens.Settings.Elements
         /// <param name="val"></param>
         /// <param name="index"></param>
         private static void OnChange(SettingsDialog dialog, string val, int index)
-            => dialog.NewQueuedDefaultSkin = (DefaultSkins) Enum.Parse(typeof(DefaultSkins), val);
+            => dialog.NewQueuedSkinStyle = (SkinStyles)Enum.Parse(typeof(SkinStyles), val);
 
         /// <summary>
         /// </summary>
         /// <returns></returns>
         private static int GetSelectedIndex()
-            => GetSelectorElements().FindIndex(x => x.ToString() == ConfigManager.DefaultSkin.Value.ToString());
+            => GetSelectorElements().FindIndex(x => x.ToString() == ConfigManager.SkinStyle.Value.ToString());
     }
 }

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Screens.Settings
         /// <summary>
         ///     A newly queued default skin, if the user chooses to change it.
         /// </summary>
-        public DefaultSkins NewQueuedDefaultSkin { get; set; }
+        public SkinStyles NewQueuedSkinStyle { get; set; }
 
         /// <summary>
         ///     If the user has changed their resolution and it needs to change when they press OK.
@@ -106,7 +106,7 @@ namespace Quaver.Shared.Screens.Settings
         {
             // Important. Make sure sure the default values that are sent in config if the values
             // are non nullable.
-            NewQueuedDefaultSkin = ConfigManager.DefaultSkin.Value;
+            NewQueuedSkinStyle = ConfigManager.SkinStyle.Value;
             NewQueuedScreenResolution = new Point(ConfigManager.WindowWidth.Value, ConfigManager.WindowHeight.Value);
 
             Animations.Add(new Animation(AnimationProperty.Alpha, Easing.OutQuint, Alpha, 0.65f, 300));
@@ -245,10 +245,10 @@ namespace Quaver.Shared.Screens.Settings
                 var dismissDalog = true;
 
                 // Handle skin reloads
-                if (NewQueuedSkin != null || NewQueuedDefaultSkin != ConfigManager.DefaultSkin.Value)
+                if (NewQueuedSkin != null || NewQueuedSkinStyle != ConfigManager.SkinStyle.Value)
                 {
                     ConfigManager.Skin.Value = NewQueuedSkin;
-                    ConfigManager.DefaultSkin.Value = NewQueuedDefaultSkin;
+                    ConfigManager.SkinStyle.Value = NewQueuedSkinStyle;
 
                     Transitioner.FadeIn();
                     TimeSkinReloadRequested = GameBase.Game.TimeRunning;
@@ -323,7 +323,7 @@ namespace Quaver.Shared.Screens.Settings
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_gamepad_console), "Gameplay", new List<Drawable>
                 {
                     new SettingsCustomSkin(this, "Custom Skin"),
-                    new SettingsDefaultSkin(this, "Default Skin"),
+                    new SettingsSkinStyle(this, "Skin Style"),
                     new SettingsSlider(this, "Background Brightness", ConfigManager.BackgroundBrightness),
                     new SettingsSlider(this, "Scroll Speed (4 Keys)", ConfigManager.ScrollSpeed4K),
                     new SettingsSlider(this, "Scroll Speed (7 Keys)", ConfigManager.ScrollSpeed7K),

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -79,7 +79,7 @@ namespace Quaver.Shared.Screens.Settings
         public string NewQueuedSkin { get; set; }
 
         /// <summary>
-        ///     A newly queued default skin, if the user chooses to change it.
+        ///     A newly queued skin style, if the user chooses to change it.
         /// </summary>
         public SkinStyles NewQueuedSkinStyle { get; set; }
 

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -223,7 +223,7 @@ namespace Quaver.Shared.Skinning
         }
 
         /// <summary>
-        ///     Sets config values based on the selected default skin.
+        ///     Sets config values based on the selected skin style.
         /// </summary>
         private void SetGenericConfig()
         {
@@ -430,7 +430,7 @@ namespace Quaver.Shared.Skinning
         ///     Reads config file for skin.ini elements.
         ///
         ///     REMEMBER TO SET YOUR DEFAULTS FOR BOTH 4K AND 7K
-        ///     AND ALL DEFAULT SKINS (BARS/ARROWS)
+        ///     AND ALL SKIN STYLES (BARS/ARROWS)
         /// </summary>
         private void ReadConfig()
         {

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -21,7 +21,7 @@ namespace Quaver.Shared.Skinning
 {
     public class SkinKeys
     {
-                /// <summary>
+        /// <summary>
         ///     Reference to the
         /// </summary>
         private SkinStore Store { get; }
@@ -41,7 +41,7 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         private string ResourceFilePrepender { get; set; }
 
-#region SKIN.INI VALUES
+        #region SKIN.INI VALUES
 
         internal int BgMaskPadding { get; private set; }
 
@@ -69,7 +69,7 @@ namespace Quaver.Shared.Skinning
 
         internal List<Color> ColumnColors { get; private set; } = new List<Color>();
 
-        internal float BgMaskAlpha { get; private set;  }
+        internal float BgMaskAlpha { get; private set; }
 
         internal bool FlipNoteImagesOnUpscroll { get; private set; }
 
@@ -101,9 +101,9 @@ namespace Quaver.Shared.Skinning
 
         internal HealthBarKeysAlignment HealthBarKeysAlignment { get; private set; }
 
-#endregion
+        #endregion
 
-#region TEXTURES
+        #region TEXTURES
 
         // ----- Column ----- //
         /// <summary>
@@ -158,7 +158,7 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteHoldBodies { get;} = new List<List<Texture2D>>();
+        internal List<List<Texture2D>> NoteHoldBodies { get; } = new List<List<Texture2D>>();
 
         /// <summary>
         ///
@@ -189,7 +189,7 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         internal List<Texture2D> HoldLighting { get; private set; } = new List<Texture2D>();
 
-#endregion
+        #endregion
 
         /// <summary>
         ///     Ctor -
@@ -227,12 +227,12 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         private void SetGenericConfig()
         {
-            switch (ConfigManager.DefaultSkin.Value)
+            switch (ConfigManager.SkinStyle.Value)
             {
-                case DefaultSkins.Arrow:
+                case SkinStyles.Arrow:
                     ResourceFilePrepender = "arrow";
                     break;
-                case DefaultSkins.Bar:
+                case SkinStyles.Bar:
                     ResourceFilePrepender = "bar";
                     break;
                 default:
@@ -256,9 +256,9 @@ namespace Quaver.Shared.Skinning
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         private void SetDefault4KConfig()
         {
-            switch (ConfigManager.DefaultSkin.Value)
+            switch (ConfigManager.SkinStyle.Value)
             {
-                case DefaultSkins.Bar:
+                case SkinStyles.Bar:
                     BgMaskPadding = 0;
                     HitPosOffsetY = 15;
                     NotePadding = 0;
@@ -294,7 +294,7 @@ namespace Quaver.Shared.Skinning
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
                     break;
-                case DefaultSkins.Arrow:
+                case SkinStyles.Arrow:
                     BgMaskPadding = 10;
                     HitPosOffsetY = 110;
                     NotePadding = 8;
@@ -340,9 +340,9 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         private void SetDefault7KConfig()
         {
-            switch (ConfigManager.DefaultSkin.Value)
+            switch (ConfigManager.SkinStyle.Value)
             {
-                case DefaultSkins.Bar:
+                case SkinStyles.Bar:
                     BgMaskPadding = 0;
                     HitPosOffsetY = 15;
                     NotePadding = 0;
@@ -381,7 +381,7 @@ namespace Quaver.Shared.Skinning
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
                     break;
-                case DefaultSkins.Arrow:
+                case SkinStyles.Arrow:
                     BgMaskPadding = 10;
                     HitPosOffsetY = 86;
                     NotePadding = 8;
@@ -513,7 +513,7 @@ namespace Quaver.Shared.Skinning
             }
             else
             {
-                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.DefaultSkin.Value.ToString()}/{folder.ToString()}" +
+                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.SkinStyle.Value.ToString()}/{folder.ToString()}" +
                                $"/{Mode.ToString()}/{GetResourcePath(element)}.png";
             }
 
@@ -540,7 +540,7 @@ namespace Quaver.Shared.Skinning
             }
             else
             {
-                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.DefaultSkin.Value.ToString()}/{folder.ToString()}" +
+                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.SkinStyle.Value.ToString()}/{folder.ToString()}" +
                            $"/{Mode.ToString()}/{GetResourcePath(element)}";
             }
 
@@ -575,7 +575,7 @@ namespace Quaver.Shared.Skinning
         private void LoadHitObjects(IList<List<Texture2D>> hitObjects, string element, int index)
         {
             // First load the beginning HitObject element that doesn't require snapping.
-            var objectsList = new List<Texture2D> {LoadTexture(SkinKeysFolder.HitObjects, element, false)};
+            var objectsList = new List<Texture2D> { LoadTexture(SkinKeysFolder.HitObjects, element, false) };
 
             // Don't bother looking for snap objects if the skin config doesn't permit it.
             if (!ColorObjectsBySnapDistance)
@@ -587,7 +587,7 @@ namespace Quaver.Shared.Skinning
             // For each snap we load the separate image for it.
             // It HAS to be loaded in an incremental fashion.
             // So you can't have 1/48, but not have 1/3, etc.
-            var snaps = new [] { "2nd", "3rd", "4th", "6th", "8th", "12th", "16th", "48th" };
+            var snaps = new[] { "2nd", "3rd", "4th", "6th", "8th", "12th", "16th", "48th" };
 
 
             // If it can find the appropriate files, load them.


### PR DESCRIPTION
The purpose of this PR is to refactor the horizontal selector setting for the _misleading_ "Default Skin" setting, which is proposed to be renamed to "Skin Style". 