### PR TITLE
Fixed Now Playing output

### DIFF
--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -87,7 +87,7 @@ namespace Quaver.Shared.Screens.Loading
                     writer.Write($"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}");
 
                 using (var writer = File.CreateText(ConfigManager.DataDirectory + "/temp/Now Playing/map.txt"))
-                    writer.Write($"{MapManager.Selected.Value.Qua.Artist} - {MapManager.Selected.Value.Qua.Title} [{MapManager.Selected.Value.Qua.DifficultyName}]");
+                    writer.Write($"{MapManager.Selected.Value.Qua.Artist} - {MapManager.Selected.Value.Qua.Title} [{MapManager.Selected.Value.Qua.DifficultyName}] ");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
AiAe said the now playing output for map's would be incorrect when used in obs, I have no idea if obs has a feature so that you can set a gap in between the side scrolling text so it doesn't have this problem, but nevertheless it's a fix.

Example: Text Text instead of TextText

Reference:
![image](https://user-images.githubusercontent.com/6015313/50451735-c81f6a80-0970-11e9-88b0-6c35c0f1225f.png)
