### PR TITLE
Add randomize modifier

### DIFF
--- a/Quaver.Shared/Database/Scores/Score.cs
+++ b/Quaver.Shared/Database/Scores/Score.cs
@@ -98,6 +98,13 @@ namespace Quaver.Shared.Database.Scores
         public int CountMiss { get; set; }
 
         /// <summary>
+        ///     Integer based seed used for shuffling the lanes when randomize mod is active.
+        ///     Defaults to -1 if there is no seed.
+        /// </summary>
+        [Ignore]
+        public int RandomizeModifierSeed { get; set; } = -1;
+        
+        /// <summary>
         ///     Bitwise sum of the mods used in the play
         /// </summary>
         public ModIdentifier Mods { get; set; }
@@ -151,8 +158,10 @@ namespace Quaver.Shared.Database.Scores
         /// <param name="md5"></param>
         /// <param name="name"></param>
         /// <param name="scrollSpeed"></param>
+        /// <param name="pauseCount"></param>
+        /// <param name="seed"></param>
         /// <returns></returns>
-        public static Score FromScoreProcessor(ScoreProcessor processor, string md5, string name, int scrollSpeed, int pauseCount)
+        public static Score FromScoreProcessor(ScoreProcessor processor, string md5, string name, int scrollSpeed, int pauseCount, int seed)
         {
             var score = new Score()
             {
@@ -173,6 +182,7 @@ namespace Quaver.Shared.Database.Scores
                 Mods = processor.Mods,
                 ScrollSpeed = scrollSpeed,
                 PauseCount =  pauseCount,
+                RandomizeModifierSeed = seed,
                 JudgementBreakdown = GzipHelper.Compress(processor.GetJudgementBreakdown()),
             };
 
@@ -231,7 +241,8 @@ namespace Quaver.Shared.Database.Scores
             CountGreat = CountGreat,
             CountGood = CountGood,
             CountOkay = CountOkay,
-            CountMiss = CountMiss
+            CountMiss = CountMiss,
+            RandomizeModifierSeed = RandomizeModifierSeed
         };
     }
 }

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -93,6 +93,9 @@ namespace Quaver.Shared.Modifiers
                 case ModIdentifier.NoFail:
                     gameplayModifier = new ModNoFail();
                     break;
+                case ModIdentifier.Randomize:
+                    gameplayModifier = new ModRandomize();
+                    break;
                 default:
                     return;
             }

--- a/Quaver.Shared/Modifiers/Mods/ModRandomize.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModRandomize.cs
@@ -1,0 +1,39 @@
+using System;
+using Quaver.API.Enums;
+using Wobble;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Modifiers.Mods
+{
+    /// <summary>
+    ///     Randomize gameplayModifier. Randomizes the lanes.
+    /// </summary>
+    internal class ModRandomize : IGameplayModifier
+    {
+
+        /// <summary>
+        ///     Integer based seed for use with the Shuffle(Random) function.
+        ///
+        ///     Used in shuffling the order of the playfields lanes.
+        /// </summary>
+        public int Seed;
+            
+        public string Name { get; set; } = "Randomize";
+
+        public ModIdentifier ModIdentifier { get; set; } = ModIdentifier.Randomize;
+
+        public ModType Type { get; set; } = ModType.Special;
+
+        public string Description { get; set; } = "Swap up the lanes.";
+
+        public bool Ranked { get; set; } = false;
+
+        public ModIdentifier[] IncompatibleMods { get; set; } = { };
+
+        public void InitializeMod()
+        {
+        }
+
+        public void GenerateSeed() => Seed = new Random().Next(int.MaxValue);
+    }
+}

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -8,11 +8,13 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Quaver.API.Enums;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Gameplay;
 using Wobble.Audio;
@@ -82,6 +84,15 @@ namespace Quaver.Shared.Screens.Loading
 
                 MapManager.Selected.Value.Qua = MapManager.Selected.Value.LoadQua();
 
+                // Generate seed and randomize lanes if Randomize modifier is active.
+                if (ModManager.IsActivated(ModIdentifier.Randomize))
+                {
+                    ModRandomize randomizeModifier = (ModRandomize) ModManager.CurrentModifiersList.Find(x => x.ModIdentifier.Equals(ModIdentifier.Randomize));
+                    randomizeModifier.GenerateSeed();
+                    
+                    MapManager.Selected.Value.Qua.RandomizeLanes(randomizeModifier.Seed);
+                }
+                
                 // Asynchronously write to a file for livestreamers the difficulty rating
                 using (var writer = File.CreateText(ConfigManager.DataDirectory + "/temp/Now Playing/difficulty.txt"))
                     writer.Write($"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}");

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -30,6 +30,7 @@ using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Gameplay;
@@ -250,6 +251,7 @@ namespace Quaver.Shared.Screens.Result
             // Set the replay that the user has generated
             Replay = Gameplay.ReplayCapturer.Replay;
             Replay.PauseCount = Gameplay.PauseCount;
+            Replay.RandomizeModifierSeed = Gameplay.Map.RandomizeModifierSeed;
             ScoreProcessor = Gameplay.Ruleset.ScoreProcessor;
             Replay.FromScoreProcessor(ScoreProcessor);
 
@@ -319,7 +321,7 @@ namespace Quaver.Shared.Screens.Result
             try
             {
                 var localScore = Score.FromScoreProcessor(ScoreProcessor, Gameplay.MapHash, ConfigManager.Username.Value, ScrollSpeed,
-                    Gameplay.PauseCount);
+                    Gameplay.PauseCount, Gameplay.Map.RandomizeModifierSeed);
 
                 localScore.RatingProcessorVersion = RatingProcessorKeys.Version;
 
@@ -487,6 +489,8 @@ namespace Quaver.Shared.Screens.Result
 
                 // Load up the .qua file again
                 var qua = MapManager.Selected.Value.LoadQua();
+                qua.RandomizeLanes(replay.RandomizeModifierSeed);
+                
                 MapManager.Selected.Value.Qua = qua;
                 GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
                 return new GameplayScreen(MapManager.Selected.Value.Qua, MapManager.Selected.Value.Md5Checksum, new List<Score>(), replay);

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/ModifiersDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/ModifiersDialog.cs
@@ -195,6 +195,11 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers
                 {
                     Alignment = Alignment.TopLeft,
                 },
+                
+                new DrawableModifierBool(this, new ModRandomize())
+                {
+                    Alignment = Alignment.TopLeft,
+                }
             };
 
             for (var i = 0; i < ModsList.Count; i++)


### PR DESCRIPTION
Implementation of randomize modifier done through the use of seed generation, which is stored in replays, and is done through modifying the Qua class file. Seeds are stored in replays after gameplay is completed, and are used for when playing back user score replays, to randomize the lanes to that same seed.