### PR TITLE
Lane cover

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -260,6 +260,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> LaneCoverBottom { get; private set; }
 
         /// <summary>
+        ///     If enabled, the lane covers will be displayed under the ui elements.
+        /// </summary>
+        internal static Bindable<bool> UiElementsOverLaneCover { get; private set; }
+
+        /// <summary>
         ///     If enabled, failed scores will not show in local scores.
         /// </summary>
         internal static Bindable<bool> DisplayFailedLocalScores { get; private set; }
@@ -505,6 +510,7 @@ namespace Quaver.Shared.Config
             LaneCoverBottomHeight = ReadInt(@"LaneCoverBottomHeight", 25, 0, 75, data);
             LaneCoverTop = ReadValue(@"LaneCoverTop", false, data);
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
+            UiElementsOverLaneCover = ReadValue(@"UiElementsOverLaneCover", true, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -590,6 +596,7 @@ namespace Quaver.Shared.Config
                     LaneCoverBottomHeight.ValueChanged += AutoSaveConfiguration;
                     LaneCoverTop.ValueChanged += AutoSaveConfiguration;
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
+                    UiElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -240,6 +240,26 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> TapToPause { get; private set; }
 
         /// <summary>
+        ///     The top lane cover's adjustable height between levels 0-50
+        /// </summary>
+        internal static BindableInt LaneCoverTopHeight { get; private set; }
+
+        /// <summary>
+        ///     The bottom lane cover's adjustable height between levels 0-50
+        /// </summary>
+        internal static BindableInt LaneCoverBottomHeight { get; private set; }
+
+        /// <summary>
+        ///     If enabled, gameplay will have a top lane cover using the adjustable height.
+        /// </summary>
+        internal static Bindable<bool> LaneCoverTop { get; private set; }
+
+        /// <summary>
+        ///     If enabled, gameplay will have a bottom lane cover using the adjustable height.
+        /// </summary>
+        internal static Bindable<bool> LaneCoverBottom { get; private set; }
+
+        /// <summary>
         ///     If enabled, failed scores will not show in local scores.
         /// </summary>
         internal static Bindable<bool> DisplayFailedLocalScores { get; private set; }
@@ -481,6 +501,11 @@ namespace Quaver.Shared.Config
             DisplayJudgementCounter = ReadValue(@"DisplayJudgementCounter", true, data);
             SkipResultsScreenAfterQuit = ReadValue(@"SkipResultsScreenAfterQuit", false, data);
             DisplayComboAlerts = ReadValue(@"DisplayComboAlerts", true, data);
+            LaneCoverTopHeight = ReadInt(@"LaneCoverTopHeight", 25, 0, 75, data);
+            LaneCoverBottomHeight = ReadInt(@"LaneCoverBottomHeight", 25, 0, 75, data);
+            LaneCoverTop = ReadValue(@"LaneCoverTop", false, data);
+            LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
+
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
                 Username.Value = "Player";
@@ -561,6 +586,10 @@ namespace Quaver.Shared.Config
                     DisplayJudgementCounter.ValueChanged += AutoSaveConfiguration;
                     SkipResultsScreenAfterQuit.ValueChanged += AutoSaveConfiguration;
                     DisplayComboAlerts.ValueChanged += AutoSaveConfiguration;
+                    LaneCoverTopHeight.ValueChanged += AutoSaveConfiguration;
+                    LaneCoverBottomHeight.ValueChanged += AutoSaveConfiguration;
+                    LaneCoverTop.ValueChanged += AutoSaveConfiguration;
+                    LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -262,7 +262,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     If enabled, the lane covers will be displayed under the ui elements.
         /// </summary>
-        internal static Bindable<bool> UiElementsOverLaneCover { get; private set; }
+        internal static Bindable<bool> UIElementsOverLaneCover { get; private set; }
 
         /// <summary>
         ///     If enabled, failed scores will not show in local scores.
@@ -510,7 +510,7 @@ namespace Quaver.Shared.Config
             LaneCoverBottomHeight = ReadInt(@"LaneCoverBottomHeight", 25, 0, 75, data);
             LaneCoverTop = ReadValue(@"LaneCoverTop", false, data);
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
-            UiElementsOverLaneCover = ReadValue(@"UiElementsOverLaneCover", true, data);
+            UIElementsOverLaneCover = ReadValue(@"UIElementsOverLaneCover", true, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -596,7 +596,7 @@ namespace Quaver.Shared.Config
                     LaneCoverBottomHeight.ValueChanged += AutoSaveConfiguration;
                     LaneCoverTop.ValueChanged += AutoSaveConfiguration;
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
-                    UiElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
+                    UIElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -1,7 +1,7 @@
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
@@ -168,7 +168,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             // Depending on what the config value is, we'll display ui elements over the lane cover.
             // Note: Lane cover will always be displayed over the receptors due to the creation order.
-            if (ConfigManager.UiElementsOverLaneCover.Value)
+            if (ConfigManager.UIElementsOverLaneCover.Value)
             {
                 CreateLaneCoverOverlay();
                 CreateComboDisplay();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -536,7 +536,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             if (!ConfigManager.LaneCoverTop.Value)
                 return;
 
-            float yAxis = -LaneCoverContainer.Height +  (float) ConfigManager.LaneCoverTopHeight.Value / 100f * LaneCoverContainer.Height;
+            var yAxis = -LaneCoverContainer.Height + ConfigManager.LaneCoverTopHeight.Value / 100f * LaneCoverContainer.Height;
 
             var laneCoverTop = new Sprite
             {
@@ -556,7 +556,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             if (!ConfigManager.LaneCoverBottom.Value)
                 return;
 
-            float yAxis = LaneCoverContainer.Height - (float) (ConfigManager.LaneCoverBottomHeight.Value / 100f * LaneCoverContainer.Height);
+            var yAxis = LaneCoverContainer.Height - ConfigManager.LaneCoverBottomHeight.Value / 100f * LaneCoverContainer.Height;
 
             var laneCoverBottom = new Sprite
             {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -83,6 +83,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         public Sprite DistantOverlay { get; private set; }
 
         /// <summary>
+        ///     Container that contains the elements for lane cover.
+        /// </summary>
+        public Container LaneCoverContainer { get; private set; }
+
+        /// <summary>
         ///     Sprite that displays the current combo.
         /// </summary>
         public NumberDisplay ComboDisplay { get; private set; }
@@ -159,14 +164,30 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 CreateHitObjectContainer();
             }
 
-            // Create Stage Elements
             CreateDistantOverlay();
-            CreateComboDisplay();
-            CreateHitError();
-            CreateJudgementHitBurst();
-            CreateHitLighting();
+
+            // Depending on what the skin.ini's value is, we'll display the lane cover over the displays.
+            // Note: Lane cover will always be displayed over the receptors due to the creation order.
+            if (Skin.LaneCoverOverDisplays)
+            {
+                CreateComboDisplay();
+                CreateHitError();
+                CreateJudgementHitBurst();
+                CreateHitLighting();
+                CreateSongInfo();
+                CreateLaneCoverOverlay();
+            }
+            else
+            {
+                CreateLaneCoverOverlay();
+                CreateComboDisplay();
+                CreateHitError();
+                CreateHitLighting();
+                CreateJudgementHitBurst();
+                CreateSongInfo();
+            }
+
             CreateHealthBar();
-            CreateSongInfo();
         }
 
         /// <summary>
@@ -331,6 +352,23 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         }
 
         /// <summary>
+        ///     Creates the lane cover container and overlay sprites.
+        /// </summary>
+        private void CreateLaneCoverOverlay()
+        {
+            LaneCoverContainer = new Container
+            {
+                Size = new ScalableVector2(Playfield.ForegroundContainer.Width, Playfield.ForegroundContainer.Height, 0, 0),
+                Alignment = Alignment.TopLeft,
+                Parent = Playfield.ForegroundContainer
+            };
+
+            // Apply the covers.
+            ApplyTopLaneCover();
+            ApplyBottomLaneCover();
+        }
+
+        /// <summary>
         ///     Creates the combo display sprite.
         /// </summary>
         private void CreateComboDisplay()
@@ -488,6 +526,46 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             Receptors[index].Image = pressed ? Skin.NoteReceptorsDown[index] : Skin.NoteReceptorsUp[index];
             ColumnLightingObjects[index].Active = pressed;
+        }
+
+        /// <summary>
+        ///     Applies a top lane cover if enabled in settings.
+        /// </summary>
+        private void ApplyTopLaneCover()
+        {
+            if (!ConfigManager.LaneCoverTop.Value)
+                return;
+
+            float yAxis = -LaneCoverContainer.Height +  (float) ConfigManager.LaneCoverTopHeight.Value / 100f * LaneCoverContainer.Height;
+
+            var laneCoverTop = new Sprite
+            {
+                Image = Skin.LaneCoverTop,
+                Y = yAxis,
+                Size = new ScalableVector2(LaneCoverContainer.Width, 700),
+                Alignment = Alignment.BotLeft,
+                Parent = LaneCoverContainer,
+            };
+        }
+
+        /// <summary>
+        ///     Applies the bottom lane cover if enabled in settings.
+        /// </summary>
+        private void ApplyBottomLaneCover()
+        {
+            if (!ConfigManager.LaneCoverBottom.Value)
+                return;
+
+            float yAxis = LaneCoverContainer.Height - (float) (ConfigManager.LaneCoverBottomHeight.Value / 100f * LaneCoverContainer.Height);
+
+            var laneCoverBottom = new Sprite
+            {
+                Image = Skin.LaneCoverBottom,
+                Y = yAxis,
+                Size = new ScalableVector2(LaneCoverContainer.Width, 700),
+                Alignment = Alignment.TopLeft,
+                Parent = LaneCoverContainer,
+            };
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -166,25 +166,25 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             CreateDistantOverlay();
 
-            // Depending on what the skin.ini's value is, we'll display the lane cover over the displays.
+            // Depending on what the config value is, we'll display ui elements over the lane cover.
             // Note: Lane cover will always be displayed over the receptors due to the creation order.
-            if (Skin.LaneCoverOverDisplays)
+            if (ConfigManager.UiElementsOverLaneCover.Value)
             {
+                CreateLaneCoverOverlay();
                 CreateComboDisplay();
                 CreateHitError();
-                CreateJudgementHitBurst();
                 CreateHitLighting();
+                CreateJudgementHitBurst();
                 CreateSongInfo();
-                CreateLaneCoverOverlay();
             }
             else
             {
-                CreateLaneCoverOverlay();
                 CreateComboDisplay();
                 CreateHitError();
-                CreateHitLighting();
                 CreateJudgementHitBurst();
+                CreateHitLighting();
                 CreateSongInfo();
+                CreateLaneCoverOverlay();
             }
 
             CreateHealthBar();

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -331,7 +331,8 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsSlider(this, "Top Lane Cover Height", ConfigManager.LaneCoverTopHeight),
                     new SettingsSlider(this, "Bottom Lane Cover Height", ConfigManager.LaneCoverBottomHeight),
                     new SettingsBool(this, "Top Lane Cover", ConfigManager.LaneCoverTop),
-                    new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom)
+                    new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom),
+                    new SettingsBool(this, "Displays UI elements over skinnable lane covers", ConfigManager.UiElementsOverLaneCover)
                 }),
                 // Skinning
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_pencil), "Skin", new List<Drawable>()

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -327,7 +327,11 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsBool(this, "Animate Judgement Counter", ConfigManager.AnimateJudgementCounter),
                     new SettingsBool(this, "Display Scoreboard", ConfigManager.ScoreboardVisible),
                     new SettingsBool(this, "Tap to Pause", ConfigManager.TapToPause),
