### PR TITLE
Add a setting for smooth accuracy change

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -271,6 +271,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> DisplayComboAlerts { get; private set; }
 
         /// <summary>
+        ///     If enabled, accuracy display is smoothed.
+        /// </summary>
+        internal static Bindable<bool> SmoothAccuracyChanges { get; private set; }
+
+        /// <summary>
         ///     The scroll speed used in the editor.
         /// </summary>
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
@@ -613,6 +618,7 @@ namespace Quaver.Shared.Config
             LaneCoverTop = ReadValue(@"LaneCoverTop", false, data);
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
             UIElementsOverLaneCover = ReadValue(@"UIElementsOverLaneCover", true, data);
+            SmoothAccuracyChanges = ReadValue(@"SmoothAccuracyChanges", true, data);
             EditorVisualizationGraph = ReadValue(@"EditorVisualizationGraph", EditorVisualizationGraphType.Tick, data);
             EditorViewLayers = ReadValue(@"EditorViewLayers", false, data);
             LobbyFilterHasPassword = ReadValue(@"LobbyFilterHasPassword", true, data);
@@ -716,6 +722,7 @@ namespace Quaver.Shared.Config
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
                     EditorViewLayers.ValueChanged += AutoSaveConfiguration;
                     UIElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
+                    SmoothAccuracyChanges.ValueChanged += AutoSaveConfiguration;
                     EditorVisualizationGraph.ValueChanged += AutoSaveConfiguration;
                     LobbyFilterHasPassword.ValueChanged += AutoSaveConfiguration;
                     LobbyFilterFullGame.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Config;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Skinning;
 using Wobble;
@@ -144,13 +145,23 @@ namespace Quaver.Shared.Graphics
             {
                 switch (Type)
                 {
-                    case NumberDisplayType.Accuracy:
                     case NumberDisplayType.Score:
                         CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
                             (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
                         break;
                     case NumberDisplayType.Combo:
                         CurrentValue = TargetValue;
+                        break;
+                    case NumberDisplayType.Accuracy:
+                        if (ConfigManager.SmoothAccuracyChanges.Value)
+                        {
+                            CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
+                                (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 400f, 1));
+                        }
+                        else
+                        {
+                            CurrentValue = TargetValue;
+                        }
                         break;
                     case NumberDisplayType.SongTime:
                         break;

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -333,7 +333,8 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsSlider(this, "Bottom Lane Cover Height", ConfigManager.LaneCoverBottomHeight, x => $"{x}%"),
                     new SettingsBool(this, "Top Lane Cover", ConfigManager.LaneCoverTop),
                     new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom),
-                    new SettingsBool(this, "Display UI Elements Over Lane Covers", ConfigManager.UIElementsOverLaneCover)
+                    new SettingsBool(this, "Display UI Elements Over Lane Covers", ConfigManager.UIElementsOverLaneCover),
+                    new SettingsBool(this, "Smooth Accuracy Changes", ConfigManager.SmoothAccuracyChanges)
                 }),
                 // Editor
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_beaker), "Editor", new List<Drawable>()


### PR DESCRIPTION
IMO accuracy smoothing shouldn't be a thing altogether but at least there's a setting to disable it now.