### PR TITLE
Scale the hit window back to 1x rate for the graph

### DIFF
--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -239,15 +239,17 @@ namespace Quaver.Shared.Screens.Result.UI
         /// </summary>
         private void CreateEarlyLateText()
         {
+            var unscaledLargestHitWindow = LargestHitWindow / ModHelper.GetRateFromMods(Processor.Mods);
+
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteText(Fonts.SourceSansProSemiBold, $"Late (+{LargestHitWindow}ms)", 13)
+            new SpriteText(Fonts.SourceSansProSemiBold, $"Late (+{unscaledLargestHitWindow}ms)", 13)
             {
                 Parent = this,
                 X = 2
             };
 
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteText(Fonts.SourceSansProSemiBold, $"Early (-{LargestHitWindow}ms)", 13)
+            new SpriteText(Fonts.SourceSansProSemiBold, $"Early (-{unscaledLargestHitWindow}ms)", 13)
             {
                 Parent = this,
                 Alignment = Alignment.BotLeft,


### PR DESCRIPTION
Idk, I definitely remember doing this while working on the hit difference graph. Must've got lost during refactoring.

It might be a better idea to store unscaled judgement window values in `ScoreProcessor` instead but that involves more changes and Quaver.API so I'm going for the easiest option first.