### PR TITLE
Added random map selection button

### DIFF
--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -136,7 +136,7 @@ namespace Quaver.Shared.Screens.Select
         /// </summary>
         /// <returns></returns>
         public override UserClientStatus GetClientStatus() => new UserClientStatus(ClientStatus.Selecting,
-            -1, "", (byte) ConfigManager.SelectedGameMode.Value, "", (long) ModManager.Mods);
+            -1, "", (byte)ConfigManager.SelectedGameMode.Value, "", (long)ModManager.Mods);
 
         /// <summary>
         ///     Handles all input for the screen.
@@ -153,6 +153,7 @@ namespace Quaver.Shared.Screens.Select
             HandleKeyPressControlRateChange();
             HandleKeyPressTab();
             HandleKeyPressF1();
+            HandleKeyPressF2();
         }
 
         /// <summary>
@@ -278,11 +279,11 @@ namespace Quaver.Shared.Screens.Select
 
             // Increase rate.
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemPlus))
-                ModManager.AddSpeedMods((float) Math.Round(AudioEngine.Track.Rate + 0.1f, 1));
+                ModManager.AddSpeedMods((float)Math.Round(AudioEngine.Track.Rate + 0.1f, 1));
 
             // Decrease Rate
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemMinus))
-                ModManager.AddSpeedMods((float) Math.Round(AudioEngine.Track.Rate - 0.1f, 1));
+                ModManager.AddSpeedMods((float)Math.Round(AudioEngine.Track.Rate - 0.1f, 1));
 
             // Change from pitched to non-pitched
             if (KeyboardManager.IsUniqueKeyPress(Keys.D0))
@@ -315,6 +316,17 @@ namespace Quaver.Shared.Screens.Select
                 return;
 
             DialogManager.Show(new ModifiersDialog());
+        }
+
+        /// <summary>
+        ///     Handles when the user presses the F2 key
+        /// </summary>
+        private void HandleKeyPressF2()
+        {
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.F2))
+                return;
+
+            SelectRandomMap();
         }
 
         /// <summary>
@@ -393,6 +405,51 @@ namespace Quaver.Shared.Screens.Select
                 return;
 
             Exit(() => new ImportingScreen());
+        }
+
+        /// <summary>
+        ///     Used to select a random mapset (or map if inside a mapset).
+        /// </summary>
+        public void SelectRandomMap()
+        {
+            var view = View as SelectScreenView;
+            var rnd = new Random(DateTime.Now.Millisecond);
+            var selectedMapsetIndex = view.MapsetScrollContainer.SelectedMapsetIndex;
+            var selectedDifficultyIndex = view.DifficultyScrollContainer.SelectedMapIndex;
+
+            switch (view.ActiveContainer)
+            {
+                case SelectContainerStatus.Mapsets:
+                    var randomMapsetIndex = selectedMapsetIndex;
+
+                    if (AvailableMapsets.Count <= 1)
+                        return;
+
+                    // To avoid selecting the mapset already selected.
+                    do
+                    {
+                        randomMapsetIndex = rnd.Next(AvailableMapsets.Count);
+                    }
+                    while (randomMapsetIndex == selectedMapsetIndex);
+
+                    view.MapsetScrollContainer.SelectMapset(randomMapsetIndex);
+                    break;
+
+                case SelectContainerStatus.Difficulty:
+                    var mapset = AvailableMapsets[selectedMapsetIndex];
+                    var randomMapIndex = selectedDifficultyIndex;
+
+                    if (mapset.Maps.Count <= 1)
+                        return;
+
+                    // To avoid selecting the mapset already selected.
+                    do
+                        randomMapIndex = new Random(DateTime.Now.Millisecond).Next(mapset.Maps.Count);
+                    while (randomMapIndex == selectedDifficultyIndex);
+
+                    view.MapsetScrollContainer.SelectMap(selectedMapsetIndex, mapset.Maps[randomMapIndex], true);
+                    break;
+            }
         }
     }
 }

--- a/Quaver.Shared/Screens/Select/SelectScreenView.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreenView.cs
@@ -170,7 +170,8 @@ namespace Quaver.Shared.Screens.Select
         {
             new NavbarItemUser(this),
             new NavbarItem("Report Bugs", false, (o, e) => BrowserHelper.OpenURL("https://github.com/Quaver/Quaver/issues")),
-        }) { Parent = Container };
+        })
+        { Parent = Container };
 
         /// <summary>
         ///     Called when the home button is clicked in the navbar.
@@ -202,7 +203,7 @@ namespace Quaver.Shared.Screens.Select
         /// <summary>
         ///     Creates the audio visaulizer container for the screen
         /// </summary>12
-        private void CreateAudioVisualizer() => Visualizer = new MenuAudioVisualizer((int) WindowManager.Width, 400, 150, 5)
+        private void CreateAudioVisualizer() => Visualizer = new MenuAudioVisualizer((int)WindowManager.Width, 400, 150, 5)
         {
             Parent = Container,
             Alignment = Alignment.BotLeft
@@ -385,6 +386,13 @@ namespace Quaver.Shared.Screens.Select
                     MapManager.Selected.Value.Mapset.ExportToZip();
                     NotificationManager.Show(NotificationLevel.Success, "Successfully exported mapset!");
                 });
+            }, true, false, true),
+
+            // Select a random map
+            new NavbarItem("Random", false, (o, e) =>
+            {
+                var screen = Screen as SelectScreen;
+                screen.SelectRandomMap();
             }, true, false, true)
         }, new List<NavbarItem>()
         {

--- a/Quaver.Shared/Screens/Select/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Select/UI/Mapsets/MapsetScrollContainer.cs
@@ -251,6 +251,19 @@ namespace Quaver.Shared.Screens.Select.UI.Mapsets
         }
 
         /// <summary>
+        ///     Selects mapset at specific index.
+        /// </summary>
+        /// <param name="mapsetIndex"></param>
+        public void SelectMapset(int mapsetIndex)
+        {
+            if (Screen.AvailableMapsets.ElementAtOrDefault(mapsetIndex) == null)
+                return;
+
+            SelectMap(mapsetIndex, Screen.AvailableMapsets[mapsetIndex].PreferredMap
+                                  ?? Screen.AvailableMapsets[mapsetIndex].Maps.First());
+        }
+
+        /// <summary>
         ///     Initializes the container with new mapsets.
         /// </summary>
         public void InitializeWithNewSets()


### PR DESCRIPTION
Random map selection button + F2 Button both do the same function in the map selector, they both will randomly select a mapset/difficulty that is not already selected and has two or more mapset/difficulty available when combined with the search bar or just in general.

The reason for making it have two or more map sets/difficulties available is because the client would crash, it would freeze before it posted any stack trace so I have no idea why it would've crashed, might've been an index out of bounds exception ¯\_(ツ)_/¯

Resolves #304 