### PR TITLE
Judgement Counter Customizability

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -250,6 +250,10 @@ namespace Quaver.Shared.Config
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
 
         /// <summary>
+        /// </summary>
+        internal static Bindable<bool> DisplayJudgementCounter { get; private set; }
+
+        /// <summary>
         ///     Keybindings for 4K
         /// </summary>
         internal static Bindable<Keys> KeyMania4K1 { get; private set; }
@@ -461,6 +465,7 @@ namespace Quaver.Shared.Config
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);
+            DisplayJudgementCounter = ReadValue(@"DisplayJudgementCounter", true, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -538,6 +543,7 @@ namespace Quaver.Shared.Config
                     KeyEditorPausePlay.ValueChanged += AutoSaveConfiguration;
                     KeyEditorDecreaseAudioRate.ValueChanged += AutoSaveConfiguration;
                     KeyEditorIncreaseAudioRate.ValueChanged += AutoSaveConfiguration;
+                    DisplayJudgementCounter.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -155,7 +155,8 @@ namespace Quaver.Shared.Screens.Gameplay
             CreateAccuracyDisplay();
 
             // Create judgement status display
-            JudgementCounter = new JudgementCounter(Screen) { Parent = Container };
+            if (ConfigManager.DisplayJudgementCounter.Value)
+                JudgementCounter = new JudgementCounter(Screen) { Parent = Container };
 
             CreateKeysPerSecondDisplay();
             CreateGradeDisplay();

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -1,7 +1,7 @@
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
@@ -23,17 +23,12 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
         /// <summary>
         ///     Reference to the ruleset.
         /// </summary>
-        private GameplayScreen Screen { get; }
+        public GameplayScreen Screen { get; }
 
         /// <summary>
         ///     The list of judgement displays.
         /// </summary>
         private Dictionary<Judgement, JudgementCounterItem> JudgementDisplays { get; }
-
-        /// <summary>
-        ///     The size of each display item.
-        /// </summary>
-        public static Vector2 DisplayItemSize { get; } = new Vector2(45, 45);
 
         /// <inheritdoc />
         /// <summary>
@@ -45,17 +40,21 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
 
             // Create the judgement displays.
             JudgementDisplays = new Dictionary<Judgement, JudgementCounterItem>();
+
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
             for (var i = 0; i < Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count; i++)
             {
                 var key = (Judgement)i;
                 var color = SkinManager.Skin.Keys[Screen.Map.Mode].JudgeColors[key];
 
                 // Default it to an inactive color.
-                JudgementDisplays[key] = new JudgementCounterItem(this, key, new Color(color.R / 2, color.G / 2, color.B / 2), new Vector2(DisplayItemSize.Y, DisplayItemSize.Y))
+                JudgementDisplays[key] = new JudgementCounterItem(this, key, new Color(color.R / 2, color.G / 2, color.B / 2),
+                    new Vector2(skin.JudgementCounterSize, skin.JudgementCounterSize))
                 {
                     Alignment = Alignment.MidRight,
                     Parent = this,
                     Image = SkinManager.Skin.JudgementOverlay,
+                    Alpha = skin.JudgementCounterAlpha
                 };
 
                 // Normalize the position of the first one so that all the rest will be completely in the middle.
@@ -94,11 +93,13 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
         /// </summary>
         /// <param name="counterItem"></param>
         /// <param name="dt"></param>
-        private static void UpdateTextAndSize(JudgementCounterItem counterItem, double dt)
+        private void UpdateTextAndSize(JudgementCounterItem counterItem, double dt)
         {
             // Tween size and pos back to normal
-            counterItem.Width = MathHelper.Lerp(counterItem.Width, DisplayItemSize.Y, (float)Math.Min(dt / 180, 1));
-            counterItem.Height = MathHelper.Lerp(counterItem.Height, DisplayItemSize.Y, (float)Math.Min(dt / 180, 1));
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
+            counterItem.Width = MathHelper.Lerp(counterItem.Width, skin.JudgementCounterSize, (float)Math.Min(dt / 180, 1));
+            counterItem.Height = MathHelper.Lerp(counterItem.Height, skin.JudgementCounterSize, (float)Math.Min(dt / 180, 1));
             counterItem.X = MathHelper.Lerp(counterItem.X, 0, (float) Math.Min(dt / 180, 1));
         }
     }

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
@@ -1,7 +1,7 @@
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) 2017-2018 Swan & The Quaver Team <support@quavergame.com>.
 */
 
@@ -56,9 +56,11 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                     return;
 
                 // Make the size of the display look more pressed.
