### PR TITLE
Add a No Long Notes mod

### DIFF
--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -93,6 +93,9 @@ namespace Quaver.Shared.Modifiers
                 case ModIdentifier.NoFail:
                     gameplayModifier = new ModNoFail();
                     break;
+                case ModIdentifier.NoLongNotes:
+                    gameplayModifier = new ModNoLongNotes();
+                    break;
                 default:
                     return;
             }

--- a/Quaver.Shared/Modifiers/Mods/ModNoLongNotes.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModNoLongNotes.cs
@@ -1,0 +1,21 @@
+using Quaver.API.Enums;
+
+namespace Quaver.Shared.Modifiers.Mods
+{
+    public class ModNoLongNotes : IGameplayModifier
+    {
+        public string Name { get; set; } = "No Long Notes";
+
+        public ModIdentifier ModIdentifier { get; set; } = ModIdentifier.NoLongNotes;
+
+        public ModType Type { get; set; } = ModType.Special;
+
+        public string Description { get; set; } = "I have a variety of taste preferences, but noodles aren't included.";
+
+        public bool Ranked { get; set; } = false;
+
+        public ModIdentifier[] IncompatibleMods { get; set; } = { };
+
+        public void InitializeMod() {}
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -220,7 +220,6 @@ namespace Quaver.Shared.Screens.Gameplay
             if (LoadedReplay != null)
             {
                 InReplayMode = true;
-                AddModsFromReplay();
             }
 
             // Create the current replay that will be captured.
@@ -228,7 +227,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             SetRuleset();
             SetRichPresence();
-            
+
             AudioTrack.AllowPlayback = true;
             View = new GameplayScreenView(this);
         }
@@ -323,30 +322,6 @@ namespace Quaver.Shared.Screens.Gameplay
                     break;
                 default:
                     throw new InvalidEnumArgumentException();
-            }
-        }
-
-        /// <summary>
-        ///     Adds all modifiers that were present in the loaded replay (if there is one.)
-        /// </summary>
-        private void AddModsFromReplay()
-        {
-            // Add the correct mods on if we're in replay mode.
-            if (!InReplayMode)
-                return;
-
-            // Remove all the current mods that we have on.
-            ModManager.RemoveAllMods();
-
-            // Put on the mods from the replay.);
-            for (var i = 0; i <= Math.Log((int)LoadedReplay.Mods, 2); i++)
-            {
-                var mod = (ModIdentifier)Math.Pow(2, i);
-
-                if (!LoadedReplay.Mods.HasFlag(mod))
-                    continue;
-
-                ModManager.AddMod(mod);
             }
         }
 

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Quaver.API.Enums;
+using Quaver.API.Replays;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
@@ -41,10 +43,16 @@ namespace Quaver.Shared.Screens.Loading
         private List<Score> Scores { get; }
 
         /// <summary>
+        ///     The replay to play back.
         /// </summary>
-        public MapLoadingScreen(List<Score> scores)
+        private Replay Replay { get; }
+
+        /// <summary>
+        /// </summary>
+        public MapLoadingScreen(List<Score> scores, Replay replay = null)
         {
             Scores = scores;
+            Replay = replay;
             View = new MapLoadingScreenView(this);
             AudioTrack.AllowPlayback = false;
         }
@@ -72,7 +80,7 @@ namespace Quaver.Shared.Screens.Loading
         /// <summary>
         ///     Loads the currently selected map asynchronously.
         /// </summary>