-                    new SettingsBool(this, "Skip Results Screen After Quitting", ConfigManager.SkipResultsScreenAfterQuit)
+                    new SettingsBool(this, "Skip Results Screen After Quitting", ConfigManager.SkipResultsScreenAfterQuit),
+                    new SettingsSlider(this, "Top Lane Cover Height", ConfigManager.LaneCoverTopHeight),
+                    new SettingsSlider(this, "Bottom Lane Cover Height", ConfigManager.LaneCoverBottomHeight),
+                    new SettingsBool(this, "Top Lane Cover", ConfigManager.LaneCoverTop),
+                    new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom)
                 }),
                 // Skinning
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_pencil), "Skin", new List<Drawable>()

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -332,7 +332,7 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsSlider(this, "Bottom Lane Cover Height", ConfigManager.LaneCoverBottomHeight),
                     new SettingsBool(this, "Top Lane Cover", ConfigManager.LaneCoverTop),
                     new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom),
-                    new SettingsBool(this, "Displays UI elements over skinnable lane covers", ConfigManager.UiElementsOverLaneCover)
+                    new SettingsBool(this, "Display UI Elements Over Lane Covers", ConfigManager.UIElementsOverLaneCover)
                 }),
                 // Skinning
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_pencil), "Skin", new List<Drawable>()

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -67,6 +67,8 @@ namespace Quaver.Shared.Skinning
 
         internal bool ReceptorsOverHitObjects { get; private set; }
 
