### PR TITLE
Optional Editor Layering View + Skinnable Layer Objects

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -335,6 +335,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<EditorVisualizationGraphType> EditorVisualizationGraph { get; private set; }
 
         /// <summary>
+        ///     If true, it'll use hitobjects specifically for viewing layers in the editor.
+        /// </summary>
+        internal static Bindable<bool> EditorUseLayerHitObjects { get; private set; }
+
+        /// <summary>
         ///     Keybinding for leftward navigation.
         /// </summary>
         internal static Bindable<Keys> KeyNavigateLeft { get; private set; }
@@ -599,6 +604,7 @@ namespace Quaver.Shared.Config
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
             UIElementsOverLaneCover = ReadValue(@"UIElementsOverLaneCover", true, data);
             EditorVisualizationGraph = ReadValue(@"EditorVisualizationGraph", EditorVisualizationGraphType.Tick, data);
+            EditorUseLayerHitObjects = ReadValue(@"EditorUserLayerHitObjects", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -699,6 +705,7 @@ namespace Quaver.Shared.Config
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
                     UIElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
                     EditorVisualizationGraph.ValueChanged += AutoSaveConfiguration;
+                    EditorUseLayerHitObjects.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -337,7 +337,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     If true, it'll use hitobjects specifically for viewing layers in the editor.
         /// </summary>
-        internal static Bindable<bool> EditorUseLayerHitObjects { get; private set; }
+        internal static Bindable<bool> EditorViewLayers { get; private set; }
 
         /// <summary>
         ///     Keybinding for leftward navigation.
@@ -604,7 +604,7 @@ namespace Quaver.Shared.Config
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
             UIElementsOverLaneCover = ReadValue(@"UIElementsOverLaneCover", true, data);
             EditorVisualizationGraph = ReadValue(@"EditorVisualizationGraph", EditorVisualizationGraphType.Tick, data);
-            EditorUseLayerHitObjects = ReadValue(@"EditorUserLayerHitObjects", false, data);
+            EditorViewLayers = ReadValue(@"EditorViewLayers", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
@@ -650,8 +650,6 @@ namespace Quaver.Shared.Config
                     DisplayTimingLines.ValueChanged += AutoSaveConfiguration;
                     DisplayMenuAudioVisualizer.ValueChanged += AutoSaveConfiguration;
                     EnableHitsounds.ValueChanged += AutoSaveConfiguration;
-
-
                     KeyNavigateLeft.ValueChanged += AutoSaveConfiguration;
                     KeyNavigateRight.ValueChanged += AutoSaveConfiguration;
                     KeyNavigateUp.ValueChanged += AutoSaveConfiguration;
@@ -703,9 +701,9 @@ namespace Quaver.Shared.Config
                     LaneCoverBottomHeight.ValueChanged += AutoSaveConfiguration;
                     LaneCoverTop.ValueChanged += AutoSaveConfiguration;
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
+                    EditorViewLayers.ValueChanged += AutoSaveConfiguration;
                     UIElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
                     EditorVisualizationGraph.ValueChanged += AutoSaveConfiguration;
-                    EditorUseLayerHitObjects.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Screens/Editor/Actions/Rulesets/Keys/EditorActionFlipObjectsHorizontallyKeys.cs
+++ b/Quaver.Shared/Screens/Editor/Actions/Rulesets/Keys/EditorActionFlipObjectsHorizontallyKeys.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Quaver.API.Maps;
+using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling;
 using Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
@@ -57,15 +58,30 @@ namespace Quaver.Shared.Screens.Editor.Actions.Rulesets.Keys
 
                 if (h.Info.IsLongNote)
                 {
-                    h.Image = skin.NoteHoldHitObjects[h.Info.Lane - 1][index];
-
                     var ln = (DrawableEditorHitObjectLong) h;
-                    ln.Body.Image = skin.NoteHoldBodies[h.Info.Lane - 1].First();
-                    ln.Tail.Image = skin.NoteHoldEnds[h.Info.Lane - 1];
+
+                    if (ConfigManager.EditorViewLayers.Value)
+                    {
+                        h.Image = skin.EditorLayerNoteHitObjects[h.Info.Lane - 1];
+                        ln.Body.Image = skin.EditorLayerNoteHoldBodies[h.Info.Lane - 1];
+                        ln.Tail.Image = skin.EditorLayerNoteHoldEnds[h.Info.Lane - 1];
+                    }
+                    else
+                    {
+                        h.Image = skin.NoteHoldHitObjects[h.Info.Lane - 1][index];
+                        ln.Body.Image = skin.NoteHoldBodies[h.Info.Lane - 1].First();
+                        ln.Tail.Image = skin.NoteHoldEnds[h.Info.Lane - 1];
+                    }
+
                     ln.ResizeLongNote();
                 }
                 else
-                    h.Image = skin.NoteHitObjects[h.Info.Lane - 1][index];
+                {
+                    if (ConfigManager.EditorViewLayers.Value)
+                        h.Image = skin.EditorLayerNoteHitObjects[h.Info.Lane - 1];
+                    else
+                        h.Image = skin.NoteHitObjects[h.Info.Lane - 1][index];
+                }
             }
         }
 