-                Width = JudgementCounter.DisplayItemSize.Y - JudgementCounter.DisplayItemSize.Y / 4;
+                var skin = SkinManager.Skin.Keys[ParentDisplay.Screen.Map.Mode];
+
+                Width = skin.JudgementCounterSize - skin.JudgementCounterSize / 4;
                 Height = Width;
-                X = -JudgementCounter.DisplayItemSize.Y / 16;
+                X = -skin.JudgementCounterSize / 16f;
             }
         }
 
@@ -87,13 +89,15 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
 
             Size = new ScalableVector2(size.X, size.Y);
 
+            var skin = SkinManager.Skin.Keys[parentDisplay.Screen.Map.Mode];
+
             SpriteText = new SpriteTextBitmap(FontsBitmap.AllerRegular, JudgementHelper.JudgementToShortName(j))
             {
                 Alignment = Alignment.MidCenter,
                 Parent = this,
-                Tint = Color.Black,
+                Tint = skin.JudgementCounterFontColor,
                 X = 0,
-                FontSize = 16
+                FontSize = (int)(Width * 0.35f)
             };
 
             InactiveColor = color;

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -321,6 +321,7 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsBool(this, "Enable Hitsounds", ConfigManager.EnableHitsounds),
                     new SettingsBool(this, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                     new SettingsBool(this, "Display Song Time Progress", ConfigManager.DisplaySongTimeProgress),
+                    new SettingsBool(this, "Display Judgement Counter", ConfigManager.DisplayJudgementCounter),
                     new SettingsBool(this, "Animate Judgement Counter", ConfigManager.AnimateJudgementCounter),
                     new SettingsBool(this, "Display Scoreboard", ConfigManager.ScoreboardVisible),
                     new SettingsBool(this, "Tap to Pause", ConfigManager.TapToPause)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -119,7 +119,13 @@ namespace Quaver.Shared.Skinning
 
         internal Color TimingLineColor { get; private set; }
 
-#endregion
+        internal float JudgementCounterAlpha { get; private set; }
+
+        internal Color JudgementCounterFontColor { get; private set; }
+
+        internal int JudgementCounterSize { get; private set; }
+
+        #endregion
 
 #region TEXTURES
 
@@ -320,6 +326,9 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    JudgementCounterAlpha = 1;
+                    JudgementCounterFontColor = Color.Black;
+                    JudgementCounterSize = 45;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -365,6 +374,9 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    JudgementCounterAlpha = 1;
+                    JudgementCounterFontColor = Color.Black;
+                    JudgementCounterSize = 45;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -425,6 +437,9 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    JudgementCounterAlpha = 1;
+                    JudgementCounterFontColor = Color.Black;
+                    JudgementCounterSize = 45;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -474,6 +489,9 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    JudgementCounterAlpha = 1;
+                    JudgementCounterFontColor = Color.Black;
+                    JudgementCounterSize = 45;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -535,6 +553,9 @@ namespace Quaver.Shared.Skinning
             HitErrorHeight = ConfigHelper.ReadInt32(HitErrorHeight, ini["HitErrorHeight"]);
             HitErrorChevronSize = ConfigHelper.ReadInt32(HitErrorChevronSize, ini["HitErrorChevronSize"]);
             TimingLineColor = ConfigHelper.ReadColor(TimingLineColor, ini["TimingLineColor"]);
+            JudgementCounterAlpha = ConfigHelper.ReadFloat(JudgementCounterAlpha, ini["JudgementCounterAlpha"]);
+            JudgementCounterFontColor = ConfigHelper.ReadColor(JudgementCounterFontColor, ini["JudgementCounterFontColor"]);
+            JudgementCounterSize = ConfigHelper.ReadInt32(JudgementCounterSize, ini["JudgementCounterSize"]);
         }
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -394,7 +394,7 @@ namespace Quaver.Shared.Skinning
             foreach (Judgement j in Enum.GetValues(typeof(Judgement)))
             {
                 if (j == Judgement.Ghost)
-                    return;
+                    continue;
 
                 var element = $"judge-{j.ToString().ToLower()}";
                Judgements[j] = new List<Texture2D>()


### PR DESCRIPTION
Adds skin config elements for:

* `JudgementCounterAlpha`
* `JudgementCounterFontColor`
* `JudgementCounterSize`

Adds a settings option to completely display the counter.

Fixes the counter skin element not loading in properly

Wiki Usage PR: https://github.com/Quaver/Quaver.Wiki/pull/7
Closes https://github.com/Quaver/Quaver/issues/483