### PR TITLE
Small Colors.cs class refactor

### DIFF
--- a/Quaver.Shared/Graphics/Colors.cs
+++ b/Quaver.Shared/Graphics/Colors.cs
@@ -38,7 +38,12 @@ namespace Quaver.Shared.Graphics
         /// <summary>
         ///     Dark gray color, usually used for headers.
         /// </summary>
-        public static readonly Color DarkGray = ColorHelper.HexToColor("#252a3e");
+        public static readonly Color DarkGray = ColorHelper.HexToColor("#181818");
+
+        /// <summary>
+        ///     Dark gray with blueish tint, usually used for search boxes.
+        /// </summary>
+        public static readonly Color BlueishDarkGray = ColorHelper.HexToColor("#252a3e");
 
         /// <summary>
         ///     Legend has it, a legendary legend used this color.

--- a/Quaver.Shared/Graphics/Menu/MenuFooter.cs
+++ b/Quaver.Shared/Graphics/Menu/MenuFooter.cs
@@ -35,7 +35,7 @@ namespace Quaver.Shared.Graphics.Menu
             LeftAligned = leftAligned;
             RightAligned = rightAlighed;
             Size = new ScalableVector2(WindowManager.Width, 44);
-            Tint = ColorHelper.HexToColor("#181818");
+            Tint = Colors.DarkGray;
             Alpha = 1;
 
             BackgroundLine = new Sprite

--- a/Quaver.Shared/Graphics/Menu/MenuHeader.cs
+++ b/Quaver.Shared/Graphics/Menu/MenuHeader.cs
@@ -44,7 +44,7 @@ namespace Quaver.Shared.Graphics.Menu
         public MenuHeader(Texture2D icon, string title, string title2, string subtitle, Color colorTheme)
         {
             Size = new ScalableVector2(WindowManager.Width, 44);
-            Tint = ColorHelper.HexToColor("#181818");
+            Tint = Colors.DarkGray;
             Alpha = 1f;
 
             Icon = new Sprite

--- a/Quaver.Shared/Graphics/Online/Playercard/UserPlayercard.cs
+++ b/Quaver.Shared/Graphics/Online/Playercard/UserPlayercard.cs
@@ -244,7 +244,7 @@ namespace Quaver.Shared.Graphics.Online.Playercard
             User = user;
 
             FullCard = fullCard;
-            Tint = Colors.DarkGray;
+            Tint = Colors.BlueishDarkGray;
 
             Size = new ScalableVector2(426, FullCard ? 154 : 96);
             Image = AssetLoader.LoadTexture2D(GameBase.Game.Resources.GetStream("Quaver.Resources/Textures/UI/Playercard/playercard-bg.png"));

--- a/Quaver.Shared/Graphics/Overlays/Chat/Components/Dialogs/JoinChannelDialog.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chat/Components/Dialogs/JoinChannelDialog.cs
@@ -106,7 +106,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chat.Components.Dialogs
             {
                 Parent = InterfaceContainer,
                 Size = new ScalableVector2(Width, 75),
-                Tint = Colors.DarkGray,
+                Tint = Colors.BlueishDarkGray,
             };
 
             var line = new Sprite()

--- a/Quaver.Shared/Screens/Download/UI/DownloadSearchBox.cs
+++ b/Quaver.Shared/Screens/Download/UI/DownloadSearchBox.cs
@@ -110,7 +110,7 @@ namespace Quaver.Shared.Screens.Download.UI
                 Alignment = Alignment.TopLeft,
                 X = TextSearch.X,
                 Y = TextSearch.Y + TextSearch.Height + 10,
-                Tint = Colors.DarkGray,
+                Tint = Colors.BlueishDarkGray,
             };
 
             SearchBox.AddBorder(Colors.MainAccent, 2);

--- a/Quaver.Shared/Screens/Lobby/UI/LobbySearchBox.cs
+++ b/Quaver.Shared/Screens/Lobby/UI/LobbySearchBox.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Screens.Lobby.UI
         {
             View = view;
 
-            Tint = Colors.DarkGray;
+            Tint = Colors.BlueishDarkGray;
             Alpha = 0.75f;
             AllowSubmission = false;
             Image = UserInterface.SelectSearchBackground;

--- a/Quaver.Shared/Screens/Select/UI/Search/MapsetSearchContainer.cs
+++ b/Quaver.Shared/Screens/Select/UI/Search/MapsetSearchContainer.cs
@@ -133,7 +133,7 @@ namespace Quaver.Shared.Screens.Select.UI.Search
                 Parent = TextSearch,
                 Position = new ScalableVector2(TextSearch.Width + 15, 0),
                 Alignment = Alignment.MidLeft,
-                Tint = Colors.DarkGray,
+                Tint = Colors.BlueishDarkGray,
                 Alpha = 0.75f,
                 AllowSubmission = false,
                 RawText = SelectScreen.PreviousSearchTerm,


### PR DESCRIPTION
The purpose of this is that the previous DarkGray is, in fact, a blueish dark gray, and is being substituted out in places it previously was with `ColorHelper.HexToColor("#181818");` instead of a reusable variable.