### PR TITLE
Song Time Progress Color Skinning & Toggle Number Display

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -250,6 +250,11 @@ namespace Quaver.Shared.Config
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
 
         /// <summary>
+        ///     If true, it'll display the numbers for the song time progress
+        /// </summary>
+        internal static Bindable<bool> DisplaySongTimeProgressNumbers { get; private set; }
+
+        /// <summary>
         ///     Keybindings for 4K
         /// </summary>
         internal static Bindable<Keys> KeyMania4K1 { get; private set; }
@@ -461,6 +466,7 @@ namespace Quaver.Shared.Config
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);
+            DisplaySongTimeProgressNumbers = ReadValue(@"DisplaySongTimeProgressNumbers", true, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -538,6 +544,7 @@ namespace Quaver.Shared.Config
                     KeyEditorPausePlay.ValueChanged += AutoSaveConfiguration;
                     KeyEditorDecreaseAudioRate.ValueChanged += AutoSaveConfiguration;
                     KeyEditorIncreaseAudioRate.ValueChanged += AutoSaveConfiguration;
+                    DisplaySongTimeProgressNumbers.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -240,8 +240,10 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!ConfigManager.DisplaySongTimeProgress.Value)
                 return;
 
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
             ProgressBar = new SongTimeProgressBar(Screen, new Vector2(WindowManager.Width, 4), 0, Screen.Map.Length / ModHelper.GetRateFromMods(ModManager.Mods), 0,
-                Colors.MainAccentInactive, Colors.MainAccent)
+                skin.SongTimeProgressInactiveColor, skin.SongTimeProgressActiveColor)
             {
                 Parent = Container,
                 Alignment = Alignment.BotLeft

--- a/Quaver.Shared/Screens/Gameplay/UI/SongTimeProgressBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SongTimeProgressBar.cs
@@ -9,6 +9,7 @@ using System;
 using Microsoft.Xna.Framework;
 using Quaver.API.Helpers;
 using Quaver.Shared.Audio;
+using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Modifiers;
 using Wobble.Graphics;
@@ -53,22 +54,25 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         {
             Screen = screen;
 
-            CurrentTime = new NumberDisplay(NumberDisplayType.SongTime, "00:00", new Vector2(0.6f, 0.6f))
+            if (ConfigManager.DisplaySongTimeProgressNumbers.Value)
             {
-                Parent = this,
-                Alignment = Alignment.TopLeft,
-                Y = -Height - 25,
-                X = 10
-            };
+                CurrentTime = new NumberDisplay(NumberDisplayType.SongTime, "00:00", new Vector2(0.6f, 0.6f))
+                {
+                    Parent = this,
+                    Alignment = Alignment.TopLeft,
+                    Y = -Height - 25,
+                    X = 10
+                };
 
-            TimeLeft = new NumberDisplay(NumberDisplayType.SongTime, "-00:00", new Vector2(0.6f, 0.6f))
-            {
-                Parent = this,
-                Alignment = Alignment.TopRight,
-                Y = CurrentTime.Y
-            };
+                TimeLeft = new NumberDisplay(NumberDisplayType.SongTime, "-00:00", new Vector2(0.6f, 0.6f))
+                {
+                    Parent = this,
+                    Alignment = Alignment.TopRight,
+                    Y = CurrentTime.Y
+                };
 
-            TimeLeft.X = -TimeLeft.TotalWidth - 10;
+                TimeLeft.X = -TimeLeft.TotalWidth - 10;
+            }
         }
 
         /// <inheritdoc />
@@ -89,26 +93,29 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             TimeLastProgressChange = Screen.Timing.Time;
 
             // Set the time of the current time
-            if (Bindable.Value > 0)
+            if (ConfigManager.DisplaySongTimeProgressNumbers.Value)
             {
-                var currTime = new DateTime(1970, 1, 1) + TimeSpan.FromMilliseconds((int) Bindable.Value);
-                CurrentTime.Value = currTime.ToString("mm:ss");
-            }
+                if (Bindable.Value > 0)
+                {
+                    var currTime = new DateTime(1970, 1, 1) + TimeSpan.FromMilliseconds((int) Bindable.Value);
+                    CurrentTime.Value = currTime.ToString("mm:ss");
+                }
 
