### PR TITLE
Add non-changeable keybind for opening options from certain menu.

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -29,6 +29,7 @@ using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Alpha;
 using Quaver.Shared.Screens.Menu;
+using Quaver.Shared.Screens.Settings;
 using Quaver.Shared.Skinning;
 using Steamworks;
 using Wobble;
@@ -205,34 +206,7 @@ namespace Quaver.Shared
             ChatManager.Update(gameTime);
             DialogManager.Update(gameTime);
 
-            // Handles FPS limiter changes
-            if (KeyboardManager.IsUniqueKeyPress(Keys.F7))
-            {
-                var index = (int) ConfigManager.FpsLimiterType.Value;
-
-                if (index + 1 < Enum.GetNames(typeof(FpsLimitType)).Length)
-                    ConfigManager.FpsLimiterType.Value = (FpsLimitType) index + 1;
-                else
-                    ConfigManager.FpsLimiterType.Value = FpsLimitType.Unlimited;
-
-                switch (ConfigManager.FpsLimiterType.Value)
-                {
-                    case FpsLimitType.Unlimited:
-                        NotificationManager.Show(NotificationLevel.Info, "FPS is now unlimited.");
-                        break;
-                    case FpsLimitType.Limited:
-                        NotificationManager.Show(NotificationLevel.Info, $"FPS is now limited to: 240 FPS");
-                        break;
-                    case FpsLimitType.Vsync:
-                        NotificationManager.Show(NotificationLevel.Info, $"Vsync Enabled");
-                        break;
-                    case FpsLimitType.Custom:
-                        NotificationManager.Show(NotificationLevel.Info, $"FPS is now custom limited to: {ConfigManager.CustomFpsLimit.Value}");
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
+            HandleGlobalInput(gameTime);
 
             QuaverScreenManager.Update(gameTime);
             Transitioner.Update(gameTime);
@@ -386,6 +360,78 @@ namespace Quaver.Shared
             }
 
             Graphics.ApplyChanges();
+        }
+        
+        /// <summary>
+        ///     Handles input's that can be executed everywhere.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void HandleGlobalInput(GameTime gameTime)
+        {
+            HandleKeyPressF7();
+            HandleKeyPressCtrlO();
+        }
+
+        /// <summary>
+        ///     Handles when the user presses the F7 button
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private void HandleKeyPressF7()
+        {
+            // Handles FPS limiter changes
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.F7))
+                return;
+            
+            var index = (int) ConfigManager.FpsLimiterType.Value;
+
+            if (index + 1 < Enum.GetNames(typeof(FpsLimitType)).Length)
+                ConfigManager.FpsLimiterType.Value = (FpsLimitType) index + 1;
+            else
+                ConfigManager.FpsLimiterType.Value = FpsLimitType.Unlimited;
+
+            switch (ConfigManager.FpsLimiterType.Value)
+            {
+                case FpsLimitType.Unlimited:
+                    NotificationManager.Show(NotificationLevel.Info, "FPS is now unlimited.");
+                    break;
+                case FpsLimitType.Limited:
+                    NotificationManager.Show(NotificationLevel.Info, $"FPS is now limited to: 240 FPS");
+                    break;
+                case FpsLimitType.Vsync:
+                    NotificationManager.Show(NotificationLevel.Info, $"Vsync Enabled");
+                    break;
+                case FpsLimitType.Custom:
+                    NotificationManager.Show(NotificationLevel.Info,
+                        $"FPS is now custom limited to: {ConfigManager.CustomFpsLimit.Value}");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        ///     Handles when the user holds either Control (CTRL) button and presses O
+        /// </summary>
+        private void HandleKeyPressCtrlO()
+        {
+            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
+                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
+                return;
+
+            if (DialogManager.Dialogs.Count > 0)
+                return;
+            
+            switch (CurrentScreen.Type)
+            {
+                case QuaverScreenType.Menu:
+                case QuaverScreenType.Select:
+                case QuaverScreenType.Edit:
+                    DialogManager.Show(new SettingsDialog());
+                    break;
+            }
         }
     }
 }

