### PR TITLE
Fixed cursor visibility after returning to gameplay.

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -228,7 +228,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             SetRuleset();
             SetRichPresence();
-
+            
             AudioTrack.AllowPlayback = true;
             View = new GameplayScreenView(this);
         }

--- a/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
@@ -8,6 +8,7 @@
 using Microsoft.Xna.Framework;
 using Quaver.Shared.Online.Chat;
 using Quaver.Shared.Skinning;
+using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
@@ -70,7 +71,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             {
                 if (!Screen.IsPaused)
                     return;
-
+                GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
                 Screen.Pause();
             })
             {
@@ -89,7 +90,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             {
                 if (!Screen.IsPaused)
                     return;
-
+                GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
                 SkinManager.Skin.SoundRetry.CreateChannel().Play();
                 QuaverScreenManager.ChangeScreen(new GameplayScreen(Screen.Map, Screen.MapHash, Screen.LocalScores));
             })
@@ -161,7 +162,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         public void Deactivate()
         {
             ClearTransformations();
-
+            
             Background.Animations.Add(new Animation(AnimationProperty.Alpha, Easing.Linear, 1, 0, 400));
             Continue.MoveToX(-Continue.Width, Easing.OutExpo, 400);
             Retry.MoveToX(-Retry.Width, Easing.OutExpo, 400);

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -488,7 +488,7 @@ namespace Quaver.Shared.Screens.Result
                 // Load up the .qua file again
                 var qua = MapManager.Selected.Value.LoadQua();
                 MapManager.Selected.Value.Qua = qua;
-
+                GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
                 return new GameplayScreen(MapManager.Selected.Value.Qua, MapManager.Selected.Value.Md5Checksum, new List<Score>(), replay);
             });
         }
@@ -496,7 +496,11 @@ namespace Quaver.Shared.Screens.Result
         /// <summary>
         ///     Exits the screen to retry the map
         /// </summary>
-        public void ExitToRetryMap() => Exit(() => new MapLoadingScreen(new List<Score>()));
+        public void ExitToRetryMap()
+        {
+            Exit(() => new MapLoadingScreen(new List<Score>()));
+            GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
+        }
 
         /// <summary>
         ///     Exits to watch a replay online.
@@ -534,7 +538,7 @@ namespace Quaver.Shared.Screens.Result
                             lock (AudioEngine.Track)
                                 AudioEngine.Track.Fade(10, 300);
                         }
-
+                        GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
                         return new GameplayScreen(MapManager.Selected.Value.Qua, MapManager.Selected.Value.Md5Checksum, new List<Score>(), replay);
                     });
                 }


### PR DESCRIPTION
See: https://github.com/Quaver/Quaver/issues/295

Fixed cursor visibility after returning to gameplay from PauseScreen, and if retrying from ResultScreen.
Also fixed cursor visibility if watching replay.