+        internal bool LaneCoverOverDisplays { get; private set; }
+
         internal SortedDictionary<Judgement, Color> JudgeColors { get; private set; }
 
         internal List<Color> ColumnColors { get; private set; } = new List<Color>();
@@ -217,6 +219,18 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         internal List<Texture2D> HoldLighting { get; private set; } = new List<Texture2D>();
 
+        // ----- Lane Covers ----- //
+
+        /// <summary>
+        ///     Top lane cover texture.
+        /// </summary>
+        internal Texture2D LaneCoverTop { get; private set; }
+
+        /// <summary>
+        ///     Bottom lane cover texture.
+        /// </summary>
+        internal Texture2D LaneCoverBottom { get; private set; }
+
 #endregion
 
         /// <summary>
@@ -299,6 +313,7 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = false;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = true;
+                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>()
                     {
                         Color.DarkGray,
@@ -349,6 +364,7 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = true;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = false;
+                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         new Color(255, 255, 255),
@@ -411,6 +427,7 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = false;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = true;
+                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         Color.DarkGray,
@@ -464,6 +481,7 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = true;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = false;
+                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         new Color(255, 255, 255),
@@ -535,6 +553,7 @@ namespace Quaver.Shared.Skinning
             ColorObjectsBySnapDistance = ConfigHelper.ReadBool(ColorObjectsBySnapDistance, ini["ColorObjectsBySnapDistance"]);
             JudgementHitBurstScale = ConfigHelper.ReadByte(JudgementHitBurstScale, ini["JudgementHitBurstScale"]);
             ReceptorsOverHitObjects = ConfigHelper.ReadBool(ReceptorsOverHitObjects, ini["ReceptorsOverHitObjects"]);
+            LaneCoverOverDisplays = ConfigHelper.ReadBool(LaneCoverOverDisplays, ini["LaneCoverOverDisplays"]);
             JudgeColors[Judgement.Marv] = ConfigHelper.ReadColor(JudgeColors[Judgement.Marv], ini["JudgeColorMarv"]);
             JudgeColors[Judgement.Perf] = ConfigHelper.ReadColor(JudgeColors[Judgement.Perf], ini["JudgeColorPerf"]);
             JudgeColors[Judgement.Great] = ConfigHelper.ReadColor(JudgeColors[Judgement.Great], ini["JudgeColorGreat"]);
@@ -590,6 +609,11 @@ namespace Quaver.Shared.Skinning
             StageRightBorder = LoadTexture(SkinKeysFolder.Stage, "stage-right-border", false);
             StageHitPositionOverlay = LoadTexture(SkinKeysFolder.Stage, "stage-hitposition-overlay", false);
             StageDistantOverlay = LoadTexture(SkinKeysFolder.Stage, "stage-distant-overlay", false);
+            #endregion
+
+            #region LANECOVER
+            LaneCoverTop = LoadTexture(SkinKeysFolder.LaneCover, "cover-top", false);
+            LaneCoverBottom = LoadTexture(SkinKeysFolder.LaneCover, "cover-bottom", false);
             #endregion
 
             #region MISC

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -67,8 +67,6 @@ namespace Quaver.Shared.Skinning
 
         internal bool ReceptorsOverHitObjects { get; private set; }
 
-        internal bool LaneCoverOverDisplays { get; private set; }
-
         internal SortedDictionary<Judgement, Color> JudgeColors { get; private set; }
 
         internal List<Color> ColumnColors { get; private set; } = new List<Color>();
@@ -313,7 +311,6 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = false;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = true;
-                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>()
                     {
                         Color.DarkGray,
@@ -364,7 +361,6 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = true;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = false;
-                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         new Color(255, 255, 255),
@@ -427,7 +423,6 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = false;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = true;
-                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         Color.DarkGray,
@@ -481,7 +476,6 @@ namespace Quaver.Shared.Skinning
                     ColorObjectsBySnapDistance = true;
                     JudgementHitBurstScale = 150;
                     ReceptorsOverHitObjects = false;
-                    LaneCoverOverDisplays = true;
                     ColumnColors = new List<Color>
                     {
                         new Color(255, 255, 255),
@@ -553,7 +547,6 @@ namespace Quaver.Shared.Skinning
             ColorObjectsBySnapDistance = ConfigHelper.ReadBool(ColorObjectsBySnapDistance, ini["ColorObjectsBySnapDistance"]);
             JudgementHitBurstScale = ConfigHelper.ReadByte(JudgementHitBurstScale, ini["JudgementHitBurstScale"]);
             ReceptorsOverHitObjects = ConfigHelper.ReadBool(ReceptorsOverHitObjects, ini["ReceptorsOverHitObjects"]);
-            LaneCoverOverDisplays = ConfigHelper.ReadBool(LaneCoverOverDisplays, ini["LaneCoverOverDisplays"]);
             JudgeColors[Judgement.Marv] = ConfigHelper.ReadColor(JudgeColors[Judgement.Marv], ini["JudgeColorMarv"]);
             JudgeColors[Judgement.Perf] = ConfigHelper.ReadColor(JudgeColors[Judgement.Perf], ini["JudgeColorPerf"]);
             JudgeColors[Judgement.Great] = ConfigHelper.ReadColor(JudgeColors[Judgement.Great], ini["JudgeColorGreat"]);

--- a/Quaver.Shared/Skinning/SkinKeysFolder.cs
+++ b/Quaver.Shared/Skinning/SkinKeysFolder.cs
@@ -12,6 +12,7 @@ namespace Quaver.Shared.Skinning
         Stage,
         HitObjects,
         Receptors,
-        Lighting
+        Lighting,
+        LaneCover
     }
 }


### PR DESCRIPTION
Added skin-able lane cover.
Added skin.ini value "LaneCoverOverDisplays" for displaying of various displays (combo, hit timing, judgement, etc) over the lane cover.

Note: Receptors are hidden under the lane cover on purpose.

Requires Quaver/Quaver.Resources#8