### PR TITLE
Keysounds and sound effects

### DIFF
--- a/Quaver.Shared/Audio/AudioEngine.cs
+++ b/Quaver.Shared/Audio/AudioEngine.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Audio
         /// <summary>
         ///     The AudioTrack for the currently selected map.
         /// </summary>
-        public static AudioTrack Track { get; internal set; }
+        public static IAudioTrack Track { get; internal set; }
 
         /// <summary>
         ///     The map the loaded AudioTrack is for.
@@ -40,7 +40,7 @@ namespace Quaver.Shared.Audio
         /// <summary>
         ///     Loads the track for the currently selected map.
         /// </summary>
-        public static void LoadCurrentTrack(bool preview = false)
+        public static void LoadCurrentTrack(bool preview = false, int time = 300000)
         {
             Source.Cancel();
             Source.Dispose();
@@ -67,11 +67,13 @@ namespace Quaver.Shared.Audio
             }
             catch (OperationCanceledException e)
             {
-                // ignored
             }
             catch (Exception e)
             {
-                //Logger.Error(e, LogType.Runtime);
+                if (Track != null && !Track.IsDisposed)
+                    Track.Dispose();
+
+                Track = new AudioTrackVirtual(time);
             }
         }
 

--- a/Quaver.Shared/Audio/CustomAudioSampleCache.cs
+++ b/Quaver.Shared/Audio/CustomAudioSampleCache.cs
@@ -7,41 +7,40 @@
 
 using System.Collections.Generic;
 using System.IO;
-using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Wobble.Audio.Samples;
 
