### PR TITLE
Added Reload Skin global hotkey

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -93,11 +93,6 @@ namespace Quaver.Shared
                 return $@"{assembly.Version.Major}.{assembly.Version.Minor}.{assembly.Version.Build}";
             }
         }
-        
-        /// <summary>
-        ///     The time that the user has requested their skin be reloaded.
-        /// </summary>
-        private long TimeSkinReloadRequested { get; set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -217,7 +212,7 @@ namespace Quaver.Shared
             QuaverScreenManager.Update(gameTime);
             Transitioner.Update(gameTime);
 
-            HandleSkinReloading();
+            SkinManager.HandleSkinReloading();
         }
 
         /// <inheritdoc />
@@ -463,27 +458,8 @@ namespace Quaver.Shared
                 case QuaverScreenType.Edit:
                     Transitioner.FadeIn();
 
-                    TimeSkinReloadRequested = GameBase.Game.TimeRunning;
+                    SkinManager.TimeSkinReloadRequested = GameBase.Game.TimeRunning;
                     break;
-            }
-        }
-
-        /// <summary>
-        ///     Used to handle reloading the skin when applicable.
-        /// </summary>
-        private void HandleSkinReloading()
-        {
-            // Reload skin when applicable
-            if (TimeSkinReloadRequested != 0 && GameBase.Game.TimeRunning - TimeSkinReloadRequested >= 400)
-            {
-                SkinManager.Load();
-                TimeSkinReloadRequested = 0;
-
-                ThreadScheduler.RunAfter(() =>
-                {
-                    Transitioner.FadeOut();
-                    NotificationManager.Show(NotificationLevel.Success, "Skin has been successfully loaded!");
-                }, 200);
             }
         }
     }

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -449,12 +449,10 @@ namespace Quaver.Shared
         private void HandleKeyPressCtrlShiftAltR()
         {
             // Check for modifier keys
-            if (!((KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)) &&
-                  (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift)) &&
-                  (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))))
+            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
                 return;
             
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.R))
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.S))
                 return;
 
             // Handle skin reloading

--- a/Quaver.Shared/Screens/Settings/Elements/SettingsCustomSkin.cs
+++ b/Quaver.Shared/Screens/Settings/Elements/SettingsCustomSkin.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Quaver.Shared.Config;
+using Quaver.Shared.Skinning;
 
 namespace Quaver.Shared.Screens.Settings.Elements
 {
@@ -54,15 +55,15 @@ namespace Quaver.Shared.Screens.Settings.Elements
                 // Check if the user already has the default skin enabled and switched back to it.
                 // User wants to choose the default skin
                 case "Default Skin" when string.IsNullOrEmpty(skin):
-                    dialog.NewQueuedSkin = null;
+                    SkinManager.NewQueuedSkin = null;
                     break;
                 // User is selecting a custom skin
                 case "Default Skin" when !string.IsNullOrEmpty(skin):
-                    dialog.NewQueuedSkin = "";
+                    SkinManager.NewQueuedSkin = "";
                     break;
                 default:
                     if (val != skin)
-                        dialog.NewQueuedSkin = val;
+                        SkinManager.NewQueuedSkin = val;
                     break;
             }
         }

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -74,11 +74,6 @@ namespace Quaver.Shared.Screens.Settings
         public SettingsSection SelectedSection { get; private set; }
 
         /// <summary>
-        ///     If non-null, we require a skin reload.
-        /// </summary>
-        public string NewQueuedSkin { get; set; }
-
-        /// <summary>
         ///     A newly queued default skin, if the user chooses to change it.
         /// </summary>
         public DefaultSkins NewQueuedDefaultSkin { get; set; }
@@ -87,11 +82,6 @@ namespace Quaver.Shared.Screens.Settings
         ///     If the user has changed their resolution and it needs to change when they press OK.
         /// </summary>
         public Point NewQueuedScreenResolution { get; set; }
-
-        /// <summary>
-        ///     The time that the user has requested their skin be reloaded.
-        /// </summary>
-        private long TimeSkinReloadRequested { get; set; }
 
         /// <summary>
         ///     If true, the dialog won't close if the user presses escape.
@@ -131,7 +121,7 @@ namespace Quaver.Shared.Screens.Settings
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            HandleSkinReloading();
+            SkinManager.HandleSkinReloading();
             base.Update(gameTime);
         }
 
