### PR TITLE
Editor Progress Bar automatically play when necessary

### DIFF
--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -135,7 +135,6 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 catch (OperationCanceledException e)
                 {
                     // ignored
-                    Console.WriteLine(e);
                 }
                 catch (Exception e)
                 {

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -120,16 +120,13 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 Map = map;
                 var token = Source.Token;
 
-                token.ThrowIfCancellationRequested();
-
                 try
                 {
                     var path = MapManager.GetBackgroundPath(map);
-
                     var tex = File.Exists(path) ? AssetLoader.LoadTexture2DFromFile(path) : UserInterface.MenuBackground;
-                    RawTexture = tex;
 
                     token.ThrowIfCancellationRequested();
+                    RawTexture = tex;
 
                     await Task.Delay(100, token);
                     ShouldBlur = true;

--- a/Quaver.Shared/Screens/Editor/UI/EditorControlBar.cs
+++ b/Quaver.Shared/Screens/Editor/UI/EditorControlBar.cs
@@ -82,6 +82,11 @@ namespace Quaver.Shared.Screens.Editor.UI
         private bool DraggingInLastFrame { get; set; }
 
         /// <summary>
+        ///     Determines if the audio has been previously paused before dragging the progress bar.
+        /// </summary>
+        private bool PreviouslyPlaying { get; set; }
+
+        /// <summary>
         /// </summary>
         private Sprite ProgressBall { get; set; }
 
@@ -316,6 +321,8 @@ namespace Quaver.Shared.Screens.Editor.UI
 
                 if ((int) targetPos != (int) AudioEngine.Track.Time && targetPos >= 0 && targetPos <= AudioEngine.Track.Length)
                 {
+                    PreviouslyPlaying = AudioEngine.Track.IsPlaying;
+
                     if (AudioEngine.Track.IsPlaying)
                         AudioEngine.Track.Pause();
 
@@ -332,7 +339,7 @@ namespace Quaver.Shared.Screens.Editor.UI
             }
             else if (DraggingInLastFrame)
             {
-                if (AudioEngine.Track.IsPaused || (AudioEngine.Track.IsStopped && !AudioEngine.Track.HasPlayed))
+                if (PreviouslyPlaying && (AudioEngine.Track.IsPaused || (AudioEngine.Track.IsStopped && !AudioEngine.Track.HasPlayed)))
                     AudioEngine.Track.Play();
 
                 DraggingInLastFrame = false;


### PR DESCRIPTION
When the player drags on the progress bar, the audio will only play if it was in a playing state before dragging. Otherwise it will remain paused.

It works exacrly like how youtube handles it.

issue https://github.com/Quaver/Quaver/issues/636