### PR TITLE
Added check for submitting score to quaver servers, if the map is only ranked.

### DIFF
--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -299,6 +299,10 @@ namespace Quaver.Shared.Screens.Result
             if (OnlineManager.Status.Value == ConnectionStatus.Disconnected)
                 return;
 
+            // Don't submit scores if they aren't ranked, there is no point.
+            if (Map.RankedStatus != RankedStatus.Ranked)
+                return;
+            
             ThreadScheduler.Run(() =>
             {
                 Logger.Important($"Beginning to submit score on map: {Gameplay.MapHash}", LogType.Network);

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -300,7 +300,7 @@ namespace Quaver.Shared.Screens.Result
                 return;
 
             // Don't submit scores if they aren't ranked, there is no point.
-            if (Map.RankedStatus != RankedStatus.Ranked)
+            if (Map.RankedStatus != RankedStatus.Ranked || Map.RankedStatus != RankedStatus.DanCourse)
                 return;
             
             ThreadScheduler.Run(() =>


### PR DESCRIPTION
The original issue was to do with unranked/notsubmitted scores still attempting to submit to the Quaver's score server.

Resolves #338 