### PR TITLE
OtherGameMapDatabaseCache: trim osu! map directory

### DIFF
--- a/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
@@ -199,7 +199,7 @@ namespace Quaver.Shared.Database.Maps
                     var newMap = new OtherGameMap()
                     {
                         Md5Checksum = map.BeatmapChecksum,
-                        Directory = map.FolderName,
+                        Directory = map.FolderName.Trim(),
                         Path = map.BeatmapFileName,
                         Artist = map.Artist,
                         Title = map.Title,


### PR DESCRIPTION
Seems to be what osu! itself does. Fixes loading of [this map](https://osu.ppy.sh/beatmapsets/919414#mania/1919691).