### PR TITLE
Fix Jukebox Multiple Tracks Bug

### DIFF
--- a/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
@@ -227,6 +227,9 @@ namespace Quaver.Shared.Screens.Menu.UI.Jukebox
                         throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
                 }
 
+                if (LoadingNextTrack)
+                    return;
+
                 LoadingNextTrack = true;
 
                 ThreadScheduler.Run(() =>
@@ -450,6 +453,9 @@ namespace Quaver.Shared.Screens.Menu.UI.Jukebox
             {
                 SkinManager.Skin.SoundClick.CreateChannel().Play();
 
+                if (LoadingNextTrack)
+                    return;
+
                 if (AudioEngine.Track == null || AudioEngine.Track.IsDisposed)
                     return;
 
@@ -487,6 +493,9 @@ namespace Quaver.Shared.Screens.Menu.UI.Jukebox
             RestartButton.Clicked += (o, e) =>
             {
                 SkinManager.Skin.SoundClick.CreateChannel().Play();
+
+                if (LoadingNextTrack)
+                    return;
 
                 try
                 {


### PR DESCRIPTION
Issue: https://github.com/Quaver/Quaver/issues/485

I've added a check for each button to make sure LoadingNextTrack is not active. It has totally fixed the issue, and does not cause any other issues.