### PR TITLE
Show current map in player cards in chat

### DIFF
--- a/Quaver.Shared/Graphics/Overlays/Chat/Components/Users/DrawableOnlineUser.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chat/Components/Users/DrawableOnlineUser.cs
@@ -122,7 +122,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chat.Components.Users
         /// <summary>
         ///     Creates the username text
         /// </summary>
-        private void CreateUsername() => Username = new SpriteText(Fonts.Exo2Bold, "Loading...", 13)
+        private void CreateUsername() => Username = new SpriteText(Fonts.Exo2Bold, "Loading...", 12)
         {
             Parent = this,
             X = Avatar.X + Avatar.Width + 5,
@@ -133,11 +133,11 @@ namespace Quaver.Shared.Graphics.Overlays.Chat.Components.Users
         /// <summary>
         ///     Creates the text for the user's status
         /// </summary>
-        private void CreateStatus() => Status = new SpriteText(Fonts.SourceSansProSemiBold, "Idle", 12)
+        private void CreateStatus() => Status = new SpriteText(Fonts.SourceSansProSemiBold, "Idle", 10)
         {
             Parent = this,
             X = Username.X,
-            Y = Username.Y + Username.Height - 2
+            Y = 27
         };
 
         /// <summary>


### PR DESCRIPTION
Check how the text positions look on Windows. If they look off I'll adjust the values so it looks right on Windows (since Linux has the incorrect font).

![image](https://user-images.githubusercontent.com/1794388/56763493-423eef00-67ab-11e9-8253-49e4cd57d763.png)
