### PR TITLE
Results screen additions and 1 ms local offset adjustment with Ctrl

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -502,10 +502,17 @@ namespace Quaver.Shared.Screens.Gameplay
                 // Only allow offset changes if the map hasn't started or if we're on a break
                 if (Ruleset.Screen.Timing.Time <= 5000 || Ruleset.Screen.EligibleToSkip)
                 {
+                    var change = 5;
+                    if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
+                        KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                    {
+                        change = 1;
+                    }
+
                     // Handle offset +
                     if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseMapOffset.Value))
                     {
-                        MapManager.Selected.Value.LocalOffset += 5;
+                        MapManager.Selected.Value.LocalOffset += change;
                         NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset} ms");
                         MapDatabaseCache.UpdateMap(MapManager.Selected.Value);
                     }
@@ -513,7 +520,7 @@ namespace Quaver.Shared.Screens.Gameplay
                     // Handle offset -
                     if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseMapOffset.Value))
                     {
-                        MapManager.Selected.Value.LocalOffset -= 5;
+                        MapManager.Selected.Value.LocalOffset -= change;
                         NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset} ms");
                         MapDatabaseCache.UpdateMap(MapManager.Selected.Value);
                     }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -506,7 +506,7 @@ namespace Quaver.Shared.Screens.Gameplay
                     if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseMapOffset.Value))
                     {
                         MapManager.Selected.Value.LocalOffset += 5;
-                        NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset}ms");
+                        NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset} ms");
                         MapDatabaseCache.UpdateMap(MapManager.Selected.Value);
                     }
 
@@ -514,7 +514,7 @@ namespace Quaver.Shared.Screens.Gameplay
                     if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseMapOffset.Value))
                     {
                         MapManager.Selected.Value.LocalOffset -= 5;
-                        NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset}ms");
+                        NotificationManager.Show(NotificationLevel.Success, $"Local map offset is now: {MapManager.Selected.Value.LocalOffset} ms");
                         MapDatabaseCache.UpdateMap(MapManager.Selected.Value);
                     }
                 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -254,7 +254,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             // Notify the user if their local offset is actually set for this map.
             if (MapManager.Selected.Value.LocalOffset != 0)
-                NotificationManager.Show(NotificationLevel.Info, $"The local audio offset for this map is: {MapManager.Selected.Value.LocalOffset}ms");
+                NotificationManager.Show(NotificationLevel.Info, $"The local audio offset for this map is: {MapManager.Selected.Value.LocalOffset} ms");
 
             if (Screen.IsCalibratingOffset)
             {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -746,7 +746,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public void UpdateCurrentTrackPosition()
         {
             // Use necessary visual offset
-            CurrentAudioPosition = Ruleset.Screen.Timing.Time + ConfigManager.GlobalAudioOffset.Value - MapManager.Selected.Value.LocalOffset;
+            CurrentAudioPosition = Ruleset.Screen.Timing.Time + ConfigManager.GlobalAudioOffset.Value * AudioEngine.Track.Rate - MapManager.Selected.Value.LocalOffset;
 
             // Update SV index if necessary. Afterwards update Position.
             while (CurrentSvIndex < ScrollVelocities.Count && CurrentAudioPosition >= ScrollVelocities[CurrentSvIndex].StartTime)

--- a/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
@@ -392,7 +392,7 @@ namespace Quaver.Shared.Screens.Menu.UI.Jukebox
                 {
                     var percentage = (MouseManager.CurrentState.X - SongTimeProgressBar.AbsolutePosition.X) / SongTimeProgressBar.AbsoluteSize.X;
 
-                    Logger.Debug($"Jukebox track seeked to: {(int)(percentage * AudioEngine.Track.Length)}ms ({(int)(percentage * 100)}%)", LogType.Runtime);
+                    Logger.Debug($"Jukebox track seeked to: {(int)(percentage * AudioEngine.Track.Length)} ms ({(int)(percentage * 100)}%)", LogType.Runtime);
 
                     lock (AudioEngine.Track)
                         AudioEngine.Track.Seek(percentage * AudioEngine.Track.Length);

--- a/Quaver.Shared/Screens/Menu/UI/Navigation/User/BorderedTextButton.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Navigation/User/BorderedTextButton.cs
@@ -26,13 +26,14 @@ namespace Quaver.Shared.Screens.Menu.UI.Navigation.User
         /// <param name="text"></param>
         /// <param name="color"></param>
         /// <param name="clickAction"></param>
-        public BorderedTextButton(string text, Color color, EventHandler clickAction = null)
+        public BorderedTextButton(string text, Color color, EventHandler clickAction = null,
+                float borderThickness = 2)
             : base(UserInterface.BlankBox, Fonts.Exo2Medium, text, 13, clickAction)
         {
             OriginalColor = color;
             Size = new ScalableVector2(175, 35);
             Tint = Color.Transparent;
-            AddBorder(color, 2);
+            AddBorder(color, borderThickness);
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/QuaverScreenManager.cs
+++ b/Quaver.Shared/Screens/QuaverScreenManager.cs
@@ -207,7 +207,7 @@ namespace Quaver.Shared.Screens
                     QueuedScreen = newScreen();
                 }
 
-                Logger.Important($"Scheduled screen change to: '{QueuedScreen.Type}'. w/ {DelayedScreenChangeTime}ms delay", LogType.Runtime);
+                Logger.Important($"Scheduled screen change to: '{QueuedScreen.Type}'. w/ {DelayedScreenChangeTime} ms delay", LogType.Runtime);
             });
         }
 

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -7,11 +7,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Quaver.API.Enums;
@@ -19,6 +16,7 @@ using Quaver.API.Helpers;
 using Quaver.API.Maps.Processors.Rating;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.API.Replays;