-        private static void ParseAndLoadMap()
+        private void ParseAndLoadMap()
         {
             try
             {
@@ -81,6 +89,11 @@ namespace Quaver.Shared.Screens.Loading
                     throw new Exception("No selected map, we should not be on this screen!");
 
                 MapManager.Selected.Value.Qua = MapManager.Selected.Value.LoadQua();
+
+                if (Replay != null)
+                {
+                    AddModsFromReplay(Replay);
+                }
 
                 // Asynchronously write to a file for livestreamers the difficulty rating
                 using (var writer = File.CreateText(ConfigManager.DataDirectory + "/temp/Now Playing/difficulty.txt"))
@@ -130,11 +143,31 @@ namespace Quaver.Shared.Screens.Loading
                         throw new ArgumentOutOfRangeException();
                 }
 
-                Exit(() => new GameplayScreen(MapManager.Selected.Value.Qua, md5, new List<Score>()));
+                Exit(() => new GameplayScreen(MapManager.Selected.Value.Qua, md5, new List<Score>(), Replay));
             }
             catch (Exception e)
             {
                 Logger.Error(e, LogType.Runtime);
+            }
+        }
+
+        /// <summary>
+        ///     Adds all modifiers that were present in the replay.
+        /// </summary>
+        private static void AddModsFromReplay(Replay replay)
+        {
+            // Remove all the current mods that we have on.
+            ModManager.RemoveAllMods();
+
+            // Put on the mods from the replay.);
+            for (var i = 0; i <= Math.Log((int)replay.Mods, 2); i++)
+            {
+                var mod = (ModIdentifier)Math.Pow(2, i);
+
+                if (!replay.Mods.HasFlag(mod))
+                    continue;
+
+                ModManager.AddMod(mod);
             }
         }
     }

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -95,6 +95,12 @@ namespace Quaver.Shared.Screens.Loading
                     AddModsFromReplay(Replay);
                 }
 
+                // If the No Long Notes mod is active, remove the long notes.
+                if (ModManager.IsActivated(ModIdentifier.NoLongNotes))
+                {
+                    MapManager.Selected.Value.Qua.ReplaceLongNotesWithRegularNotes();
+                }
+
                 // Asynchronously write to a file for livestreamers the difficulty rating
                 using (var writer = File.CreateText(ConfigManager.DataDirectory + "/temp/Now Playing/difficulty.txt"))
                     writer.Write($"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}");

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -488,11 +488,8 @@ namespace Quaver.Shared.Screens.Result
                         AudioEngine.Track.Fade(10, 300);
                 }
 
-                // Load up the .qua file again
-                var qua = MapManager.Selected.Value.LoadQua();
-                MapManager.Selected.Value.Qua = qua;
                 GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
-                return new GameplayScreen(MapManager.Selected.Value.Qua, MapManager.Selected.Value.Md5Checksum, new List<Score>(), replay);
+                return new MapLoadingScreen(new List<Score>(), replay);
             });
         }
 
@@ -530,10 +527,6 @@ namespace Quaver.Shared.Screens.Result
                     OnlineManager.Client?.DownloadReplay(Score.Id, path);
                     var replay = new Replay(path);
 
-                    // Load up the .qua file again
-                    var qua = MapManager.Selected.Value.LoadQua();
-                    MapManager.Selected.Value.Qua = qua;
-
                     Exit(() =>
                     {
                         if (AudioEngine.Track != null)
@@ -542,7 +535,7 @@ namespace Quaver.Shared.Screens.Result
                                 AudioEngine.Track.Fade(10, 300);
                         }
                         GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
-                        return new GameplayScreen(MapManager.Selected.Value.Qua, MapManager.Selected.Value.Md5Checksum, new List<Score>(), replay);
+                        return new MapLoadingScreen(new List<Score>(), replay);
                     });
                 }
                 catch (Exception e)

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/ModifiersDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/ModifiersDialog.cs
@@ -195,6 +195,11 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers
                 {
                     Alignment = Alignment.TopLeft,
                 },
+
+                new DrawableModifierBool(this, new ModNoLongNotes())
+                {
+                    Alignment = Alignment.TopLeft,
+                },
             };
 
             for (var i = 0; i < ModsList.Count; i++)


### PR DESCRIPTION
Replaces LNs with regular notes at their respective starts.

Ideally this should impact difficulty calculation, but the current code isn't really extensible.

Requires https://github.com/Quaver/Quaver.API/pull/21.

Resolves #406.