### PR TITLE
Change maximum length for file path after map conversion to match Windows limit

### DIFF
--- a/Quaver.Shared/Converters/Osu/Osu.cs
+++ b/Quaver.Shared/Converters/Osu/Osu.cs
@@ -70,7 +70,7 @@ namespace Quaver.Shared.Converters.Osu
                     var fileName = $"{extractDirectory}/{Path.GetFileName(tempFile)}";
 
                     // Make sure the path to the file is less than 200 characters
-                    while (fileName.Length > 200)
+                    while (fileName.Length > 260) // Matching windows file length limit
                         fileName = fileName.Remove(fileName.Length - 1);
 
                     // Go through each file and move it.


### PR DESCRIPTION
Length limit changed from 200 to 260 to prevent file naming errors after map conversion.