### PR TITLE
Fixed HitPosOffsetY on default arrows 4K skin.

### DIFF
--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -308,7 +308,7 @@ namespace Quaver.Shared.Skinning
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
-                    HitPosOffsetY = 110;
+                    HitPosOffsetY = 105;
                     NotePadding = 8;
                     TimingBarPixelSize = 2;
                     ColumnLightingScale = 1.0f;


### PR DESCRIPTION
See: https://github.com/Quaver/Quaver/issues/386

I figured that appropiate value would be 105 instead of recommended 95 because 95 doesn't directly overlap with receptors