@@ -141,7 +131,7 @@ namespace Quaver.Shared.Screens.Settings
         /// <param name="gameTime"></param>
         public override void HandleInput(GameTime gameTime)
         {
-            if (TimeSkinReloadRequested != 0 || PreventExitOnEscapeKeybindPress)
+            if (SkinManager.TimeSkinReloadRequested != 0 || PreventExitOnEscapeKeybindPress)
                 return;
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.Escape))
@@ -245,14 +235,14 @@ namespace Quaver.Shared.Screens.Settings
                 var dismissDalog = true;
 
                 // Handle skin reloads
-                if (NewQueuedSkin != null || NewQueuedDefaultSkin != ConfigManager.DefaultSkin.Value)
+                if (SkinManager.NewQueuedSkin != null || NewQueuedDefaultSkin != ConfigManager.DefaultSkin.Value)
                 {
-                    ConfigManager.Skin.Value = NewQueuedSkin;
+                    ConfigManager.Skin.Value = SkinManager.NewQueuedSkin;
                     ConfigManager.DefaultSkin.Value = NewQueuedDefaultSkin;
 
                     Transitioner.FadeIn();
-                    TimeSkinReloadRequested = GameBase.Game.TimeRunning;
-                    IsGloballyClickable = false;
+                    SkinManager.TimeSkinReloadRequested = GameBase.Game.TimeRunning;
+//                    IsGloballyClickable = false;
                     dismissDalog = false;
                 }
 
@@ -420,27 +410,6 @@ namespace Quaver.Shared.Screens.Settings
             SelectedSection.Container.Parent = ContentContainer;
 
             Logger.Debug($"Switched to options section: {section.Name}", LogType.Runtime);
-        }
-
-        /// <summary>
-        ///     Called every frame. Waits for a skin reload to be queued up.
-        /// </summary>
-        private void HandleSkinReloading()
-        {
-            // Reload skin when applicable
-            if (TimeSkinReloadRequested != 0 && GameBase.Game.TimeRunning - TimeSkinReloadRequested >= 400)
-            {
-                SkinManager.Load();
-                NewQueuedSkin = null;
-                TimeSkinReloadRequested = 0;
-                IsGloballyClickable = true;
-
-                ThreadScheduler.RunAfter(() =>
-                {
-                    Transitioner.FadeOut();
-                    NotificationManager.Show(NotificationLevel.Success, "Skin has been successfully loaded!");
-                }, 200);
-            }
         }
     }
 }

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -5,10 +5,25 @@
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Graphics.Transitions;
+using Quaver.Shared.Scheduling;
+using Wobble;
+
 namespace Quaver.Shared.Skinning
 {
     public static class SkinManager
     {
+        /// <summary>
+        ///     The time that the user has requested their skin be reloaded.
+        /// </summary>
+        public static long TimeSkinReloadRequested { get; set; }
+        
+        /// <summary>
+        ///     If non-null, we require a skin reload.
+        /// </summary>
+        public static string NewQueuedSkin { get; set; }
+        
         /// <summary>
         ///     The currently selected skin
         /// </summary>
@@ -18,5 +33,25 @@ namespace Quaver.Shared.Skinning
         ///     Loads the currently selected skin
         /// </summary>
         public static void Load() => Skin = new SkinStore();
+        
+        /// <summary>
+        ///     Called every frame. Waits for a skin reload to be queued up.
+        /// </summary>
+        public static void HandleSkinReloading()
+        {
+            // Reload skin when applicable
+            if (TimeSkinReloadRequested != 0 && GameBase.Game.TimeRunning - TimeSkinReloadRequested >= 400)
+            {
+                Load();
+                NewQueuedSkin = null;
+                TimeSkinReloadRequested = 0;
+
+                ThreadScheduler.RunAfter(() =>
+                {
+                    Transitioner.FadeOut();
+                    NotificationManager.Show(NotificationLevel.Success, "Skin has been successfully loaded!");
+                }, 200);
+            }
+        }
     }
 }


### PR DESCRIPTION
Global hotkey for Reloading of the current skin can only be used in specific screens.

Also, It's annoying how reloading via the Load method in SkinManager cannot be used on separate threads, meaning I just had to use similar code to what is used for reloading the skin in the SettingsDialog.cs class.

Resolves #267 