### PR TITLE
Fixed Map Metadata: Length

### DIFF
--- a/Quaver.Shared/Screens/Select/UI/Banner/BannerMetadata.cs
+++ b/Quaver.Shared/Screens/Select/UI/Banner/BannerMetadata.cs
@@ -98,9 +98,11 @@ namespace Quaver.Shared.Screens.Select.UI.Banner
         /// <param name="map"></param>
         public void UpdateAndAlignMetadata(Map map)
         {
+            var length = TimeSpan.FromMilliseconds(map.SongLength / ModHelper.GetRateFromMods(ModManager.Mods));
+
             Mode.UpdateValue(ModeHelper.ToShortHand(map.Mode));
             Bpm.UpdateValue(((int)(map.Bpm * ModHelper.GetRateFromMods(ModManager.Mods))).ToString(CultureInfo.InvariantCulture));
-            Length.UpdateValue(TimeSpan.FromMilliseconds(map.SongLength / ModHelper.GetRateFromMods(ModManager.Mods)).ToString(@"mm\:ss"));
+            Length.UpdateValue(length.Hours > 0 ? length.ToString(@"hh\:mm\:ss") : length.ToString(@"mm\:ss"));
             Difficulty.UpdateValue(StringHelper.AccuracyToString((float) map.DifficultyFromMods(ModManager.Mods)).Replace("%", ""));
 
             for (var i = 0; i < Items.Count; i++)


### PR DESCRIPTION
The wrong format was used, **mm:ss** has now been corrected to **hh:mm:ss** if the map is 1 or more hours.

Resolves #312 

![image](https://user-images.githubusercontent.com/6015313/50377846-cd727180-065f-11e9-8170-be49645cdcef.png)