### PR TITLE
Replay Player Fixes

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -206,9 +206,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             // Update Playfield
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
-            playfield.Stage.ComboDisplay.MakeVisible();
-            playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - manager.CurrentAudioPosition);
-            playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+
+            if (ReplayInputManager == null)
+            {
+                playfield.Stage.ComboDisplay.MakeVisible();
+                playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - manager.CurrentAudioPosition);
+                playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+            }
 
             // Update Object Pooling
             switch (judgement)
@@ -273,9 +277,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 ((GameplayScreenView)Ruleset.Screen.View).UpdateScoreboardUsers();
 
                 // Update Playfield
-                playfield.Stage.ComboDisplay.MakeVisible();
-                playfield.Stage.HitError.AddJudgement(judgement, (int)(gameplayHitObject.Info.EndTime - manager.CurrentAudioPosition));
-                playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+                if (ReplayInputManager == null)
+                {
+                    playfield.Stage.ComboDisplay.MakeVisible();
+                    playfield.Stage.HitError.AddJudgement(judgement, (int)(gameplayHitObject.Info.EndTime - manager.CurrentAudioPosition));
+                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+                }
 
                 // If the player recieved an early miss or "okay",
                 // show the player that they were inaccurate by killing the object instead of recycling it
@@ -313,7 +320,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             view.UpdateScoreAndAccuracyDisplays();
 
             // Perform hit burst animation
-            playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+            if (ReplayInputManager == null)
+                playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
 
             // Update Object Pool
             manager.KillHoldPoolObject(gameplayHitObject);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -175,7 +175,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Get Judgement and references
             var time = (int)manager.CurrentAudioPosition;
             var hitDifference = gameplayHitObject.Info.StartTime - time;
-            var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Press);
+            var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Press, ReplayInputManager == null);
             var lane = gameplayHitObject.Info.Lane - 1;
 
             // Ignore Ghost Taps
@@ -242,7 +242,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             var lane = gameplayHitObject.Info.Lane - 1;
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
             var hitDifference = (int)(manager.HeldLongNoteLanes[lane].Peek().Info.EndTime - manager.CurrentAudioPosition);
-            var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Release);
+            var judgement = ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(hitDifference, KeyPressType.Release, ReplayInputManager == null);
 
             // Update animations
             playfield.Stage.HitLightingObjects[lane].StopHolding();
@@ -301,7 +301,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     Ruleset.ScoreProcessor.Accuracy,
                     Ruleset.ScoreProcessor.Health
             ));
