### PR TITLE
Fix crash when activating mods

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
@@ -125,7 +125,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             };
 
             // Get a formatted string of the activated mods.
-            var modsString = "Mods: " + (ModManager.CurrentModifiersList.Count > 0 ? $"{ModHelper.GetModsString(Screen.Ruleset.ScoreProcessor.Mods)}" : "None");
+            var modsString = "Mods: " + (ModManager.CurrentModifiersList.Count > 0 ? $"{ModHelper.GetModsString(ModManager.Mods)}" : "None");
             Mods = new SpriteText(Fonts.SourceSansProSemiBold, modsString, 13)
             {
                 Parent = this,


### PR DESCRIPTION
It regressed from when I moved SongInformation over to the playfield stage.

Fixes #334 