--- a/Quaver.Shared/Screens/Menu/MenuScreen.cs
+++ b/Quaver.Shared/Screens/Menu/MenuScreen.cs
@@ -93,15 +93,6 @@ namespace Quaver.Shared.Screens.Menu
         /// <param name="gameTime"></param>
         private void HandleInput(GameTime gameTime)
         {
-            HandleKeyPressEsc();
-            HandleKeyPressCTRLO();
-        }
-
-        /// <summary>
-        ///     Handles when the user presses the escape button
-        /// </summary>
-        private void HandleKeyPressEsc()
-        {
             if (DialogManager.Dialogs.Count > 0 || Exiting)
                 return;
 
@@ -109,21 +100,6 @@ namespace Quaver.Shared.Screens.Menu
                 DialogManager.Show(new QuitDialog());
         }
         
-        /// <summary>
-        ///     Handles when the user is holding either Control button and presses O
-        /// </summary>
-        private void HandleKeyPressCTRLO()
-        {
-            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
-                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
-                return;
-
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
-                return;
-
-            DialogManager.Show(new SettingsDialog());
-        }
-
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Menu/MenuScreen.cs
+++ b/Quaver.Shared/Screens/Menu/MenuScreen.cs
@@ -14,6 +14,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Online;
 using Quaver.Shared.Screens.Menu.UI.Dialogs;
+using Quaver.Shared.Screens.Settings;
 using Wobble;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
@@ -92,11 +93,35 @@ namespace Quaver.Shared.Screens.Menu
         /// <param name="gameTime"></param>
         private void HandleInput(GameTime gameTime)
         {
+            HandleKeyPressEsc();
+            HandleKeyPressCTRLO();
+        }
+
+        /// <summary>
+        ///     Handles when the user presses the escape button
+        /// </summary>
+        private void HandleKeyPressEsc()
+        {
             if (DialogManager.Dialogs.Count > 0 || Exiting)
                 return;
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.Escape))
                 DialogManager.Show(new QuitDialog());
+        }
+        
+        /// <summary>
+        ///     Handles when the user is holding either Control button and presses O
+        /// </summary>
+        private void HandleKeyPressCTRLO()
+        {
+            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
+                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
+                return;
+
+            DialogManager.Show(new SettingsDialog());
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -25,6 +25,7 @@ using Quaver.Shared.Screens.Result;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
 using Quaver.Shared.Screens.Select.UI.Mapsets;
 using Quaver.Shared.Screens.Select.UI.Modifiers;
+using Quaver.Shared.Screens.Settings;
 using Wobble;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -70,7 +71,8 @@ namespace Quaver.Shared.Screens.Select
         public SelectScreen()
         {
             // Go to the import screen if we've imported a map not on the select screen
-            if (MapsetImporter.Queue.Count > 0 || MapDatabaseCache.LoadedMapsFromOtherGames != ConfigManager.AutoLoadOsuBeatmaps.Value ||
+            if (MapsetImporter.Queue.Count > 0 ||
+                MapDatabaseCache.LoadedMapsFromOtherGames != ConfigManager.AutoLoadOsuBeatmaps.Value ||
                 QuaverSettingsDatabaseCache.OutdatedMaps.Count != 0)
             {
                 Exit(() => new ImportingScreen());
@@ -86,7 +88,8 @@ namespace Quaver.Shared.Screens.Select
 
             AvailableMapsets = MapsetHelper.OrderMapsetsByConfigValue(AvailableMapsets);
 
-            Logger.Debug($"There are currently: {AvailableMapsets.Count} available mapsets to play in select.", LogType.Runtime);
+            Logger.Debug($"There are currently: {AvailableMapsets.Count} available mapsets to play in select.",
+                LogType.Runtime);
 
             DiscordHelper.Presence.Details = "Selecting a song";
             DiscordHelper.Presence.State = "In the menus";
@@ -134,7 +137,7 @@ namespace Quaver.Shared.Screens.Select
         /// </summary>
         /// <returns></returns>
         public override UserClientStatus GetClientStatus() => new UserClientStatus(ClientStatus.Selecting,
-            -1, "", (byte)ConfigManager.SelectedGameMode.Value, "", (long)ModManager.Mods);
+            -1, "", (byte) ConfigManager.SelectedGameMode.Value, "", (long) ModManager.Mods);
 
         /// <summary>
         ///     Handles all input for the screen.
@@ -152,6 +155,7 @@ namespace Quaver.Shared.Screens.Select
             HandleKeyPressTab();
             HandleKeyPressF1();
             HandleKeyPressF2();
+            HandleKeyPressCTRLO();
             HandleMousePressRight();
         }
 
@@ -228,7 +232,8 @@ namespace Quaver.Shared.Screens.Select
         {
             var view = View as SelectScreenView;
 
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
+            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) ||
+                KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Right))
@@ -255,7 +260,8 @@ namespace Quaver.Shared.Screens.Select
         {
             var view = View as SelectScreenView;
 
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
+            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) ||
+                KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Left))
@@ -279,22 +285,24 @@ namespace Quaver.Shared.Screens.Select
         /// </summary>
         private static void HandleKeyPressControlRateChange()
         {
-            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) && !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
+                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
                 return;
 
             // Increase rate.
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemPlus))
-                ModManager.AddSpeedMods((float)Math.Round(AudioEngine.Track.Rate + 0.1f, 1));
+                ModManager.AddSpeedMods((float) Math.Round(AudioEngine.Track.Rate + 0.1f, 1));
 
             // Decrease Rate
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemMinus))
-                ModManager.AddSpeedMods((float)Math.Round(AudioEngine.Track.Rate - 0.1f, 1));
+                ModManager.AddSpeedMods((float) Math.Round(AudioEngine.Track.Rate - 0.1f, 1));
 
             // Change from pitched to non-pitched
             if (KeyboardManager.IsUniqueKeyPress(Keys.D0))
             {
                 ConfigManager.Pitched.Value = !ConfigManager.Pitched.Value;
-                Logger.Debug($"Audio Rate Pitching is {(ConfigManager.Pitched.Value ? "Enabled" : "Disabled")}", LogType.Runtime);
+                Logger.Debug($"Audio Rate Pitching is {(ConfigManager.Pitched.Value ? "Enabled" : "Disabled")}",
+                    LogType.Runtime);
             }
         }
 