-            Ruleset.ScoreProcessor.CalculateScore(missedJudgement);
+
+            if (ReplayInputManager == null)
+                Ruleset.ScoreProcessor.CalculateScore(missedJudgement);
 
             // Update scoreboard
             var view = (GameplayScreenView) Ruleset.Screen.View;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -14,6 +14,7 @@ using Quaver.API.Replays;
 using Quaver.API.Replays.Virtual;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 {
@@ -129,11 +130,21 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
                 if (hom?.CurrentAudioPosition >= VirtualPLayer.ScoreProcessor.Stats[i].SongPosition)
                 {
-                    ((ScoreProcessorKeys)Screen.Ruleset.ScoreProcessor).CalculateScore(VirtualPLayer.ScoreProcessor.Stats[i].Judgement);
+                    var judgement = VirtualPLayer.ScoreProcessor.Stats[i].Judgement;
+
+                    ((ScoreProcessorKeys)Screen.Ruleset.ScoreProcessor).CalculateScore(judgement);
 
                     // Update Scoreboard
                     var view = (GameplayScreenView) Screen.View;
                     view.UpdateScoreAndAccuracyDisplays();
+
+                    var playfield = (GameplayPlayfieldKeys)Screen.Ruleset.Playfield;
+                    playfield.Stage.ComboDisplay.MakeVisible();
+
+                    if (judgement != Judgement.Miss)
+                        playfield.Stage.HitError.AddJudgement(judgement, VirtualPLayer.ScoreProcessor.Stats[i].HitDifference);
+
+                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
 
                     CurrentVirtualReplayStat++;
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -53,7 +53,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
         /// <summary>
         ///     Virtually plays replay frames
         /// </summary>
-        public VirtualReplayPlayer VirtualPLayer { get; }
+        public VirtualReplayPlayer VirtualPlayer { get; }
 
         /// <summary>
         ///     The current frame being played in the virtual replay player
@@ -69,8 +69,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             Screen = screen;
             Replay = Screen.LoadedReplay;
 
-            VirtualPLayer = new VirtualReplayPlayer(Replay, Screen.Map);
-            VirtualPLayer.PlayAllFrames();
+            VirtualPlayer = new VirtualReplayPlayer(Replay, Screen.Map);
+            VirtualPlayer.PlayAllFrames();
 
             // Populate unique key presses/releases.
             for (var i = 0; i < screen.Map.GetKeyCount(); i++)
@@ -124,13 +124,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
         private void HandleScoring()
         {
-            for (var i = CurrentVirtualReplayStat + 1; i < VirtualPLayer.ScoreProcessor.Stats.Count; i++)
+            for (var i = CurrentVirtualReplayStat + 1; i < VirtualPlayer.ScoreProcessor.Stats.Count; i++)
             {
                 var hom = Screen.Ruleset.HitObjectManager as HitObjectManagerKeys;
 
-                if (hom?.CurrentAudioPosition >= VirtualPLayer.ScoreProcessor.Stats[i].SongPosition)
+                if (hom?.CurrentAudioPosition >= VirtualPlayer.ScoreProcessor.Stats[i].SongPosition)
                 {
-                    var judgement = VirtualPLayer.ScoreProcessor.Stats[i].Judgement;
+                    var judgement = VirtualPlayer.ScoreProcessor.Stats[i].Judgement;
 
                     ((ScoreProcessorKeys)Screen.Ruleset.ScoreProcessor).CalculateScore(judgement);
 
@@ -142,7 +142,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     playfield.Stage.ComboDisplay.MakeVisible();
 
                     if (judgement != Judgement.Miss)
-                        playfield.Stage.HitError.AddJudgement(judgement, VirtualPLayer.ScoreProcessor.Stats[i].HitDifference);
+                        playfield.Stage.HitError.AddJudgement(judgement, VirtualPlayer.ScoreProcessor.Stats[i].HitDifference);
 
                     playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
@@ -326,7 +327,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     var stat = new HitStat(HitStatType.Miss, KeyPressType.None, hitObject.Info, hitObject.Info.StartTime, Judgement.Miss,
                                             int.MinValue, Ruleset.ScoreProcessor.Accuracy, Ruleset.ScoreProcessor.Health);
                     Ruleset.ScoreProcessor.Stats.Add(stat);
-                    Ruleset.ScoreProcessor.CalculateScore(Judgement.Miss);
+
+                    var im = Ruleset.InputManager as KeysInputManager;
+
+                    if (im?.ReplayInputManager == null)
+                        Ruleset.ScoreProcessor.CalculateScore(Judgement.Miss);
 
                     var view = (GameplayScreenView)Ruleset.Screen.View;
                     view.UpdateScoreAndAccuracyDisplays();
@@ -341,7 +346,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (hitObject.Info.IsLongNote)
                     {
                         KillPoolObject(hitObject);
-                        Ruleset.ScoreProcessor.CalculateScore(Judgement.Miss);
+
+                        if (im?.ReplayInputManager == null)
+                            Ruleset.ScoreProcessor.CalculateScore(Judgement.Miss);
 
                         view.UpdateScoreAndAccuracyDisplays();
                         Ruleset.ScoreProcessor.Stats.Add(stat);
@@ -386,7 +393,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     var stat = new HitStat(HitStatType.Miss, KeyPressType.None, hitObject.Info, hitObject.Info.EndTime, Judgement.Okay,
                                                 int.MinValue, Ruleset.ScoreProcessor.Accuracy, Ruleset.ScoreProcessor.Health);
                     Ruleset.ScoreProcessor.Stats.Add(stat);
-                    Ruleset.ScoreProcessor.CalculateScore(missedJudgement);
+
+                    var im = Ruleset.InputManager as KeysInputManager;
+
+                    if (im?.ReplayInputManager == null)
+                        Ruleset.ScoreProcessor.CalculateScore(missedJudgement);
 
                     // Update scoreboard for simulated plays
                     var screenView = (GameplayScreenView)Ruleset.Screen.View;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -338,8 +338,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
                     // Perform Playfield animations
                     var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
-                    playfield.Stage.ComboDisplay.MakeVisible();
-                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+
+                    if (im?.ReplayInputManager == null)
+                    {
+                        playfield.Stage.ComboDisplay.MakeVisible();
+                        playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+                    }
 
                     // If ManiaHitObject is an LN, kill it and count it as another miss because of the tail.
                     // - missing an LN counts as two misses
@@ -406,8 +410,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
                     // Perform Playfield animations
                     var stage = ((GameplayPlayfieldKeys)Ruleset.Playfield).Stage;
-                    stage.ComboDisplay.MakeVisible();
-                    stage.JudgementHitBurst.PerformJudgementAnimation(missedJudgement);
+
+                    if (im?.ReplayInputManager == null)
+                    {
+                        stage.ComboDisplay.MakeVisible();
+                        stage.JudgementHitBurst.PerformJudgementAnimation(missedJudgement);
+                    }
+
                     stage.HitLightingObjects[hitObject.Info.Lane - 1].StopHolding();
 
                     // Update Pooling

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -98,6 +98,8 @@ namespace Quaver.Shared.Screens.Result.UI
 
             // Make some fake hits for debugging.
             // CreateFakeHitStats();
+
+            // Draw the dots if there are any.
             if (Processor.Stats != null)
             {
                 FilterHitStats();
@@ -161,11 +163,10 @@ namespace Quaver.Shared.Screens.Result.UI
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         private static ScoreProcessor GetScoreProcessor(ResultScreen screen)
         {
-            // Draw the dots if there are any.
             if (screen.Gameplay != null && screen.Gameplay.InReplayMode)
             {
                 var im = screen.Gameplay.Ruleset.InputManager as KeysInputManager;
-                return im?.ReplayInputManager.VirtualPLayer.ScoreProcessor;
+                return im?.ReplayInputManager.VirtualPlayer.ScoreProcessor;
             }
 
             // If we already have stats (for example, this is a result screen right after a player finished playing a map), use them.

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -20,6 +20,7 @@ using Quaver.API.Replays.Virtual;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
 using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Graphics;
@@ -97,8 +98,6 @@ namespace Quaver.Shared.Screens.Result.UI
 
             // Make some fake hits for debugging.
             // CreateFakeHitStats();
-
-            // Draw the dots if there are any.
             if (Processor.Stats != null)
             {
                 FilterHitStats();
@@ -162,6 +161,13 @@ namespace Quaver.Shared.Screens.Result.UI
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         private static ScoreProcessor GetScoreProcessor(ResultScreen screen)
         {
+            // Draw the dots if there are any.
+            if (screen.Gameplay != null && screen.Gameplay.InReplayMode)
+            {
+                var im = screen.Gameplay.Ruleset.InputManager as KeysInputManager;
+                return im?.ReplayInputManager.VirtualPLayer.ScoreProcessor;
+            }
+
             // If we already have stats (for example, this is a result screen right after a player finished playing a map), use them.
             if (screen.ScoreProcessor.Stats != null)
                 return screen.ScoreProcessor;

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -163,6 +163,9 @@ namespace Quaver.Shared.Screens.Result.UI
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         private static ScoreProcessor GetScoreProcessor(ResultScreen screen)
         {
+            // Handles the case when watching a replay in its entirety. This uses the preprocessed
+            // ScoreProcessor/Replay from gameplay to get a 100% accurate score output.
+            // Also avoids having to process the replay again (as done below).
             if (screen.Gameplay != null && screen.Gameplay.InReplayMode)
             {
                 var im = screen.Gameplay.Ruleset.InputManager as KeysInputManager;


### PR DESCRIPTION
Fixes #341 

Makes scoring for replays accurate & fixes autoplay failing when lagging. This solution preprocesses replays with [VirtualReplayPlayer](https://github.com/Quaver/Quaver.API/blob/master/Quaver.API/Replays/Virtual/VirtualReplayPlayer.cs) and uses those calculated judgements for scoring.

Still needs a bit of work, as there are still some *visual* bugs (w/ judgements & LNs) when completely freezing the window, but this is a decent start.

**Edit**

Said visual bugs have been fixed. Only thing remaining is making sure the replay player catches up for missed frames