### PR TITLE
Add HitErrorPosX/Y, HitErrorHeight, & HitErrorChevronSize Skin.ini values

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -366,13 +366,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     Creates the HitError Sprite.
         /// </summary>
-        private void CreateHitError() => HitError = new HitErrorBar(new ScalableVector2(50, 10))
+        private void CreateHitError()
         {
-            Parent = Playfield.ForegroundContainer,
-            Alignment = Alignment.MidCenter,
-            Position = new ScalableVector2(0, 55)
-        };
-
+            HitError = new HitErrorBar(new ScalableVector2(50, Skin.HitErrorHeight))
+            {
+                Parent = Playfield.ForegroundContainer,
+                Alignment = Alignment.MidCenter,
+                Position = new ScalableVector2(Skin.HitErrorPosX, Skin.HitErrorPosY),
+            };
+        }
         /// <summary>
         ///     Creates the JudgementHitBurst sprite.
         /// </summary>

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -1,7 +1,7 @@
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
@@ -78,6 +78,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             }
 
             // Create the hit chevron.
+            var chevronSize = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorChevronSize;
+
             LastHitCheveron = new Sprite()
             {
                 Parent = this,
@@ -85,7 +87,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 Alpha = 1,
                 Image = FontAwesome.Get(FontAwesomeIcon.fa_caret_down),
                 Y = -Height - 3,
-                Size = new ScalableVector2(8, 8)
+                Size = new ScalableVector2(chevronSize, chevronSize)
             };
         }
 

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -97,6 +97,14 @@ namespace Quaver.Shared.Skinning
 
         internal int JudgementBurstPosY { get; private set; }
 
+        internal int HitErrorPosX { get; private set; }
+
+        internal int HitErrorPosY { get; private set; }
+
+        internal int HitErrorHeight { get; private set; }
+
+        internal int HitErrorChevronSize { get; private set; }
+
         internal HealthBarType HealthBarType { get; private set; }
 
         internal HealthBarKeysAlignment HealthBarKeysAlignment { get; private set; }
@@ -293,6 +301,10 @@ namespace Quaver.Shared.Skinning
                     JudgementBurstPosY = 108;
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
+                    HitErrorPosX = 0;
+                    HitErrorPosY = 55;
+                    HitErrorHeight = 10;
+                    HitErrorChevronSize = 8;
                     break;
                 case DefaultSkins.Arrow:
                     BgMaskPadding = 10;
@@ -329,6 +341,10 @@ namespace Quaver.Shared.Skinning
                     JudgementBurstPosY = 108;
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
+                    HitErrorPosX = 0;
+                    HitErrorPosY = 55;
+                    HitErrorHeight = 10;
+                    HitErrorChevronSize = 8;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -380,6 +396,10 @@ namespace Quaver.Shared.Skinning
                     JudgementBurstPosY = 108;
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
+                    HitErrorPosX = 0;
+                    HitErrorPosY = 55;
+                    HitErrorHeight = 10;
+                    HitErrorChevronSize = 8;
                     break;
                 case DefaultSkins.Arrow:
                     BgMaskPadding = 10;
@@ -420,6 +440,10 @@ namespace Quaver.Shared.Skinning
                     JudgementBurstPosY = 108;
                     HealthBarType = HealthBarType.Vertical;
                     HealthBarKeysAlignment = HealthBarKeysAlignment.RightStage;
+                    HitErrorPosX = 0;
+                    HitErrorPosY = 55;
+                    HitErrorHeight = 10;
+                    HitErrorChevronSize = 8;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -469,6 +493,10 @@ namespace Quaver.Shared.Skinning
             JudgementBurstPosY = ConfigHelper.ReadInt32(JudgementBurstPosY, ini["JudgementBurstPosY"]);
             HealthBarType = ConfigHelper.ReadHealthBarType(HealthBarType, ini["HealthBarType"]);
             HealthBarKeysAlignment = ConfigHelper.ReadHealthBarKeysAlignment(HealthBarKeysAlignment, ini["HealthBarKeysAlignment"]);
+            HitErrorPosX = ConfigHelper.ReadInt32(HitErrorPosX, ini["HitErrorPosX"]);
+            HitErrorPosY = ConfigHelper.ReadInt32(HitErrorPosY, ini["HitErrorPosY"]);
+            HitErrorHeight = ConfigHelper.ReadInt32(HitErrorHeight, ini["HitErrorHeight"]);
+            HitErrorChevronSize = ConfigHelper.ReadInt32(HitErrorChevronSize, ini["HitErrorChevronSize"]);
         }
 
         /// <summary>


### PR DESCRIPTION
Allows the player to customize the position and height of the hit error, as well as the size of the hit error chevron.

Closes #339 

![img](https://i.imgur.com/Wgi737O.png)
