### PR TITLE
LN percentage

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Quaver.API.Enums;
 using Quaver.API.Maps;
@@ -157,6 +158,16 @@ namespace Quaver.Shared.Database.Maps
         /// </summary>
         public DateTime DateAdded { get; set; }
 
+        /// <summary>
+        ///     The count of regular notes.
+        /// </summary>
+        public int RegularNoteCount { get; set; }
+
+        /// <summary>
+        ///     The count of long notes.
+        /// </summary>
+        public int LongNoteCount { get; set; }
+
 #region DIFFICULTY_RATINGS
         public double Difficulty05X { get; set; }
         public double Difficulty055X { get; set; }
@@ -253,6 +264,8 @@ namespace Quaver.Shared.Database.Maps
                 Tags = qua.Tags,
                 SongLength =  qua.Length,
                 Mode = qua.Mode,
+                RegularNoteCount = qua.HitObjects.Count(x => !x.IsLongNote),
+                LongNoteCount = qua.HitObjects.Count(x => x.IsLongNote),
             };
 
             try

--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -168,6 +168,18 @@ namespace Quaver.Shared.Database.Maps
         /// </summary>
         public int LongNoteCount { get; set; }
 
+        /// <summary>
+        ///     The percentage of long notes among the map's hit objects.
+        /// </summary>
+        public float LNPercentage
+        {
+            get
+            {
+                var hitObjectCount = RegularNoteCount + LongNoteCount;
+                return hitObjectCount == 0 ? 0 : ((float) LongNoteCount / hitObjectCount * 100);
+            }
+        }
+
 #region DIFFICULTY_RATINGS
         public double Difficulty05X { get; set; }
         public double Difficulty055X { get; set; }

--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -276,6 +276,8 @@ namespace Quaver.Shared.Database.Maps
                         SongLength = map.TotalTime,
                         Game = MapGame.Osu,
                         BackgroundPath = "",
+                        RegularNoteCount = map.CountHitCircles,
+                        LongNoteCount = map.CountSliders,
                     };
 
                     // Get the BPM of the osu! maps

--- a/Quaver.Shared/Database/Maps/MapsetHelper.cs
+++ b/Quaver.Shared/Database/Maps/MapsetHelper.cs
@@ -172,6 +172,7 @@ namespace Quaver.Shared.Database.Maps
                 { SearchFilterOption.Length,     ("l", "length") },
                 { SearchFilterOption.Keys,       ("k", "keys") },
                 { SearchFilterOption.Status,     ("s", "status") },
+                { SearchFilterOption.LNs,        ("ln", "lns") },
             };
 
             // Stores a dictionary of the found pairs in the search query
@@ -293,6 +294,31 @@ namespace Quaver.Shared.Database.Maps
                                     default:
                                         throw new ArgumentOutOfRangeException();
                                 }
+                                break;
+                            case SearchFilterOption.LNs:
+                                var valueToCompareTo = 0;
+                                var stringToParse = "";
+
+                                if (searchQuery.Value.Last() == '%')
+                                {
+                                    stringToParse = searchQuery.Value.Substring(0, searchQuery.Value.Length - 1);
+                                    valueToCompareTo = (int) map.LNPercentage;
+                                }
+                                else
+                                {
+                                    stringToParse = searchQuery.Value;
+                                    valueToCompareTo = map.LongNoteCount;
+                                }
+
+                                if (!int.TryParse(stringToParse, out var value))
+                                {
+                                    exitLoop = true;
+                                    break;
+                                }
+
+                                if (!CompareValues(valueToCompareTo, value, searchQuery.Operator))
+                                    exitLoop = true;
+
                                 break;
                             default:
                                 break;
@@ -431,5 +457,10 @@ namespace Quaver.Shared.Database.Maps
         ///     Status (ranked, not submitted, etc.)
         /// </summary>
         Status,
+
+        /// <summary>
+        ///     LN count or percentage.
+        /// </summary>
+        LNs,
     }
 }

--- a/Quaver.Shared/Screens/Select/UI/Banner/BannerMetadata.cs
+++ b/Quaver.Shared/Screens/Select/UI/Banner/BannerMetadata.cs
@@ -52,6 +52,11 @@ namespace Quaver.Shared.Screens.Select.UI.Banner
         /// </summary>
         private BannerMetadataItem Difficulty { get; }
 
+        /// <summary>
+        ///     The percentage of long notes among the map's hit objects.
+        /// </summary>
+        private BannerMetadataItem LNPercentage { get; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -70,13 +75,15 @@ namespace Quaver.Shared.Screens.Select.UI.Banner
             Bpm = new BannerMetadataItem(Fonts.Exo2SemiBold, 13, "BPM", "240") { Parent = this, Alignment = Alignment.MidLeft };
             Length = new BannerMetadataItem(Fonts.Exo2SemiBold, 13, "Length", "0:00") { Parent = this, Alignment = Alignment.MidLeft };
             Difficulty = new BannerMetadataItem(Fonts.Exo2SemiBold, 13, "Difficulty", "13.22") { Parent = this, Alignment = Alignment.MidLeft };
+            LNPercentage = new BannerMetadataItem(Fonts.Exo2SemiBold, 13, "LNs", "10%") { Parent = this, Alignment = Alignment.MidLeft };
 
             Items = new List<BannerMetadataItem>
             {
                 Mode,
                 Bpm,
                 Length,
-                Difficulty
+                Difficulty,
+                LNPercentage
             };
 
             ModManager.ModsChanged += OnModsChanged;
@@ -104,6 +111,7 @@ namespace Quaver.Shared.Screens.Select.UI.Banner
             Bpm.UpdateValue(((int)(map.Bpm * ModHelper.GetRateFromMods(ModManager.Mods))).ToString(CultureInfo.InvariantCulture));
             Length.UpdateValue(length.Hours > 0 ? length.ToString(@"hh\:mm\:ss") : length.ToString(@"mm\:ss"));
             Difficulty.UpdateValue(StringHelper.AccuracyToString((float) map.DifficultyFromMods(ModManager.Mods)).Replace("%", ""));
+            LNPercentage.UpdateValue(((int) map.LNPercentage).ToString(CultureInfo.InvariantCulture) + "%");
 
             for (var i = 0; i < Items.Count; i++)
             {


### PR DESCRIPTION
- Added regular object and LN count into the map database;
- Added the LN percentage to the map banner (so you can tell if it's an LN map or not);
- Added an `ln` or `lns` search key: `ln>50` filters by raw LN count (more than 50 LNs in the map) while `ln>50%` filters by LN percentage (more than 50% of the objects are LNs).

![image](https://user-images.githubusercontent.com/1794388/53791237-f9e91a80-3f39-11e9-8c11-c54e734b033b.png)