-namespace Quaver.Shared.Screens.Gameplay
+namespace Quaver.Shared.Audio
 {
-    public class CustomAudioSampleCache
+    public static class CustomAudioSampleCache
     {
         /// <summary>
         ///     MD5 hash of the map where the sound samples are from.
         /// </summary>
-        private string MapMd5 { get; set; }
+        private static string MapMd5 { get; set; }
 
         /// <summary>
         ///     The cached audio samples.
         /// </summary>
-        private List<AudioSample> Samples { get; set; } = new List<AudioSample>();
+        private static List<AudioSample> Samples { get; set; } = new List<AudioSample>();
 
         /// <summary>
         ///     Whether the corresponding audio samples are unaffected by rate.
         /// </summary>
-        private List<bool> UnaffectedByRate { get; set; } = new List<bool>();
+        private static List<bool> UnaffectedByRate { get; set; } = new List<bool>();
 
         /// <summary>
         ///     Currently playing channels.
         /// </summary>
-        private List<AudioSampleChannel> Channels { get; set; } = new List<AudioSampleChannel>();
+        private static List<AudioSampleChannel> Channels { get; set; } = new List<AudioSampleChannel>();
 
         /// <summary>
         ///     Loads audio samples for the specified map into the cache.
         /// </summary>
         /// <param name="map"></param>
         /// <param name="md5"></param>
-        public void LoadSamples(Map map, string md5)
+        public static void LoadSamples(Map map, string md5)
         {
             // Always clean up the left-over channels.
             StopAll();
@@ -103,7 +102,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         /// <param name="index">Index of a sample to play, same as into the Qua.CustomAudioSamples array.</param>
         /// <param name="volume">Volume between 0 and 100.</param>
-        public void Play(int index, int volume = 100)
+        public static void Play(int index, int volume = 100)
         {
             var channel = Samples[index].CreateChannel(
                 ConfigManager.Pitched.Value, UnaffectedByRate[index] ? 1f : AudioEngine.Track.Rate);
@@ -116,7 +115,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     Pauses all playing samples.
         /// </summary>
-        public void PauseAll()
+        public static void PauseAll()
         {
             for (var i = Channels.Count - 1; i >= 0; i--)
             {
@@ -133,7 +132,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     Resumes all samples.
         /// </summary>
-        public void ResumeAll()
+        public static void ResumeAll()
         {
             foreach (var channel in Channels)
                 channel.Play();
@@ -142,7 +141,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     Stops and frees all playing samples without the ability to resume them.
         /// </summary>
-        public void StopAll()
+        public static void StopAll()
         {
             foreach (var channel in Channels)
                 channel.Stop();

--- a/Quaver.Shared/Audio/GameplayAudioSample.cs
+++ b/Quaver.Shared/Audio/GameplayAudioSample.cs
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
+*/
+
+using System;
+using Wobble.Audio.Samples;
+
+namespace Quaver.Shared.Audio
+{
+    /// <summary>
+    ///     An audio sample such as a sound effect or a keysound.
+    /// </summary>
+    public class GameplayAudioSample : IDisposable
+    {
+        /// <summary>
+        ///     The underlying AudioSample.
+        /// </summary>
+        public AudioSample Sample { get; }
+
+        /// <summary>
+        ///     Whether the audio sample is unaffected by rate.
+        /// </summary>
+        public bool UnaffectedByRate { get; }
+
+        public GameplayAudioSample(AudioSample sample, bool unaffectedByRate)
+        {
+            Sample = sample;
+            UnaffectedByRate = unaffectedByRate;
+        }
+
+        public void Dispose() => Sample?.Dispose();
+    }
+}

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -227,6 +227,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> EnableHitsounds { get; private set; }
 
         /// <summary>
+        ///     If true, keysounds in gameplay will be played.
+        /// </summary>
+        internal static Bindable<bool> EnableKeysounds { get; private set; }
+
+        /// <summary>
         ///     If enabled, the user's background will be blurred in gameplay.
         /// </summary>
         internal static Bindable<bool> BlurBackgroundInGameplay { get; private set; }
@@ -284,6 +289,11 @@ namespace Quaver.Shared.Config
         ///     Whether or not to play hitsounds in the editor.
         /// </summary>
         internal static Bindable<bool> EditorEnableHitsounds { get; private set; }
+
+        /// <summary>
+        ///     Whether or not to play keysounds in the editor.
+        /// </summary>
+        internal static Bindable<bool> EditorEnableKeysounds { get; private set; }
 
         /// <summary>
         ///     The type of beat snap colors that'll be displayed in the editor.
@@ -568,6 +578,7 @@ namespace Quaver.Shared.Config
             DisplayTimingLines = ReadValue(@"DisplayTimingLines", true, data);
             DisplayMenuAudioVisualizer = ReadValue(@"DisplayMenuAudioVisualizer", true, data);
             EnableHitsounds = ReadValue(@"EnableHitsounds", true, data);
+            EnableKeysounds = ReadValue(@"EnableKeysounds", true, data);
             KeyNavigateLeft = ReadValue(@"KeyNavigateLeft", Keys.Left, data);
             KeyNavigateRight = ReadValue(@"KeyNavigateRight", Keys.Right, data);
             KeyNavigateUp = ReadValue(@"KeyNavigateUp", Keys.Up, data);
@@ -603,6 +614,7 @@ namespace Quaver.Shared.Config
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);
             EditorEnableHitsounds = ReadValue(@"EditorEnableHitsounds", true, data);
+            EditorEnableKeysounds = ReadValue(@"EditorEnableKeysounds", true, data);
             EditorBeatSnapColorType = ReadValue(@"EditorBeatSnapColorType", EditorBeatSnapColor.Default, data);
             EditorOnlyShowMeasureLines = ReadValue(@"EditorOnlyShowMeasureLines", false, data);
             EditorShowLaneDividerLines = ReadValue(@"EditorShowDividerLines", true, data);
@@ -670,6 +682,7 @@ namespace Quaver.Shared.Config
                     DisplayTimingLines.ValueChanged += AutoSaveConfiguration;
                     DisplayMenuAudioVisualizer.ValueChanged += AutoSaveConfiguration;
                     EnableHitsounds.ValueChanged += AutoSaveConfiguration;
+                    EnableKeysounds.ValueChanged += AutoSaveConfiguration;
                     KeyNavigateLeft.ValueChanged += AutoSaveConfiguration;
                     KeyNavigateRight.ValueChanged += AutoSaveConfiguration;
                     KeyNavigateUp.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -82,5 +82,24 @@ namespace Quaver.Shared.Database.Maps
                     return "";
             }
         }
+
+        /// <summary>
+        ///     Gets a map's custom audio sample path taking into account the game.
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="samplePath"></param>
+        /// <returns></returns>
+        public static string GetCustomAudioSamplePath(Map map, string samplePath)
+        {
+            switch (map.Game)
+            {
+                case MapGame.Osu:
+                    return OsuSongsFolder + "/" + map.Directory + "/" + samplePath;
+                case MapGame.Quaver:
+                    return ConfigManager.SongDirectory + "/" + map.Directory + "/" + samplePath;
+                default:
+                    return "";
+            }
+        }
     }
 }

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -627,8 +627,13 @@ namespace Quaver.Shared.Screens.Editor
                 {
                     var view = (EditorScreenView) View;
 
-                    if (ConfigManager.EditorEnableHitsounds.Value && !view.LayerCompositor.ScrollContainer.AvailableItems[obj.EditorLayer].Hidden)
-                        HitObjectManager.PlayObjectHitSounds(obj);
+                    if (!view.LayerCompositor.ScrollContainer.AvailableItems[obj.EditorLayer].Hidden)
+                    {
+                        if (ConfigManager.EditorEnableHitsounds.Value)
+                            HitObjectManager.PlayObjectHitSounds(obj);
+                        if (ConfigManager.EditorEnableKeysounds.Value)
+                            HitObjectManager.PlayObjectKeySounds(obj);
+                    }
 
                     HitSoundObjectIndex = i + 1;
                 }

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -48,6 +48,7 @@ using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Menu;
 using Quaver.Shared.Screens.Select;
 using Wobble;
+using Wobble.Audio.Tracks;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Dialogs;
@@ -410,17 +411,17 @@ namespace Quaver.Shared.Screens.Editor
         {
             try
             {
-                if (AudioEngine.Track != null && AudioEngine.Track.IsPaused && !AudioEngine.Track.IsPreview)
+                if (AudioEngine.Track != null && AudioEngine.Track.IsPaused)
                     return true;
 
-                AudioEngine.LoadCurrentTrack();
+                AudioEngine.LoadCurrentTrack(false, WorkingMap.Length + 60000);
                 return true;
             }
             catch (Exception e)
             {
                 NotificationManager.Show(NotificationLevel.Error, "Audio track was unable to be loaded for this map.");
                 Exit(() => new MenuScreen());
-                return false;
+                return true;
             }
         }
 
@@ -715,7 +716,10 @@ namespace Quaver.Shared.Screens.Editor
                 if (AudioEngine.Track != null)
                     AudioEngine.Track.Rate = 1.0f;
 
-                AudioEngine.Track?.Fade(0, 100);
+                var track = AudioEngine.Track;
+
+                if (track is AudioTrack t)
+                    t?.Fade(0, 100);
 
                 return new SelectScreen();
             });

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -173,6 +173,8 @@ namespace Quaver.Shared.Screens.Editor
             if (!LoadAudioTrack())
                 return;
 
+            GameplayScreen.CustomAudioSampleCache.LoadSamples(MapManager.Selected.Value, MapManager.Selected.Value.Md5Checksum);
+
             SetHitSoundObjectIndex();
 
             GameBase.Game.IsMouseVisible = true;

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -173,7 +173,7 @@ namespace Quaver.Shared.Screens.Editor
             if (!LoadAudioTrack())
                 return;
 
-            GameplayScreen.CustomAudioSampleCache.LoadSamples(MapManager.Selected.Value, MapManager.Selected.Value.Md5Checksum);
+            CustomAudioSampleCache.LoadSamples(MapManager.Selected.Value, MapManager.Selected.Value.Md5Checksum);
 
             SetHitSoundObjectIndex();
 

--- a/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
+++ b/Quaver.Shared/Screens/Editor/UI/EditorMenuBar.cs
@@ -284,6 +284,8 @@ namespace Quaver.Shared.Screens.Editor.UI
 
             if (ImGui.MenuItem("Enable Hitsounds", null, ConfigManager.EditorEnableHitsounds.Value))
                 ConfigManager.EditorEnableHitsounds.Value = !ConfigManager.EditorEnableHitsounds.Value;
+            if (ImGui.MenuItem("Enable Keysounds", null, ConfigManager.EditorEnableKeysounds.Value))
+                ConfigManager.EditorEnableKeysounds.Value = !ConfigManager.EditorEnableKeysounds.Value;
 
             ImGui.EndMenu();
         }

