### PR TITLE
Import files passed as commandline arguments in the running instance

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -78,15 +78,24 @@ namespace Quaver.Shared.Database.Maps
         /// </summary>
         internal static void OnFileDropped(object sender, string e)
         {
+            ImportFile(e);
+        }
+
+        /// <summary>
+        ///     Tries to import the given file, be it a map, a replay, a skin, etc.
+        ///     <param name="path">path to the file to import</param>
+        /// </summary>
+        public static void ImportFile(string path)
+        {
             var game = GameBase.Game as QuaverGame;
             var screen = game.CurrentScreen;
 
             // Mapset files
-            if (e.EndsWith(".qp") || e.EndsWith(".osz") || e.EndsWith(".sm"))
+            if (path.EndsWith(".qp") || path.EndsWith(".osz") || path.EndsWith(".sm"))
             {
-                Queue.Add(e);
+                Queue.Add(path);
 
-                var log = $"Scheduled {Path.GetFileName(e)} to be imported!";
+                var log = $"Scheduled {Path.GetFileName(path)} to be imported!";
                 NotificationManager.Show(NotificationLevel.Info, log);
 
                 if (screen.Exiting)
@@ -112,7 +121,7 @@ namespace Quaver.Shared.Database.Maps
                 }
             }
             // Quaver Replay
-            else if (e.EndsWith(".qr"))
+            else if (path.EndsWith(".qr"))
             {
                 try
                 {
@@ -127,7 +136,7 @@ namespace Quaver.Shared.Database.Maps
                             return;
                     }
 
-                    var replay = new Replay(e);
+                    var replay = new Replay(path);
 
                     // Find the map associated with the replay.
                     var mapset = MapManager.Mapsets.Find(x => x.Maps.Any(y => y.Md5Checksum == replay.MapMd5));
@@ -158,26 +167,26 @@ namespace Quaver.Shared.Database.Maps
                 }
             // Skins
             }
-            else if (e.EndsWith(".qs"))
+            else if (path.EndsWith(".qs"))
             {
                 switch (screen.Type)
                 {
                     case QuaverScreenType.Menu:
                     case QuaverScreenType.Results:
                     case QuaverScreenType.Select:
-                        SkinManager.Import(e);
+                        SkinManager.Import(path);
                         break;
                     default:
                         NotificationManager.Show(NotificationLevel.Error, "Please exit this screen before importing a skin");
                         return;
                 }
             }
-            else if (e.EndsWith(".mp3") || e.EndsWith(".ogg"))
+            else if (path.EndsWith(".mp3") || path.EndsWith(".ogg"))
             {
                 switch (screen.Type)
                 {
                     case QuaverScreenType.Select:
-                        EditorScreen.HandleNewMapsetCreation(e);
+                        EditorScreen.HandleNewMapsetCreation(path);
                         break;
                     default:
                         NotificationManager.Show(NotificationLevel.Error, "Go to the song select screen first to create a new mapset!");

--- a/Quaver.Shared/IPC/QuaverIpcHandler.cs
+++ b/Quaver.Shared/IPC/QuaverIpcHandler.cs
@@ -25,12 +25,16 @@ namespace Quaver.Shared.IPC
         {
             Logger.Important($"Received IPC Message: {message}", LogType.Runtime);
 
-            if (!message.StartsWith(protocolUriStarter))
-                return;
+            if (message.StartsWith(protocolUriStarter))
+                HandleProtocolMessage(message.Substring(protocolUriStarter.Length));
+        }
 
-            var regex = new Regex(@"quaver:\/\/");
-            message = regex.Replace(message, "", 1);
-
+        /// <summary>
+        ///     Handles a quaver:// message.
+        ///     <param name="message">the IPC message with quaver:// stripped</param>
+        /// </summary>
+        public static void HandleProtocolMessage(string message)
+        {
             // Highlighting notes within the editor
             if (message.StartsWith("editor/"))
             {

--- a/Quaver.Shared/IPC/QuaverIpcHandler.cs
+++ b/Quaver.Shared/IPC/QuaverIpcHandler.cs
@@ -1,7 +1,9 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Editor;
@@ -27,6 +29,11 @@ namespace Quaver.Shared.IPC
 
             if (message.StartsWith(protocolUriStarter))
                 HandleProtocolMessage(message.Substring(protocolUriStarter.Length));
+            else
+            {
+                // Quaver was launched with a file path, try to import it.
+                MapsetImporter.ImportFile(message);
+            }
         }
 
         /// <summary>

--- a/Quaver/Program.cs
+++ b/Quaver/Program.cs
@@ -54,7 +54,7 @@ namespace Quaver
 
                     // Send to running instance only if we have actual data to send
                     if (args.Length > 0)
-                        SendToRunningInstanceIpc(args[0]);
+                        SendToRunningInstanceIpc(args);
 
                     return;
                 }
@@ -144,13 +144,15 @@ namespace Quaver
         ///     Creates an IPC client and sends a message to the already
         ///     running instance of Quaver
         /// </summary>
-        private static void SendToRunningInstanceIpc(string message)
+        private static void SendToRunningInstanceIpc(string[] messages)
         {
             try
             {
                 var c = new IpcClient();
                 c.Initialize(IpcPort);
-                c.Send(message);
+
+                foreach (var message in messages)
+                    c.Send(message);
             }
             catch (Exception e)
             {

--- a/Quaver/Program.cs
+++ b/Quaver/Program.cs
@@ -154,7 +154,7 @@ namespace Quaver
             }
             catch (Exception e)
             {
-                Logger.Error(e, LogType.Runtime);
+                Console.WriteLine(e.ToString());
             }
         }
     }


### PR DESCRIPTION
https://streamable.com/y7uac

Allows doing stuff like `./Quaver ~/Downloads/new-map.qp`, or `./Quaver ~/Downloads/*.qp`, or even simply double-clicking on `.qp` files if they are properly associated. The next logical step would be to create the `.qp` association, but I'd rather not do it in this PR since it's not very simple and should be done Wobble.