### PR TITLE
Gradually increase number displays + Skinnable Sizes

### DIFF
--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Helpers;
 using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Graphics;
@@ -20,17 +22,10 @@ namespace Quaver.Shared.Graphics
     public class NumberDisplay : Sprite
     {
         /// <summary>
-        ///     The number value for this display in string format.
-        ///     If the value isn't a valid number or percentage.
-        ///
-        ///     Sample Inputs:
-        ///         - 123
-        ///         - 1000000
-        ///         - 40.23
-        ///         - 99.12%
+        ///     The value of the number display
         /// </summary>
         private string _value;
-        internal string Value
+        public string Value
         {
             get => _value;
             set
@@ -50,6 +45,15 @@ namespace Quaver.Shared.Graphics
                     InitializeDigits();
             }
         }
+
+        /// <summary>
+        /// </summary>
+        public double TargetValue { get; private set; }
+
+        /// <summary>
+        ///     The value that is currently displayed
+        /// </summary>
+        public double CurrentValue { get; private set; }
 
         /// <summary>
         ///     The type of number display this is.
@@ -99,6 +103,14 @@ namespace Quaver.Shared.Graphics
         /// </summary>
         private Vector2 ImageScale { get; }
 
+        /// <summary>
+        ///     The initial position of the display, used to place it in the same position when
+        ///     the length of the numbers change
+        /// </summary>
+        private float InitialPosition { get; }
+
+        private double TimeSinceLastScoreUpdate { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         ///     Ctor -
@@ -106,10 +118,13 @@ namespace Quaver.Shared.Graphics
         /// <param name="type"></param>
         /// <param name="startingValue"></param>
         /// <param name="imageScale"></param>
-        internal NumberDisplay(NumberDisplayType type, string startingValue, Vector2 imageScale)
+        /// <param name="position"></param>
+        internal NumberDisplay(NumberDisplayType type, string startingValue, Vector2 imageScale, float position)
         {
             ImageScale = imageScale;
             Value = startingValue;
+            InitialPosition = position;
+            CurrentValue = 0;
             Type = type;
 
             // First validate the initial value to see if everything is correct.
@@ -118,6 +133,80 @@ namespace Quaver.Shared.Graphics
             // Create and initialize the digits.
             Digits = new List<Sprite>();
             InitializeDigits();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (CurrentValue != TargetValue)
+            {
+                switch (Type)
+                {
+                    case NumberDisplayType.Score:
+                        CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
+                            (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
+                        break;
+                    case NumberDisplayType.Accuracy:
+                        CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
+                            (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
+                        break;
+                    case NumberDisplayType.Combo:
+                        CurrentValue = TargetValue;
+                        break;
+                    case NumberDisplayType.SongTime:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                switch (Type)
+                {
+                    case NumberDisplayType.Score:
+                        Value = StringHelper.ScoreToString((int) Math.Ceiling(CurrentValue));
+                        break;
+                    case NumberDisplayType.Combo:
+                        Value = ((int) Math.Ceiling(CurrentValue)).ToString();
+                        break;
+                    case NumberDisplayType.Accuracy:
+                        Value = StringHelper.AccuracyToString((float) CurrentValue);
+                        break;
+                    case NumberDisplayType.SongTime:
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            SetXPosition();
+            base.Update(gameTime);
+        }
+
+        private void SetXPosition()
+        {
+            switch (Alignment)
+            {
+                case Alignment.TopLeft:
+                case Alignment.MidLeft:
+                case Alignment.BotLeft:
+                    X = InitialPosition;
+                    break;
+                case Alignment.TopCenter:
+                case Alignment.MidCenter:
+                case Alignment.BotCenter:
+                    X = -TotalWidth / 2f;
+                    break;
+                case Alignment.TopRight:
+                case Alignment.MidRight:
+                case Alignment.BotRight:
+                    X = -TotalWidth + InitialPosition;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
 
         /// <summary>
@@ -210,6 +299,12 @@ namespace Quaver.Shared.Graphics
             for (var i = Value.Length; i < Digits.Count; i++)
                 Digits[i].Visible = false;
         }
+
+        /// <summary>
+        ///     Updates the value of the number idsplay
+        /// </summary>
+        /// <param name="num"></param>
+        public void UpdateValue(double num) => TargetValue = num;
 
         /// <summary>
         ///     Converts a single character into a texture.

--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -144,11 +144,8 @@ namespace Quaver.Shared.Graphics
             {
                 switch (Type)
                 {
-                    case NumberDisplayType.Score:
-                        CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
-                            (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
-                        break;
                     case NumberDisplayType.Accuracy:
+                    case NumberDisplayType.Score:
                         CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
                             (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
                         break;

--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -96,7 +96,7 @@ namespace Quaver.Shared.Graphics
         ///     The last time the value was changed
         ///     (Used for timing animations for example).
         /// </summary>
-        internal long LastValueChangeTime { get; private set; }
+        private long LastValueChangeTime { get; set; }
 
         /// <summary>
         ///     The size of the digits.
@@ -108,8 +108,6 @@ namespace Quaver.Shared.Graphics
         ///     the length of the numbers change
         /// </summary>
         private float InitialPosition { get; }
-
-        private double TimeSinceLastScoreUpdate { get; set; }
 
         /// <inheritdoc />
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -261,29 +261,32 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     Creates the score display sprite.
         /// </summary>
-        private void CreateScoreDisplay() => ScoreDisplay = new NumberDisplay(NumberDisplayType.Score, StringHelper.ScoreToString(0),
-                                                                                new Vector2(0.45f, 0.45f))
+        private void CreateScoreDisplay()
         {
-            Parent = Container,
-            Alignment = Alignment.TopLeft,
-            X = SkinManager.Skin.Keys[Screen.Map.Mode].ScoreDisplayPosX,
-            Y = SkinManager.Skin.Keys[Screen.Map.Mode].ScoreDisplayPosY
-        };
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
+            ScoreDisplay = new NumberDisplay(NumberDisplayType.Score, StringHelper.ScoreToString(0),
+                new Vector2(skin.ScoreDisplayScale / 100f, skin.ScoreDisplayScale / 100f), SkinManager.Skin.Keys[Screen.Map.Mode].ScoreDisplayPosX)
+            {
+                Parent = Container,
+                Alignment = Alignment.TopLeft,
+                Y = SkinManager.Skin.Keys[Screen.Map.Mode].ScoreDisplayPosY
+            };
+        }
 
         /// <summary>
         ///     Creates the accuracy display sprite.
         /// </summary>
         private void CreateAccuracyDisplay()
         {
-            AccuracyDisplay = new NumberDisplay(NumberDisplayType.Accuracy, StringHelper.AccuracyToString(0), new Vector2(0.45f, 0.45f))
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
+            AccuracyDisplay = new NumberDisplay(NumberDisplayType.Accuracy, StringHelper.AccuracyToString(0),
+                new Vector2(skin.AccuracyDisplayScale / 100f, skin.AccuracyDisplayScale / 100f), SkinManager.Skin.Keys[Screen.Map.Mode].AccuracyDisplayPosX)
             {
                 Parent = Container,
                 Alignment = Alignment.TopRight,
             };
-
-            // Set the position of the accuracy display.
-            AccuracyDisplay.X = -AccuracyDisplay.TotalWidth + SkinManager.Skin.Keys[Screen.Map.Mode].AccuracyDisplayPosX;
-            AccuracyDisplay.Y = SkinManager.Skin.Keys[Screen.Map.Mode].AccuracyDisplayPosY;
         }
 
         /// <summary>
@@ -292,18 +295,8 @@ namespace Quaver.Shared.Screens.Gameplay
         public void UpdateScoreAndAccuracyDisplays()
         {
             // Update score and accuracy displays
-            ScoreDisplay.Value = StringHelper.ScoreToString(Screen.Ruleset.ScoreProcessor.Score);
-
-            // Grab the old accuracy
-            var oldAcc = AccuracyDisplay.Value;
-
-            // Update the new accuracy.
-            AccuracyDisplay.Value = StringHelper.AccuracyToString(Screen.Ruleset.ScoreProcessor.Accuracy);
-
-            // If the old accuracy's length isn't the same, then we need to reposition the sprite
-            // Example: 100.00% to 99.99% needs repositioning.
-            if (oldAcc.Length != AccuracyDisplay.Value.Length)
-                AccuracyDisplay.X = -AccuracyDisplay.TotalWidth + SkinManager.Skin.Keys[Screen.Map.Mode].AccuracyDisplayPosX;
+            ScoreDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Score);
+            AccuracyDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Accuracy);
         }
 
         /// <summary>
@@ -311,15 +304,16 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         private void CreateKeysPerSecondDisplay()
         {
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
             // Create KPS display
-            KpsDisplay = new KeysPerSecond(NumberDisplayType.Score, "0", new Vector2(0.45f, 0.45f))
+            KpsDisplay = new KeysPerSecond(NumberDisplayType.Score, "0", new Vector2(skin.KpsDisplayScale / 100f, skin.KpsDisplayScale / 100f),
+                SkinManager.Skin.Keys[Screen.Map.Mode].KpsDisplayPosX)
             {
                 Parent = Container,
                 Alignment = Alignment.TopRight
             };
 
-            // Set the position of the KPS display
-            KpsDisplay.X = -KpsDisplay.TotalWidth + SkinManager.Skin.Keys[Screen.Map.Mode].KpsDisplayPosX;
             KpsDisplay.Y = AccuracyDisplay.Y + AccuracyDisplay.Digits[0].Height + SkinManager.Skin.Keys[Screen.Map.Mode].KpsDisplayPosY;
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -373,8 +373,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// </summary>
         private void CreateComboDisplay()
         {
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+
             // Create the combo display.
-            ComboDisplay = new NumberDisplay(NumberDisplayType.Combo, "0", new Vector2(1, 1))
+            ComboDisplay = new NumberDisplay(NumberDisplayType.Combo, "0", new Vector2(skin.ComboDisplayScale / 100f, skin.ComboDisplayScale / 100f), 0)
             {
                 Parent = Playfield.ForegroundContainer,
                 Alignment = Alignment.MidCenter,
@@ -382,7 +384,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             };
 
             OriginalComboDisplayY = ComboDisplay.Y;
-            ComboDisplay.X = -ComboDisplay.TotalWidth / 2f;
 
             // Start off the map by making the display invisible.
             ComboDisplay.MakeInvisible();
@@ -401,7 +402,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 return;
 
             // Set the new one
-            ComboDisplay.Value = Screen.Ruleset.ScoreProcessor.Combo.ToString();
+            ComboDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Combo);
 
             // If the combo needs repositioning, do so accordingly.
             if ((int)Math.Floor(Math.Log10(OldCombo) + 1) != (int)Math.Floor(Math.Log10(Screen.Ruleset.ScoreProcessor.Combo) + 1))

--- a/Quaver.Shared/Screens/Gameplay/UI/KeysPerSecond.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/KeysPerSecond.cs
@@ -30,9 +30,15 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// </summary>
         private double Time { get; set; }
 
-
-        public KeysPerSecond(NumberDisplayType type, string startingValue, Vector2 imageScale)
-            : base(type, startingValue, imageScale)
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="startingValue"></param>
+        /// <param name="imageScale"></param>
+        /// <param name="position"></param>
+        internal KeysPerSecond(NumberDisplayType type, string startingValue, Vector2 imageScale, float position)
+            : base(type, startingValue, imageScale, position)
         {
         }
 

--- a/Quaver.Shared/Screens/Gameplay/UI/SongTimeProgressBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SongTimeProgressBar.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.UI;
 
@@ -54,25 +55,26 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         {
             Screen = screen;
 
+            var skin = SkinManager.Skin.Keys[screen.Map.Mode];
             if (ConfigManager.DisplaySongTimeProgressNumbers.Value)
             {
-                CurrentTime = new NumberDisplay(NumberDisplayType.SongTime, "00:00", new Vector2(0.6f, 0.6f))
+
+                CurrentTime = new NumberDisplay(NumberDisplayType.SongTime, "00:00", new Vector2(skin.SongTimeProgressScale / 100f,
+                    skin.SongTimeProgressScale / 100f), 10)
                 {
                     Parent = this,
                     Alignment = Alignment.TopLeft,
                     Y = -Height - 25,
-                    X = 10
                 };
 
                 var startText = (new DateTime(1970, 1, 1) + TimeSpan.FromMilliseconds((int)Bindable.MaxValue)).ToString("mm:ss");
-                TimeLeft = new NumberDisplay(NumberDisplayType.SongTime, "-" + startText, new Vector2(0.6f, 0.6f))
+                TimeLeft = new NumberDisplay(NumberDisplayType.SongTime, "-" + startText, new Vector2(skin.SongTimeProgressScale / 100f,
+                    skin.SongTimeProgressScale / 100f), -10)
                 {
                     Parent = this,
                     Alignment = Alignment.TopRight,
                     Y = CurrentTime.Y
                 };
-
-                TimeLeft.X = -TimeLeft.TotalWidth - 10;
             }
         }
 

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -93,15 +93,23 @@ namespace Quaver.Shared.Skinning
 
         internal int ScoreDisplayPosY { get; private set; }
 
+        internal int ScoreDisplayScale { get; private set; }
+
         internal int AccuracyDisplayPosX { get; private set; }
 
         internal int AccuracyDisplayPosY { get; private set; }
+
+        internal int AccuracyDisplayScale { get; private set; }
 
         internal int KpsDisplayPosX { get; private set; }
 
         internal int KpsDisplayPosY { get; private set; }
 
+        internal int KpsDisplayScale { get; private set; }
+
         internal int ComboPosY { get; private set; }
+
+        internal int ComboDisplayScale { get; private set; }
 
         internal int JudgementBurstPosY { get; private set; }
 
@@ -122,6 +130,8 @@ namespace Quaver.Shared.Skinning
         internal Color SongTimeProgressInactiveColor { get; private set; }
 
         internal Color SongTimeProgressActiveColor { get; private set; }
+
+        internal int SongTimeProgressScale { get; private set; }
 
         internal float JudgementCounterAlpha { get; private set; }
 
@@ -350,6 +360,11 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
                     DrawLongNoteEnd = true;
+                    ScoreDisplayScale = 45;
+                    AccuracyDisplayScale = 45;
+                    ComboDisplayScale = 100;
+                    KpsDisplayScale = 45;
+                    SongTimeProgressScale = 60;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -401,6 +416,11 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
                     DrawLongNoteEnd = true;
+                    ScoreDisplayScale = 45;
+                    AccuracyDisplayScale = 45;
+                    ComboDisplayScale = 100;
+                    KpsDisplayScale = 45;
+                    SongTimeProgressScale = 60;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -467,6 +487,11 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
                     DrawLongNoteEnd = true;
+                    ScoreDisplayScale = 45;
+                    AccuracyDisplayScale = 45;
+                    ComboDisplayScale = 100;
+                    KpsDisplayScale = 45;
+                    SongTimeProgressScale = 60;
                     break;
                 case DefaultSkins.Arrow:
                     StageReceptorPadding = 10;
@@ -522,6 +547,11 @@ namespace Quaver.Shared.Skinning
                     JudgementCounterFontColor = Color.Black;
                     JudgementCounterSize = 45;
                     DrawLongNoteEnd = true;
+                    ScoreDisplayScale = 45;
+                    AccuracyDisplayScale = 45;
+                    ComboDisplayScale = 100;
+                    KpsDisplayScale = 45;
+                    SongTimeProgressScale = 60;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -589,6 +619,11 @@ namespace Quaver.Shared.Skinning
             JudgementCounterFontColor = ConfigHelper.ReadColor(JudgementCounterFontColor, ini["JudgementCounterFontColor"]);
             JudgementCounterSize = ConfigHelper.ReadInt32(JudgementCounterSize, ini["JudgementCounterSize"]);
             DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);
+            ScoreDisplayScale = ConfigHelper.ReadInt32(ScoreDisplayScale, ini["ScoreDisplayScale"]);
+            AccuracyDisplayScale = ConfigHelper.ReadInt32(AccuracyDisplayScale, ini["AccuracyDisplayScale"]);
+            ComboDisplayScale = ConfigHelper.ReadInt32(ComboDisplayScale, ini["ComboDisplayScale"]);
+            KpsDisplayScale = ConfigHelper.ReadInt32(KpsDisplayScale, ini["KpsDisplayScale"]);
+            SongTimeProgressScale = ConfigHelper.ReadInt32(SongTimeProgressScale, ini["SongTimeProgressScale"]);
         }
 
         /// <summary>


### PR DESCRIPTION
* Makes it so the score/acc displays increase gradually 
* Adds `ScoreDisplayScale`, `AccuracyDisplayScale`, `KpsDisplayScale`, `ComboDisplayScale`, and `SongTimeProgressScale` skin.ini config values to modify their sizes.
* [Wiki PR](https://github.com/Quaver/Quaver.Wiki/pull/18)
* Closes #164 