--- a/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
+++ b/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
@@ -7,6 +7,8 @@
 
 using System.Collections.Generic;
 using System.IO;
+using Quaver.Shared.Audio;
+using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Wobble.Audio.Samples;
 
@@ -95,7 +97,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="volume">Volume between 0 and 100.</param>
         public void Play(int index, int volume = 100)
         {
-            var channel = Samples[index].CreateChannel();
+            var channel = Samples[index].CreateChannel(ConfigManager.Pitched.Value, AudioEngine.Track.Rate);
             channel.Volume *= volume / 100f;
             channel.Play();
 

--- a/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
+++ b/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
@@ -93,7 +93,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         /// <param name="index">Index of a sample to play, same as into the Qua.CustomAudioSamples array.</param>
         /// <param name="volume">Volume between 0 and 100.</param>
-        public void Play(int index, int volume)
+        public void Play(int index, int volume = 100)
         {
             var channel = Samples[index].CreateChannel();
             channel.Volume *= volume / 100f;

--- a/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
+++ b/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
@@ -27,6 +27,11 @@ namespace Quaver.Shared.Screens.Gameplay
         private List<AudioSample> Samples { get; set; } = new List<AudioSample>();
 
         /// <summary>
+        ///     Whether the corresponding audio samples are unaffected by rate.
+        /// </summary>
+        private List<bool> UnaffectedByRate { get; set; } = new List<bool>();
+
+        /// <summary>
         ///     Currently playing channels.
         /// </summary>
         private List<AudioSampleChannel> Channels { get; set; } = new List<AudioSampleChannel>();
@@ -51,8 +56,11 @@ namespace Quaver.Shared.Screens.Gameplay
                 sample.Dispose();
 
             Samples = new List<AudioSample>();
+            UnaffectedByRate = new List<bool>();
             foreach (var info in map.Qua.CustomAudioSamples)
             {
+                UnaffectedByRate.Add(info.UnaffectedByRate);
+
                 // If the path is missing an extension or the file doesn't exist, we need to try some other extensions
                 // for compatibility with osu!.
                 var pathWithoutExt = info.Path;
@@ -97,7 +105,8 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="volume">Volume between 0 and 100.</param>
         public void Play(int index, int volume = 100)
         {
-            var channel = Samples[index].CreateChannel(ConfigManager.Pitched.Value, AudioEngine.Track.Rate);
+            var channel = Samples[index].CreateChannel(
+                ConfigManager.Pitched.Value, UnaffectedByRate[index] ? 1f : AudioEngine.Track.Rate);
             channel.Volume *= volume / 100f;
             channel.Play();
 

--- a/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
+++ b/Quaver.Shared/Screens/Gameplay/CustomAudioSampleCache.cs
@@ -1,0 +1,105 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
+*/
+
+using System.Collections.Generic;
+using Quaver.Shared.Database.Maps;
+using Wobble.Audio.Samples;
+
+namespace Quaver.Shared.Screens.Gameplay
+{
+    public class CustomAudioSampleCache
+    {
+        /// <summary>
+        ///     MD5 hash of the map where the sound samples are from.
+        /// </summary>
+        private string MapMd5 { get; set; }
+
+        /// <summary>
+        ///     The cached audio samples.
+        /// </summary>
+        private List<AudioSample> Samples { get; set; } = new List<AudioSample>();
+
+        /// <summary>
+        ///     Currently playing channels.
+        /// </summary>
+        private List<AudioSampleChannel> Channels { get; set; } = new List<AudioSampleChannel>();
+
+        /// <summary>
+        ///     Loads audio samples for the specified map into the cache.
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="md5"></param>
+        public void LoadSamples(Map map, string md5)
+        {
+            // Always clean up the left-over channels.
+            StopAll();
+
+            // If the MD5 is the same, no need to re-load the samples.
+            if (MapMd5 == md5)
+                return;
+
+            MapMd5 = map.Md5Checksum;
+
+            foreach (var sample in Samples)
+                sample.Dispose();
+
+            Samples = new List<AudioSample>();
+            foreach (var info in map.Qua.CustomAudioSamples)
+                Samples.Add(new AudioSample(MapManager.GetCustomAudioSamplePath(map, info.Path)));
+        }
+
+        /// <summary>
+        ///     Plays the sample for the given index.
+        /// </summary>
+        /// <param name="index">Index of a sample to play, same as into the Qua.CustomAudioSamples array.</param>
+        /// <param name="volume">Volume between 0 and 100.</param>
+        public void Play(int index, int volume)
+        {
+            var channel = Samples[index].CreateChannel();
+            channel.Volume *= volume / 100f;
+            channel.Play();
+
+            Channels.Add(channel);
+        }
+
+        /// <summary>
+        ///     Pauses all playing samples.
+        /// </summary>
+        public void PauseAll()
+        {
+            for (var i = Channels.Count - 1; i >= 0; i--)
+            {
+                var channel = Channels[i];
+
+                channel.Pause();
+
+                // Remove channels that have finished playing.
+                if (channel.IsStopped)
+                    Channels.RemoveAt(i);
+            }
+        }
+
+        /// <summary>
+        ///     Resumes all samples.
+        /// </summary>
+        public void ResumeAll()
+        {
+            foreach (var channel in Channels)
+                channel.Play();
+        }
+
+        /// <summary>
+        ///     Stops and frees all playing samples without the ability to resume them.
+        /// </summary>
+        public void StopAll()
+        {
+            foreach (var channel in Channels)
+                channel.Stop();
+            Channels = new List<AudioSampleChannel>();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -50,6 +50,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 if (Screen.IsPlayTesting)
                 {
                     AudioEngine.Track.Seek(Screen.PlayTestAudioTime);
+                    Time = AudioEngine.Track.Time;
                     return;
                 }
             }

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -49,7 +49,6 @@ namespace Quaver.Shared.Screens.Gameplay
                 else
                 {
                     AudioEngine.LoadCurrentTrack();
-                    AudioEngine.Track.Rate = ModHelper.GetRateFromMods(ModManager.Mods);
                 }
 
                 if (Screen.IsPlayTesting)

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -7,7 +7,9 @@
 
 using System;
 using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
 using Quaver.Shared.Audio;
+using Quaver.Shared.Modifiers;
 using Wobble;
 using Wobble.Audio;
 using Wobble.Audio.Tracks;
@@ -45,7 +47,10 @@ namespace Quaver.Shared.Screens.Gameplay
                 if (Screen.IsCalibratingOffset)
                     AudioEngine.Track = new AudioTrack(GameBase.Game.Resources.Get($"Quaver.Resources/Maps/Offset/offset.mp3"));
                 else
+                {
                     AudioEngine.LoadCurrentTrack();
+                    AudioEngine.Track.Rate = ModHelper.GetRateFromMods(ModManager.Mods);
+                }
 
                 if (Screen.IsPlayTesting)
                 {

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -226,11 +226,6 @@ namespace Quaver.Shared.Screens.Gameplay
         public Metronome Metronome { get; }
 
         /// <summary>
-        ///     Loads and caches the custom audio samples.
-        /// </summary>
-        public static CustomAudioSampleCache CustomAudioSampleCache { get; } = new CustomAudioSampleCache();
-
-        /// <summary>
         ///     Index of the next sound effect to play.
         /// </summary>
         private int NextSoundEffectIndex { get; set; }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
@@ -90,6 +90,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects
         }
 
         /// <summary>
+        ///     Plays the correct keysounds based on the note index of the HitObjectPool.
+        /// </summary>
+        public static void PlayObjectKeySounds(HitObjectInfo hitObject)
+        {
+            foreach (var keySound in hitObject.KeySounds)
+                GameplayScreen.CustomAudioSampleCache.Play(keySound - 1);
+        }
+
+        /// <summary>
         ///     Returns color of note beatsnap
         /// </summary>
         /// <param name="info"></param>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
@@ -11,6 +11,7 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Enums;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Skinning;
 
@@ -95,7 +96,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects
         public static void PlayObjectKeySounds(HitObjectInfo hitObject)
         {
             foreach (var keySound in hitObject.KeySounds)
-                GameplayScreen.CustomAudioSampleCache.Play(keySound - 1);
+                CustomAudioSampleCache.Play(keySound - 1);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -171,6 +171,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Play the HitSounds of closest hit object.
             if (ConfigManager.EnableHitsounds.Value)
                 HitObjectManager.PlayObjectHitSounds(gameplayHitObject.Info);
+            if (ConfigManager.EnableKeysounds.Value)
+                HitObjectManager.PlayObjectKeySounds(gameplayHitObject.Info);
 
             // Get Judgement and references
             var time = (int)manager.CurrentAudioPosition;

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -476,7 +476,8 @@ namespace Quaver.Shared.Screens.Select
         /// </summary>
         public void ExitToEditor() => Exit(() =>
         {
-            AudioEngine.Track?.Pause();
+            if (!AudioEngine.Track.IsDisposed)
+                AudioEngine.Track?.Pause();
 
             try
             {

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Quaver.API.Helpers;
 using Quaver.Server.Common.Enums;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Audio;
@@ -304,7 +305,7 @@ namespace Quaver.Shared.Screens.Select
         /// <returns></returns>
         private static float GetNextRate(bool faster)
         {
-            var current = AudioEngine.Track.Rate;
+            var current = ModHelper.GetRateFromMods(ModManager.Mods);
             var adjustment = 0.1f;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -321,6 +321,7 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsScrollDirection(this, "Scroll Direction 7K", ConfigManager.ScrollDirection7K),
                     new SettingsBool(this, "Blur Background In Gameplay", ConfigManager.BlurBackgroundInGameplay),
                     new SettingsBool(this, "Enable Hitsounds", ConfigManager.EnableHitsounds),
+                    new SettingsBool(this, "Enable Keysounds", ConfigManager.EnableKeysounds),
                     new SettingsBool(this, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                     new SettingsBool(this, "Display Song Time Progress", ConfigManager.DisplaySongTimeProgress),
                     new SettingsBool(this, "Display Song Time Progress Numbers", ConfigManager.DisplaySongTimeProgressNumbers),
@@ -341,6 +342,7 @@ namespace Quaver.Shared.Screens.Settings
                 {
                     new SettingsEditorSnapColors(this),
                     new SettingsBool(this, "Enable Hitsounds", ConfigManager.EditorEnableHitsounds),
+                    new SettingsBool(this, "Enable Keysounds", ConfigManager.EditorEnableKeysounds),
                     new SettingsBool(this, "Enable Metronome", ConfigManager.EditorPlayMetronome),
                     new SettingsBool(this, "Play Metronome Half-Beats", ConfigManager.EditorMetronomePlayHalfBeats),
                     new SettingsBool(this, "Show Lane Divider Lines", ConfigManager.EditorShowLaneDividerLines),


### PR DESCRIPTION
Poggers

Example mapsets: [7k fully keysounded pack](https://osu.ppy.sh/beatmapsets/577617), [o2jam converts with sound effects audio and keysounds](https://osu.ppy.sh/beatmapsets/827408#mania/1733808), [4k ranked sound effects and keysounds](https://osu.ppy.sh/beatmapsets/302726#mania/678460).

Videos: [7k keysounded pack](https://streamable.com/o5jn9), [that 4k map](https://streamable.com/nbezj). Sounds weird because I have big sample delay which I still haven't figured out.

`CustomAudioSampleCache` should probably be its own static class or something and not inside `GameplayScreen`, cc @Swan.

As far as I can tell everything works.

Requires https://github.com/Quaver/Wobble/pull/65 and https://github.com/Quaver/Quaver.API/pull/63.