### PR TITLE
Add DrawLongNoteEnd + a couple of fixes of positioning of stuff

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -290,15 +290,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             if (!Info.IsLongNote)
                 return;
 
-            // It will ignore the rest of the code after this statement if long note size is less than 0
-            // LNs of zero size can happen on SV maps (the size is too small and rounds to zero)
-            if (CurrentLongNoteSize < 0)
-            {
+            // Don't draw the body if the length is <= 0. Note that this does not mean that the LN should be hidden
+            // altogether: very short LNs, including zero-size on some SV maps after SV adjustment, have this below zero
+            // because CurrentLongNoteSize does not include half of the HitObjectSprite and half of the
+            // LongNoteEndSprite.
+            if (CurrentLongNoteSize <= 0)
                 LongNoteBodySprite.Visible = false;
-                LongNoteEndSprite.Visible = false;
-                HitObjectSprite.Visible = false;
-                return;
-            }
 
             //Update HoldBody Position and Size
             LongNoteBodySprite.Height = CurrentLongNoteSize;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -208,7 +208,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 LongNoteBodySprite.Tint = Color.White;
                 LongNoteEndSprite.Tint = Color.White;
-                LongNoteEndSprite.Visible = true;
+                LongNoteEndSprite.Visible = SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd;
                 LongNoteBodySprite.Visible = true;
                 InitialLongNoteTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 UpdateLongNoteSize(InitialTrackPosition);
@@ -246,7 +246,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public void ForceUpdateLongnote(long offset)
         {
-            if (offset < InitialTrackPosition)
+            // When LN end is not drawn, the LNs don't change their size as they are held.
+            if (offset < InitialTrackPosition || !SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
             {
                 UpdateLongNoteSize(InitialTrackPosition);
                 InitialLongNoteSize = CurrentLongNoteSize;
@@ -261,7 +262,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public void UpdateSpritePositions(long offset)
         {
             // Update Sprite position with regards to LN's state
-            if (CurrentlyBeingHeld)
+            //
+            // If the LN end is not drawn, don't move the LN start up with time since it ends up sliding above the LN in
+            // the end.
+            if (CurrentlyBeingHeld && SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
             {
                 if (offset > InitialTrackPosition)
                 {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -66,11 +66,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
         /// <summary>
         ///      The offset of the long note body from the hit object.
+        ///
+        ///      LN bodies are drawn from the middle of the start object to the middle of the end object. This is the
+        ///      half-size of the start object.
         /// </summary>
         private float LongNoteBodyOffset { get; set; }
 
         /// <summary>
         ///     The offset of the hold end from hold body.
+        ///
+        ///     LN bodies are drawn from the middle of the start object to the middle of the end object. This is the
+        ///     half-size of the end object.
         /// </summary>
         private float LongNoteEndOffset { get; set; }
 
@@ -100,7 +106,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         private float HitPosition { get; set; }
 
         /// <summary>
-        ///     Size Difference between HitObject and HoldHitOBject
+        ///     Difference between the actual LN length and the LN body sprite length.
+        ///
+        ///     LN bodies are drawn from the middle of the start object to the middle of the end object, and this
+        ///     difference takes those two half-heights into account.
         /// </summary>
         private float LongNoteSizeDifference { get; }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -301,13 +301,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             if (ScrollDirection.Equals(ScrollDirection.Down))
             {
-                LongNoteBodySprite.Y = +LongNoteBodyOffset + SpritePosition - CurrentLongNoteSize;
-                LongNoteEndSprite.Y = SpritePosition - CurrentLongNoteSize - LongNoteEndOffset + LongNoteBodyOffset;
+                LongNoteBodySprite.Y = SpritePosition + LongNoteBodyOffset - CurrentLongNoteSize;
+                LongNoteEndSprite.Y = SpritePosition + LongNoteBodyOffset - CurrentLongNoteSize - LongNoteEndOffset;
             }
             else
             {
                 LongNoteBodySprite.Y = SpritePosition + LongNoteBodyOffset;
-                LongNoteEndSprite.Y = SpritePosition + CurrentLongNoteSize - LongNoteEndOffset + LongNoteBodyOffset;
+                LongNoteEndSprite.Y = SpritePosition + LongNoteBodyOffset + CurrentLongNoteSize - LongNoteEndOffset;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -451,6 +451,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     hitObject.ForceUpdateLongnote(CurrentTrackPosition);
                 foreach (var hitObject in DeadNoteLanes[i])
                     hitObject.ForceUpdateLongnote(CurrentTrackPosition);
+                foreach (var hitObject in HeldLongNoteLanes[i])
+                    hitObject.ForceUpdateLongnote(CurrentTrackPosition);
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -203,8 +203,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             {
                 var hitObOffset = LaneSize * skin.NoteHitObjects[i][0].Height / skin.NoteHitObjects[i][0].Width;
                 var holdHitObOffset = LaneSize * skin.NoteHoldHitObjects[i][0].Height / skin.NoteHoldHitObjects[i][0].Width;
+                var holdEndOffset = LaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
                 var receptorOffset = LaneSize * skin.NoteReceptorsUp[i].Height / skin.NoteReceptorsUp[i].Width;
-                LongNoteSizeAdjustment[i] = (holdHitObOffset - hitObOffset) / 2;
+
+                if (SkinManager.Skin.Keys[Screen.Map.Mode].DrawLongNoteEnd)
+                    LongNoteSizeAdjustment[i] = (holdHitObOffset - holdEndOffset) / 2;
+                else
+                    LongNoteSizeAdjustment[i] = holdHitObOffset / 2;
 
                 switch (ScrollDirections[i])
                 {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -217,8 +217,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                         break;
                     case ScrollDirection.Up:
                         ReceptorPositionY[i] = skin.ReceptorPosOffsetY;
-                        HitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + hitObOffset;
-                        HoldHitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + holdHitObOffset;
+                        HitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + receptorOffset;
+                        HoldHitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + receptorOffset;
                         ColumnLightingPositionY[i] = ReceptorPositionY[i] + receptorOffset + skin.HitLightingY;
                         TimingLinePositionY[i] = HitPositionY[i];
                         break;

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -129,6 +129,8 @@ namespace Quaver.Shared.Skinning
 
         internal int JudgementCounterSize { get; private set; }
 
+        internal bool DrawLongNoteEnd { get; private set; }
+
         #endregion
 
 #region TEXTURES
@@ -347,6 +349,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
+                    DrawLongNoteEnd = false;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -397,6 +400,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
+                    DrawLongNoteEnd = true;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -462,6 +466,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
+                    DrawLongNoteEnd = false;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -516,6 +521,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
+                    DrawLongNoteEnd = true;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -582,6 +588,7 @@ namespace Quaver.Shared.Skinning
             JudgementCounterAlpha = ConfigHelper.ReadFloat(JudgementCounterAlpha, ini["JudgementCounterAlpha"]);
             JudgementCounterFontColor = ConfigHelper.ReadColor(JudgementCounterFontColor, ini["JudgementCounterFontColor"]);
             JudgementCounterSize = ConfigHelper.ReadInt32(JudgementCounterSize, ini["JudgementCounterSize"]);
+            DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);
         }
 
         /// <summary>


### PR DESCRIPTION
seems to work.png

I didn't change the editor cuz it's all probably rewritten anyway.

This removes the need for the black LN end hack in the default bar skin, but it's probably best to keep the images since it's used as the fallback skin. Switching it on also makes it so the LN start isn't "dragged" at the hit position when the LN is held (this dragging only makes sense when the LN end is present as otherwise the LN start ends up moving above the LN end).