+using Quaver.API.Replays.Virtual;
 using Quaver.Server.Client;
 using Quaver.Server.Client.Structures;
 using Quaver.Server.Common.Enums;
@@ -34,18 +32,16 @@ using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
-using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Gameplay;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
 using Quaver.Shared.Screens.Gameplay.UI.Scoreboard;
 using Quaver.Shared.Screens.Loading;
 using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Result.UI;
 using Quaver.Shared.Screens.Select;
 using Wobble;
-using Wobble.Discord;
-using Wobble.Graphics;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
 using Wobble.Logging;
@@ -758,6 +754,66 @@ namespace Quaver.Shared.Screens.Result
             }
 
             ScoreProcessor = self.Processor;
+        }
+
+        /// <summary>
+        ///     Returns the score processor to use. Loads hit stats from a replay if needed.
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public ScoreProcessor GetScoreProcessor()
+        {
+            // Handles the case when watching a replay in its entirety. This uses the preprocessed
+            // ScoreProcessor/Replay from gameplay to get a 100% accurate score output.
+            // Also avoids having to process the replay again (as done below).
+            if (Gameplay != null && Gameplay.InReplayMode)
+            {
+                var im = Gameplay.Ruleset.InputManager as KeysInputManager;
+                return im?.ReplayInputManager.VirtualPlayer.ScoreProcessor;
+            }
+
+            // If we already have stats (for example, this is a result screen right after a player finished playing a map), use them.
+            if (ScoreProcessor.Stats != null)
+                return ScoreProcessor;
+
+            // Otherwise, get the stats from a replay.
+            Replay replay = null;
+
+            // FIXME: unify this logic with watching a replay from a ResultScreen.
+            try
+            {
+                switch (ResultsType)
+                {
+                    case ResultScreenType.Gameplay:
+                    case ResultScreenType.Replay:
+                        replay = Replay;
+                        break;
+                    case ResultScreenType.Score:
+                        // Don't do anything for online replays since they aren't downloaded yet.
+                        if (!Score.IsOnline)
+                            replay = new Replay($"{ConfigManager.DataDirectory.Value}/r/{Score.Id}.qr");
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+            catch (Exception e)
+            {
+                NotificationManager.Show(NotificationLevel.Error, "Unable to read replay file");
+                Logger.Error(e, LogType.Runtime);
+            }
+
+            // Load a replay if we got one.
+            if (replay == null)
+                return ScoreProcessor;
+
+            var qua = Map.LoadQua();
+            qua.ApplyMods(replay.Mods);
+
+            var player = new VirtualReplayPlayer(replay, qua);
+            player.PlayAllFrames();
+
+            return player.ScoreProcessor;
         }
     }
 }

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -204,7 +204,7 @@ namespace Quaver.Shared.Screens.Result.UI
             var unscaledLargestHitWindow = LargestHitWindow / ModHelper.GetRateFromMods(Processor.Mods);
 
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteTextBitmap(FontsBitmap.GothamRegular, $"Late (+{unscaledLargestHitWindow}ms)")
+            new SpriteTextBitmap(FontsBitmap.GothamRegular, $"Late (+{unscaledLargestHitWindow} ms)")
             {
                 Parent = this,
                 X = 4,
@@ -213,7 +213,7 @@ namespace Quaver.Shared.Screens.Result.UI
             };
 
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteTextBitmap(FontsBitmap.GothamRegular, $"Early (-{unscaledLargestHitWindow}ms)")
+            new SpriteTextBitmap(FontsBitmap.GothamRegular, $"Early (-{unscaledLargestHitWindow} ms)")
             {
                 Parent = this,
                 Alignment = Alignment.BotLeft,

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -73,14 +73,14 @@ namespace Quaver.Shared.Screens.Result.UI
         /// <summary>
         /// </summary>
         /// <param name="size"></param>
-        /// <param name="screen"></param>
-        public ResultHitDifferenceGraph(ScalableVector2 size, ResultScreen screen)
+        /// <param name="processor"></param>
+        public ResultHitDifferenceGraph(ScalableVector2 size, ScoreProcessor processor)
         {
             Tint = Color.Black;
             Alpha = 0.2f;
             Size = size;
 
-            Processor = screen.GetScoreProcessor();
+            Processor = processor;
             LargestHitWindow = Processor.JudgementWindow.Values.Max();
 
             CreateMiddleLine();

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -7,26 +7,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Enums;
 using Quaver.API.Helpers;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.API.Maps.Processors.Scoring.Data;
-using Quaver.API.Replays;
-using Quaver.API.Replays.Virtual;
 using Quaver.Shared.Assets;
-using Quaver.Shared.Config;
-using Quaver.Shared.Graphics.Notifications;
-using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
 using Quaver.Shared.Skinning;
-using Wobble;
 using Wobble.Graphics;
-using Wobble.Graphics.Primitives;
 using Wobble.Graphics.Sprites;
-using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.Result.UI
 {
@@ -90,7 +80,7 @@ namespace Quaver.Shared.Screens.Result.UI
             Alpha = 0.2f;
             Size = size;
 
-            Processor = GetScoreProcessor(screen);
+            Processor = screen.GetScoreProcessor();
             LargestHitWindow = Processor.JudgementWindow.Values.Max();
 
             CreateMiddleLine();
@@ -153,67 +143,6 @@ namespace Quaver.Shared.Screens.Result.UI
                         hitDifference * 2, judgement, k * hitDifference, 0, 0));
                 }
             }
