### PR TITLE
Add config value to toggle gameplay background blur

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -230,6 +230,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> EnableHitsounds { get; private set; }
 
         /// <summary>
+        ///     If enabled, the user's background will be blurred in gameplay.
+        /// </summary>
+        internal static Bindable<bool> BlurBackgroundInGameplay { get; private set; }
+
+        /// <summary>
         ///     Keybindings for 4K
         /// </summary>
         internal static Bindable<Keys> KeyMania4K1 { get; private set; }
@@ -411,6 +416,7 @@ namespace Quaver.Shared.Config
             KeyIncreaseScrollSpeed = ReadValue(@"KeyIncreaseScrollSpeed", Keys.F4, data);
             KeyScoreboardVisible = ReadValue(@"KeyHideScoreboard", Keys.Tab, data);
             KeyQuickExit = ReadValue(@"KeyQuickExit", Keys.F1, data);
+            BlurBackgroundInGameplay = ReadValue(@"BlurBackgroundInGameplay", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -479,6 +485,7 @@ namespace Quaver.Shared.Config
                     KeyQuickExit.ValueChanged += AutoSaveConfiguration;
                     SelectedGameMode.ValueChanged += AutoSaveConfiguration;
                     SelectedOnlineUserFilterType.ValueChanged += AutoSaveConfiguration;
+                    BlurBackgroundInGameplay.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -30,6 +30,7 @@ using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
+using Wobble.Graphics.UI;
 using Wobble.Screens;
 using Wobble.Window;
 
@@ -43,9 +44,9 @@ namespace Quaver.Shared.Screens.Gameplay
         public new GameplayScreen Screen { get; }
 
         /// <summary>
-        ///     The container that will be used for displaying objects in the background.
+        ///     The map's background.
         /// </summary>
-        public Container BackgroundContainer { get; }
+        public BackgroundImage Background { get; private set; }
 
         /// <summary>
         ///     The progress bar that displays the current song time.
@@ -151,14 +152,8 @@ namespace Quaver.Shared.Screens.Gameplay
         public GameplayScreenView(Screen screen) : base(screen)
         {
             Screen = (GameplayScreen)screen;
-            BackgroundContainer = new Container();
 
-            BackgroundHelper.Background.Dim = 100 - ConfigManager.BackgroundBrightness.Value;
-
-            BackgroundManager.PermittedToFadeIn = false;
-            FadeBackgroundToDim();
-            BackgroundManager.Loaded += OnBackgroundLoaded;
-
+            CreateBackground();
             CreateProgressBar();
             CreateScoreDisplay();
             CreateAccuracyDisplay();
@@ -225,7 +220,7 @@ namespace Quaver.Shared.Screens.Gameplay
         {
             GameBase.Game.GraphicsDevice.Clear(Color.Black);
 
-            BackgroundHelper.Draw(gameTime);
+            Background.Draw(gameTime);
             Screen.Ruleset?.Draw(gameTime);
             Container?.Draw(gameTime);
         }
@@ -235,10 +230,20 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         public override void Destroy()
         {
-            BackgroundContainer.Destroy();
             Screen.Ruleset?.Destroy();
             Container?.Destroy();
-            BackgroundManager.Loaded -= OnBackgroundLoaded;
+        }
+
+        /// <summary>
+        ///     Creates the background sprite for the screen.
+        /// </summary>
+        private void CreateBackground()
+        {
+            var background = ConfigManager.BlurBackgroundInGameplay.Value ? BackgroundHelper.BlurredTexture : BackgroundHelper.RawTexture;
+
+            // We don't set a parent here because we have to manually call draw on the background, as the
+            // ScreenView's container is drawn after the ruleset.
+            Background = new BackgroundImage(background, 100 - ConfigManager.BackgroundBrightness.Value, false);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -1,7 +1,7 @@
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
@@ -329,6 +329,7 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsSlider(this, "Scroll Speed (7 Keys)", ConfigManager.ScrollSpeed7K),
                     new SettingsBool(this, "Notes Fall Downwards (4 Keys)", ConfigManager.DownScroll4K),
                     new SettingsBool(this, "Notes Fall Downwards (7 Keys)", ConfigManager.DownScroll7K),
+                    new SettingsBool(this, "Blur Background In Gameplay", ConfigManager.BlurBackgroundInGameplay),
                     new SettingsBool(this, "Enable Hitsounds", ConfigManager.EnableHitsounds),
                     new SettingsBool(this, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                     new SettingsBool(this, "Display Song Time Progress", ConfigManager.DisplaySongTimeProgress),


### PR DESCRIPTION
Allows the user to choose in the settings menu whether or not they want to blur the background during gameplay.

Closes #252 

**Config**

![Config](https://i.imgur.com/s5X7c2N.png)

**Gameplay** 

![New](https://i.imgur.com/xH093j0.png)