@@ -333,7 +341,7 @@ namespace Quaver.Shared.Screens.Select
 
             SelectRandomMap();
         }
-        
+
         /// <summary>
         ///     Handles when the user presses the right mouse button
         /// </summary>
@@ -348,8 +356,24 @@ namespace Quaver.Shared.Screens.Select
                     {
                         view.SwitchToContainer(SelectContainerStatus.Mapsets);
                     }
+
                     break;
             }
+        }
+
+        /// <summary>
+        ///     Handles when the user is holding either Control button and presses O
+        /// </summary>
+        private void HandleKeyPressCTRLO()
+        {
+            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
+                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
+                return;
+
+            DialogManager.Show(new SettingsDialog());
         }
 
         /// <summary>
@@ -452,8 +476,7 @@ namespace Quaver.Shared.Screens.Select
                     do
                     {
                         randomMapsetIndex = rnd.Next(AvailableMapsets.Count);
-                    }
-                    while (randomMapsetIndex == selectedMapsetIndex);
+                    } while (randomMapsetIndex == selectedMapsetIndex);
 
                     view.MapsetScrollContainer.SelectMapset(randomMapsetIndex);
                     break;

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -155,7 +155,6 @@ namespace Quaver.Shared.Screens.Select
             HandleKeyPressTab();
             HandleKeyPressF1();
             HandleKeyPressF2();
-            HandleKeyPressCTRLO();
             HandleMousePressRight();
         }
 
@@ -359,21 +358,6 @@ namespace Quaver.Shared.Screens.Select
 
                     break;
             }
-        }
-
-        /// <summary>
-        ///     Handles when the user is holding either Control button and presses O
-        /// </summary>
-        private void HandleKeyPressCTRLO()
-        {
-            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
-                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
-                return;
-
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
-                return;
-
-            DialogManager.Show(new SettingsDialog());
         }
 
         /// <summary>


### PR DESCRIPTION
Implements feature that was to be added from https://github.com/Quaver/Quaver/projects/1#card-15662565

Note: When further screens that have an option to open the options are available, those screens should also have code for this same keybind, the only reason for doing it one by one is because the settings dialog shouldn't be opened from just anywhere.