### PR TITLE
Fix autoplay crash on stacked notes

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -76,14 +76,28 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             foreach (var activeLane in currentActive)
             {
-                if (!previousActive.Contains(activeLane))
-                    UniquePresses[activeLane] = true;
+                try
+                {
+                    if (!previousActive.Contains(activeLane))
+                        UniquePresses[activeLane] = true;
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
 
             foreach (var activeLane in previousActive)
             {
-                if (!currentActive.Contains(activeLane))
-                    UniqueReleases[activeLane] = true;
+                try
+                {
+                    if (!currentActive.Contains(activeLane))
+                        UniqueReleases[activeLane] = true;
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
             }
 
             CurrentFrame++;


### PR DESCRIPTION
Fixes #608 

The underlying issue is the autogenerated replay not handling stacked notes properly, so that still needs to be fixed. This'll at least get rid of the game crashing, but the replay won't be perfect until that part is fixed.