### PR TITLE
Default DrawLongNoteEnd to true

### DIFF
--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -349,7 +349,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
-                    DrawLongNoteEnd = false;
+                    DrawLongNoteEnd = true;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -466,7 +466,7 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterAlpha = 1;
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
-                    DrawLongNoteEnd = false;
+                    DrawLongNoteEnd = true;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;


### PR DESCRIPTION
For the actual default bar skin it should be set to false but I can't find its `skin.ini`?

Closes #593 