### PR TITLE
Use new Qua when test playing in the editor

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -224,11 +224,11 @@ namespace Quaver.Shared.Screens.Gameplay
         {
             TimePlayed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            var testingQua = ObjectHelper.DeepClone(map);
-            testingQua.HitObjects.RemoveAll(x => x.StartTime < playTestTime);
-
             if (isPlayTesting)
             {
+                var testingQua = ObjectHelper.DeepClone(map);
+                testingQua.HitObjects.RemoveAll(x => x.StartTime < playTestTime);
+
                 Map = testingQua;
                 OriginalEditorMap = map;
             }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -73,6 +73,13 @@ namespace Quaver.Shared.Screens.Gameplay
         public Qua Map { get; }
 
         /// <summary>
+        ///     If test playing, a new .qua is made with only objects from that section of the map
+        ///     It is set to <see cref="Map"/>. This keeps the original map, so we can use it
+        ///     to go back to the editor after testing.
+        /// </summary>
+        public Qua OriginalEditorMap { get; }
+
+        /// <summary>
         ///     The list of scores displayed on the leaderboard.
         /// </summary>
         public List<Score> LocalScores { get; }
@@ -212,11 +219,22 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="scores"></param>
         /// <param name="replay"></param>
         /// <param name="isPlayTesting"></param>
+        /// <param name="playTestTime"></param>
         public GameplayScreen(Qua map, string md5, List<Score> scores, Replay replay = null, bool isPlayTesting = false, double playTestTime = 0)
         {
             TimePlayed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            Map = map;
+            var testingQua = ObjectHelper.DeepClone(map);
+            testingQua.HitObjects.RemoveAll(x => x.StartTime < playTestTime);
+
+            if (isPlayTesting)
+            {
+                Map = testingQua;
+                OriginalEditorMap = map;
+            }
+            else
+                Map = map;
+
             LocalScores = scores;
             MapHash = md5;
             LoadedReplay = replay;
@@ -396,7 +414,7 @@ namespace Quaver.Shared.Screens.Gameplay
                     AudioEngine.Track.Seek(PlayTestAudioTime);
                 }
 
-                Exit(() => new EditorScreen(Map));
+                Exit(() => new EditorScreen(OriginalEditorMap));
             }
 
             if (!IsPaused && (KeyboardManager.CurrentState.IsKeyDown(ConfigManager.KeyPause.Value) || KeyboardManager.CurrentState.IsKeyDown(Keys.Escape)))
@@ -684,7 +702,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             // Use ChangeScreen here to give instant feedback. Can't be threaded
             if (IsPlayTesting)
-                QuaverScreenManager.ChangeScreen(new GameplayScreen(Map, MapHash, LocalScores, null, true, PlayTestAudioTime));
+                QuaverScreenManager.ChangeScreen(new GameplayScreen(OriginalEditorMap, MapHash, LocalScores, null, true, PlayTestAudioTime));
             else if (InReplayMode)
                 QuaverScreenManager.ChangeScreen(new GameplayScreen(Map, MapHash, LocalScores, LoadedReplay));
             else

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -469,7 +469,7 @@ namespace Quaver.Shared.Screens.Gameplay
                         AudioEngine.Track.Seek(Screen.PlayTestAudioTime);
                     }
 
-                    Screen.Exit(() => new EditorScreen(Screen.Map));
+                    Screen.Exit(() => new EditorScreen(Screen.OriginalEditorMap));
                     ResultsScreenLoadInitiated = true;
                     return;
                 }


### PR DESCRIPTION
To isolate scoring to that particular section of the map, so the user doesn't have misses for objects before it.