--- a/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
+++ b/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
@@ -247,8 +247,8 @@ namespace Quaver.Shared.Screens.Editor.UI
             if (ImGui.MenuItem("Anchor Objects At Midpoint", null, ConfigManager.EditorHitObjectsMidpointAnchored.Value))
                 ConfigManager.EditorHitObjectsMidpointAnchored.Value = !ConfigManager.EditorHitObjectsMidpointAnchored.Value;
 
-            if (ImGui.MenuItem("Use Layer Objects", null, ConfigManager.EditorUseLayerHitObjects.Value))
-                ConfigManager.EditorUseLayerHitObjects.Value = !ConfigManager.EditorUseLayerHitObjects.Value;
+            if (ImGui.MenuItem("View Layers", null, ConfigManager.EditorViewLayers.Value))
+                ConfigManager.EditorViewLayers.Value = !ConfigManager.EditorViewLayers.Value;
 
            ImGui.EndMenu();
         }

--- a/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
+++ b/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
@@ -247,6 +247,9 @@ namespace Quaver.Shared.Screens.Editor.UI
             if (ImGui.MenuItem("Anchor Objects At Midpoint", null, ConfigManager.EditorHitObjectsMidpointAnchored.Value))
                 ConfigManager.EditorHitObjectsMidpointAnchored.Value = !ConfigManager.EditorHitObjectsMidpointAnchored.Value;
 
+            if (ImGui.MenuItem("Use Layer Objects", null, ConfigManager.EditorUseLayerHitObjects.Value))
+                ConfigManager.EditorUseLayerHitObjects.Value = !ConfigManager.EditorUseLayerHitObjects.Value;
+
            ImGui.EndMenu();
         }
 

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/EditorScrollContainerKeys.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/EditorScrollContainerKeys.cs
@@ -13,6 +13,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Enums;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
@@ -139,6 +140,7 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
             ConfigManager.EditorScrollSpeedKeys.ValueChanged += OnScrollSpeedChanged;
             ConfigManager.EditorShowLaneDividerLines.ValueChanged += OnShowDividerLinesChanged;
             ConfigManager.EditorHitObjectsMidpointAnchored.ValueChanged += OnHitObjectMidpointAnchoredChanged;
+            ConfigManager.EditorUseLayerHitObjects.ValueChanged += OnEditorUseLayerHitObjects;
 
             var view = (EditorScreenView) Ruleset.Screen.View;
             view.LayerCompositor.LayerUpdated += OnEditorLayerUpdated;
@@ -202,6 +204,7 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
             ConfigManager.EditorScrollSpeedKeys.ValueChanged -= OnScrollSpeedChanged;
             ConfigManager.EditorShowLaneDividerLines.ValueChanged -= OnShowDividerLinesChanged;
             ConfigManager.EditorHitObjectsMidpointAnchored.ValueChanged -= OnHitObjectMidpointAnchoredChanged;
+            ConfigManager.EditorUseLayerHitObjects.ValueChanged -= OnEditorUseLayerHitObjects;
 
             var view = (EditorScreenView) Ruleset.Screen.View;
             view.LayerCompositor.LayerUpdated -= OnEditorLayerUpdated;