-            // Set the time of the time left.
-            if (Bindable.MaxValue - Bindable.Value >= 0)
-            {
-                var timeLeft = new DateTime(1970, 1, 1) + TimeSpan.FromMilliseconds((int)Bindable.MaxValue - Bindable.Value);
+                // Set the time of the time left.
+                if (Bindable.MaxValue - Bindable.Value >= 0)
+                {
+                    var timeLeft = new DateTime(1970, 1, 1) + TimeSpan.FromMilliseconds((int)Bindable.MaxValue - Bindable.Value);
 
-                // Get the old value.
-                var oldValue = TimeLeft.Value;
+                    // Get the old value.
+                    var oldValue = TimeLeft.Value;
 
-                // Set the new value.
-                TimeLeft.Value = "-" + timeLeft.ToString("mm:ss");
+                    // Set the new value.
+                    TimeLeft.Value = "-" + timeLeft.ToString("mm:ss");
 
-                // Check if we need to reposition it since it's on the right side of the screen.
-                if (oldValue.Length != TimeLeft.Value.Length)
-                    TimeLeft.X = -TimeLeft.TotalWidth - 10;
+                    // Check if we need to reposition it since it's on the right side of the screen.
+                    if (oldValue.Length != TimeLeft.Value.Length)
+                        TimeLeft.X = -TimeLeft.TotalWidth - 10;
+                }
             }
 
             base.Update(gameTime);

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -321,6 +321,7 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsBool(this, "Enable Hitsounds", ConfigManager.EnableHitsounds),
                     new SettingsBool(this, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                     new SettingsBool(this, "Display Song Time Progress", ConfigManager.DisplaySongTimeProgress),
+                    new SettingsBool(this, "Display Song Time Progress Numbers", ConfigManager.DisplaySongTimeProgressNumbers),
                     new SettingsBool(this, "Animate Judgement Counter", ConfigManager.AnimateJudgementCounter),
                     new SettingsBool(this, "Display Scoreboard", ConfigManager.ScoreboardVisible),
                     new SettingsBool(this, "Tap to Pause", ConfigManager.TapToPause)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -119,7 +119,11 @@ namespace Quaver.Shared.Skinning
 
         internal Color TimingLineColor { get; private set; }
 
-#endregion
+        internal Color SongTimeProgressInactiveColor { get; private set; }
+
+        internal Color SongTimeProgressActiveColor { get; private set; }
+
+        #endregion
 
 #region TEXTURES
 
@@ -320,6 +324,8 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    SongTimeProgressInactiveColor = new Color(136, 136, 136);
+                    SongTimeProgressActiveColor = Color.Red;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -365,6 +371,8 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    SongTimeProgressInactiveColor = new Color(136, 136, 136);
+                    SongTimeProgressActiveColor = Color.Red;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -425,6 +433,8 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    SongTimeProgressInactiveColor = new Color(136, 136, 136);
+                    SongTimeProgressActiveColor = Color.Red;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -474,6 +484,8 @@ namespace Quaver.Shared.Skinning
                     HitErrorHeight = 10;
                     HitErrorChevronSize = 8;
                     TimingLineColor = Color.White;
+                    SongTimeProgressInactiveColor = new Color(136, 136, 136);
+                    SongTimeProgressActiveColor = Color.Red;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -535,6 +547,8 @@ namespace Quaver.Shared.Skinning
             HitErrorHeight = ConfigHelper.ReadInt32(HitErrorHeight, ini["HitErrorHeight"]);
             HitErrorChevronSize = ConfigHelper.ReadInt32(HitErrorChevronSize, ini["HitErrorChevronSize"]);
             TimingLineColor = ConfigHelper.ReadColor(TimingLineColor, ini["TimingLineColor"]);
+            SongTimeProgressInactiveColor = ConfigHelper.ReadColor(SongTimeProgressInactiveColor, ini["SongTimeProgressInactiveColor"]);
+            SongTimeProgressActiveColor = ConfigHelper.ReadColor(SongTimeProgressActiveColor, ini["SongTimeProgressActiveColor"]);
         }
 
         /// <summary>


### PR DESCRIPTION
* Adds the ability to change the song time progress bar inactive & active colors
* Adds the ability to toggle the display of the song time progress numbers

Wiki Usage PR: https://github.com/Quaver/Quaver.Wiki/pull/8