-        }
-
-        /// <summary>
-        ///     Returns the score processor to use. Loads hit stats from a replay if needed.
-        /// </summary>
-        /// <param name="screen"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private static ScoreProcessor GetScoreProcessor(ResultScreen screen)
-        {
-            // Handles the case when watching a replay in its entirety. This uses the preprocessed
-            // ScoreProcessor/Replay from gameplay to get a 100% accurate score output.
-            // Also avoids having to process the replay again (as done below).
-            if (screen.Gameplay != null && screen.Gameplay.InReplayMode)
-            {
-                var im = screen.Gameplay.Ruleset.InputManager as KeysInputManager;
-                return im?.ReplayInputManager.VirtualPlayer.ScoreProcessor;
-            }
-
-            // If we already have stats (for example, this is a result screen right after a player finished playing a map), use them.
-            if (screen.ScoreProcessor.Stats != null)
-                return screen.ScoreProcessor;
-
-            // Otherwise, get the stats from a replay.
-            Replay replay = null;
-
-            // FIXME: unify this logic with watching a replay from a ResultScreen.
-            try
-            {
-                switch (screen.ResultsType)
-                {
-                    case ResultScreenType.Gameplay:
-                    case ResultScreenType.Replay:
-                        replay = screen.Replay;
-                        break;
-                    case ResultScreenType.Score:
-                        // Don't do anything for online replays since they aren't downloaded yet.
-                        if (!screen.Score.IsOnline)
-                            replay = new Replay($"{ConfigManager.DataDirectory.Value}/r/{screen.Score.Id}.qr");
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-            }
-            catch (Exception e)
-            {
-                NotificationManager.Show(NotificationLevel.Error, "Unable to read replay file");
-                Logger.Error(e, LogType.Runtime);
-            }
-
-            // Load a replay if we got one.
-            if (replay == null)
-                return screen.ScoreProcessor;
-
-            var qua = ResultScreen.Map.LoadQua();
-            qua.ApplyMods(replay.Mods);
-
-            var player = new VirtualReplayPlayer(replay, qua);
-            player.PlayAllFrames();
-
-            return player.ScoreProcessor;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Maps.Processors.Rating;
+using Quaver.API.Maps.Processors.Scoring;
+using Quaver.API.Maps.Processors.Scoring.Data;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
@@ -90,6 +92,19 @@ namespace Quaver.Shared.Screens.Result.UI
         /// </summary>
         private ResultHitDifferenceGraph HitDifferenceGraphRaw { get; }
 
+        /// <summary>
+        ///     A ScoreProcessor which is more likely to be filled with hit stats than the one in
+        ///     ResultScreen. For example, this one will have stats loaded from a replay.
+        ///
+        ///     TODO: this should really be the ResultScreen processor.
+        /// </summary>
+        private ScoreProcessor Processor { get; }
+
+        /// <summary>
+        ///     Hit statistics computed for the current score.
+        /// </summary>
+        private HitStatistics HitStatistics { get; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -99,6 +114,12 @@ namespace Quaver.Shared.Screens.Result.UI
             Size = new ScalableVector2(WindowManager.Width - 56, 490);
             Image = UserInterface.ResultScorePanel;
             DestroyIfParentIsNull = false;
+            Processor = Screen.GetScoreProcessor();
+
+            if (Processor.Stats != null)
+                HitStatistics = Processor.GetHitStatistics();
+            else
+                HitStatistics = new HitStatistics();
 
             CreateTopHorizontalDividerLine();
             CreateHeaderBackground();

--- a/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
@@ -286,7 +286,7 @@ namespace Quaver.Shared.Screens.Result.UI
             {
                 Parent = this,
                 Y = firstItem.Y + firstItem.TextValue.Y + firstItem.TextValue.Height + 15,
-                Size = new ScalableVector2(VerticalDividerLine.X, 1),
+                Size = new ScalableVector2(Width, 1),
                 Alpha = 0.45f
             };
         }

--- a/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
@@ -132,7 +132,7 @@ namespace Quaver.Shared.Screens.Result.UI
             CreateOnlineStats();
 
             // Create the graph but don't set a constructor, as we need to draw it to a RenderTarget2D
-            HitDifferenceGraphRaw = new ResultHitDifferenceGraph(new ScalableVector2(Width - VerticalDividerLine.X - 30, 200), Screen);
+            HitDifferenceGraphRaw = new ResultHitDifferenceGraph(new ScalableVector2(Width - VerticalDividerLine.X - 30, 200), Processor);
         }
 
         public override void Update(GameTime gameTime)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1794388/61179023-e8caad00-a5ae-11e9-98e9-7f4bb3e6ba1a.png)

Things to consider:
- I would guess that the main button to be used here is the local offset adjustment one, so it might make sense to emphasize it somehow to make it easier to click. Perhaps put the buttons horizontally, below the divider line?
- You want to click only one of these buttons once, and only when your global or local offset equals to that which you used when playing the score. Perhaps we should store the global and local offset used in the score and then base the new offset calculation off of that instead of the current offset? This way it will always set the offset to the correct value.
- Not sure what the best place would be to put `FilterHitStats()`. I think there needs to be some place in `ResultsScreen` where all this data is computed once for all sub-components to use it?
- Maybe "average" sounds better than "mean"?
- "Adjust Map Offset" instead of "Adjust Local Offset"?
- Thinking about it, the LN release judgement window scale should probably _not_ be applied when computing mean and stddev.

Fixes ...uhh, I was sure there were at least 2 issues about this stuff, but I guess not. I believe this offers a better solution than #949 though.