### PR TITLE
Add a Linux launch script

### DIFF
--- a/Quaver.Shared/Quaver.Shared.csproj
+++ b/Quaver.Shared/Quaver.Shared.csproj
@@ -68,6 +68,9 @@
     <None Update="steam_api64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="quaver.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="HoLLy.osu.DatabaseReader" Version="2.1.0" />

--- a/Quaver.Shared/quaver.sh
+++ b/Quaver.Shared/quaver.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SCRIPT_DIR"
+exec dotnet "$SCRIPT_DIR/Quaver.dll" "$@"


### PR DESCRIPTION
Sets up LD_LIBRARY_PATH so libbass works correctly, even on publish.