@@ -353,14 +356,27 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
 
             if (h.IsLongNote)
             {
-                hitObject = new DrawableEditorHitObjectLong(this, h,
-                    skin.NoteHoldHitObjects[h.Lane - 1][index],
-                    skin.NoteHoldBodies[h.Lane - 1].First(),
-                    skin.NoteHoldEnds[h.Lane - 1]);
+                if (ConfigManager.EditorUseLayerHitObjects.Value)
+                {
+                    hitObject = new DrawableEditorHitObjectLong(this, h,
+                        UserInterface.BlankBox,
+                        UserInterface.BlankBox,
+                        UserInterface.BlankBox);
+                }
+                else
+                {
+                    hitObject = new DrawableEditorHitObjectLong(this, h,
+                        skin.NoteHoldHitObjects[h.Lane - 1][index],
+                        skin.NoteHoldBodies[h.Lane - 1].First(),
+                        skin.NoteHoldEnds[h.Lane - 1]);
+                }
             }
             else
             {
-                hitObject = new DrawableEditorHitObject(this, h, skin.NoteHitObjects[h.Lane - 1][index]);
+                if (ConfigManager.EditorUseLayerHitObjects.Value)
+                    hitObject = new DrawableEditorHitObject(this, h, UserInterface.BlankBox);
+                else
+                    hitObject = new DrawableEditorHitObject(this, h, skin.NoteHitObjects[h.Lane - 1][index]);
             }
 
             hitObject.Alignment = Alignment.TopLeft;
@@ -523,6 +539,16 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
                         x.AppearAsActive();
                 });
             }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnEditorUseLayerHitObjects(object sender, BindableValueChangedEventArgs<bool> e)
+        {
+            Console.WriteLine("??");
         }
     }
 }

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
@@ -106,7 +106,11 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling.HitObjects
         public virtual void AppearAsActive()
         {
             var view = (EditorScreenView) Container.Ruleset.Screen.View;
-            Tint = ColorHelper.ToXnaColor(view.LayerCompositor.ScrollContainer.AvailableItems[Info.EditorLayer].GetColor());
+
+            if (ConfigManager.EditorViewLayers.Value)
+                Tint = ColorHelper.ToXnaColor(view.LayerCompositor.ScrollContainer.AvailableItems[Info.EditorLayer].GetColor());
+            else
+                Tint = Color.White;
 
             SelectionSprite.Visible = false;
         }

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -211,10 +211,6 @@ namespace Quaver.Shared.Skinning
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteHoldHitObjects { get; } = new List<Texture2D>();
-
-        /// <summary>
-        /// </summary>
         internal List<Texture2D> EditorLayerNoteHoldBodies { get; } = new List<Texture2D>();
 
         /// <summary>
@@ -820,6 +816,11 @@ namespace Quaver.Shared.Skinning
                 // Receptors
                 NoteReceptorsUp.Add(LoadTexture(SkinKeysFolder.Receptors, $"receptor-up-{i + 1}", false));
                 NoteReceptorsDown.Add(LoadTexture(SkinKeysFolder.Receptors, $"receptor-down-{i + 1}", false));
+
+                // Editor
+                EditorLayerNoteHitObjects.Add(LoadTexture(SkinKeysFolder.Editor, $"note-hitobject-{i + 1}", false));
+                EditorLayerNoteHoldBodies.Add(LoadTexture(SkinKeysFolder.Editor, $"note-holdbody-{i + 1}", false));
+                EditorLayerNoteHoldEnds.Add(LoadTexture(SkinKeysFolder.Editor, $"note-holdend-{i + 1}", false));
             }
         }
     }

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -205,6 +205,22 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         internal List<Texture2D> NoteHoldEnds { get; } = new List<Texture2D>();
 
+        /// <summary>
+        /// </summary>
+        internal List<Texture2D> EditorLayerNoteHitObjects { get; } = new List<Texture2D>();
+
+        /// <summary>
+        /// </summary>
+        internal List<Texture2D> EditorLayerNoteHoldHitObjects { get; } = new List<Texture2D>();
+
+        /// <summary>
+        /// </summary>
+        internal List<Texture2D> EditorLayerNoteHoldBodies { get; } = new List<Texture2D>();
+
+        /// <summary>
+        /// </summary>
+        internal List<Texture2D> EditorLayerNoteHoldEnds { get; } = new List<Texture2D>();
+
         // ----- Receptors ----- //
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinKeysFolder.cs
+++ b/Quaver.Shared/Skinning/SkinKeysFolder.cs
@@ -13,6 +13,7 @@ namespace Quaver.Shared.Skinning
         HitObjects,
         Receptors,
         Lighting,
-        LaneCover
+        LaneCover,
+        Editor
     }
 }


### PR DESCRIPTION
Previously, layer coloring was forced on users which could look bad when tinting if their skin doesn't have white colored notes. 

This makes viewing layers completely optional and allows the layered objects to be skinned.

* [Wiki PR](https://github.com/Quaver/Quaver.Wiki/pull/19)