### PR TITLE
Implement Song Select Navigation Keybinds

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -266,6 +266,36 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> SkipResultsScreenAfterQuit { get; private set; }
 
         /// <summary>
+        ///     Keybinding for leftward navigation.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateLeft { get; private set; }
+
+        /// <summary>
+        ///     Keybinding for rightward navigation.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateRight { get; private set; }
+
+        /// <summary>
+        ///     Keybinding for upward navigation.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateUp { get; private set; }
+
+        /// <summary>
+        ///     Keybinding for downward navigation.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateDown { get; private set; }
+
+        /// <summary>
+        ///     Keybinding for backward navigation.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateBack { get; private set; }
+
+        /// <summary>
+        ///     Keybinding for selection in navigation interface.
+        /// </summary>
+        internal static Bindable<Keys> KeyNavigateSelect { get; private set; }
+
+        /// <summary>
         ///     Keybindings for 4K
         /// </summary>
         internal static Bindable<Keys> KeyMania4K1 { get; private set; }
@@ -449,6 +479,12 @@ namespace Quaver.Shared.Config
             DisplayTimingLines = ReadValue(@"DisplayTimingLines", true, data);
             DisplayMenuAudioVisualizer = ReadValue(@"DisplayMenuAudioVisualizer", true, data);
             EnableHitsounds = ReadValue(@"EnableHitsounds", true, data);
+            KeyNavigateLeft = ReadValue(@"KeyNavigateLeft", Keys.Left, data);
+            KeyNavigateRight = ReadValue(@"KeyNavigateRight", Keys.Right, data);
+            KeyNavigateUp = ReadValue(@"KeyNavigateUp", Keys.Up, data);
+            KeyNavigateDown = ReadValue(@"KeyNavigateDown", Keys.Down, data);
+            KeyNavigateBack = ReadValue(@"KeyNavigateBack", Keys.Back, data);
+            KeyNavigateSelect = ReadValue(@"KeyNavigateSelect", Keys.Select, data);
             KeyMania4K1 = ReadValue(@"KeyMania4K1", Keys.A, data);
             KeyMania4K2 = ReadValue(@"KeyMania4K2", Keys.S, data);
             KeyMania4K3 = ReadValue(@"KeyMania4K3", Keys.K, data);
@@ -525,6 +561,14 @@ namespace Quaver.Shared.Config
                     DisplayTimingLines.ValueChanged += AutoSaveConfiguration;
                     DisplayMenuAudioVisualizer.ValueChanged += AutoSaveConfiguration;
                     EnableHitsounds.ValueChanged += AutoSaveConfiguration;
+
+
+                    KeyNavigateLeft.ValueChanged += AutoSaveConfiguration;
+                    KeyNavigateRight.ValueChanged += AutoSaveConfiguration;
+                    KeyNavigateUp.ValueChanged += AutoSaveConfiguration;
+                    KeyNavigateDown.ValueChanged += AutoSaveConfiguration;
+                    KeyNavigateBack.ValueChanged += AutoSaveConfiguration;
+                    KeyNavigateSelect.ValueChanged += AutoSaveConfiguration;
                     KeyMania4K1.ValueChanged += AutoSaveConfiguration;
                     KeyMania4K2.ValueChanged += AutoSaveConfiguration;
                     KeyMania4K3.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -484,7 +484,7 @@ namespace Quaver.Shared.Config
             KeyNavigateUp = ReadValue(@"KeyNavigateUp", Keys.Up, data);
             KeyNavigateDown = ReadValue(@"KeyNavigateDown", Keys.Down, data);
             KeyNavigateBack = ReadValue(@"KeyNavigateBack", Keys.Back, data);
-            KeyNavigateSelect = ReadValue(@"KeyNavigateSelect", Keys.Select, data);
+            KeyNavigateSelect = ReadValue(@"KeyNavigateSelect", Keys.Escape, data);
             KeyMania4K1 = ReadValue(@"KeyMania4K1", Keys.A, data);
             KeyMania4K2 = ReadValue(@"KeyMania4K2", Keys.S, data);
             KeyMania4K3 = ReadValue(@"KeyMania4K3", Keys.K, data);

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -195,7 +195,7 @@ namespace Quaver.Shared.Screens.Select
         {
             var view = View as SelectScreenView;
 
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.Escape))
+            if (!KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyNavigateBack.Value))
                 return;
 
             switch (view.ActiveContainer)
@@ -218,7 +218,7 @@ namespace Quaver.Shared.Screens.Select
         {
             var view = View as SelectScreenView;
 
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.Enter) || AvailableMapsets.Count == 0)
+            if (!KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyNavigateSelect.Value) || AvailableMapsets.Count == 0)
                 return;
 
             switch (view.ActiveContainer)
@@ -246,7 +246,7 @@ namespace Quaver.Shared.Screens.Select
                 KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
                 return;
 
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.Right))
+            if (!KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyNavigateRight.Value))
                 return;
 
             switch (view.ActiveContainer)
@@ -274,7 +274,7 @@ namespace Quaver.Shared.Screens.Select
                 KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
                 return;
 
-            if (!KeyboardManager.IsUniqueKeyPress(Keys.Left))
+            if (!KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyNavigateLeft.Value))
                 return;
 
             switch (view.ActiveContainer)


### PR DESCRIPTION
Requires merge from #556 first.

Preface that the search bar does not ignore key-binded values. It might be worth to note that the search bar should not be handling key-binded values in the future.