### PR TITLE
Add DrawableMapset, FilterPanelMapInfo Metadata, Bug Fixes & Visual Testing Rich Presence

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -87,5 +87,11 @@ namespace Quaver.Shared.Assets
         public static Texture2D DropdownOpen => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/dropdown-open.png");
         public static Texture2D DropdownBottom => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/dropdown-bottom.png");
         public static Texture2D SearchBox => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/search-box.png");
+        public static Texture2D Keys4Panel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/keys4.png");
+        public static Texture2D Keys7Panel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/keys7.png");
+        public static Texture2D BothModesPanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/both-modes-panel.png");
+        public static Texture2D ModePanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/mode-panel.png");
+        public static Texture2D EditPlayButton => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/edit-play-button.png");
+        public static Texture2D StatusPanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/status-panel.png");
     }
 }

--- a/Quaver.Shared/Config/OrderMapsetsBy.cs
+++ b/Quaver.Shared/Config/OrderMapsetsBy.cs
@@ -13,6 +13,7 @@ namespace Quaver.Shared.Config
         Title,
         Creator,
         DateAdded,
-        Status
+        Status,
+        BPM
     }
 }

--- a/Quaver.Shared/Database/Maps/MapsetHelper.cs
+++ b/Quaver.Shared/Database/Maps/MapsetHelper.cs
@@ -148,10 +148,21 @@ namespace Quaver.Shared.Database.Maps
                     return OrderMapsetsByDateAdded(mapsets);
                 case OrderMapsetsBy.Status:
                     return OrderMapsetsByStatus(mapsets);
+                case OrderMapsetsBy.BPM:
+                    return OrderMapsetsByBpm(mapsets);
                 default:
                     return mapsets.ToList();
             }
         }
+
+        /// <summary>
+        ///     Orders the mapsets by BPM
+        /// </summary>
+        /// <param name="mapsets"></param>
+        /// <returns></returns>
+        private static List<Mapset> OrderMapsetsByBpm(List<Mapset> mapsets)
+            => mapsets.OrderByDescending(x => x.Maps.First().Bpm).ThenBy(x => x.Maps.First().Artist).ThenBy(x => x.Maps.First().Title).ToList();
+
         /// <summary>
         ///     Orders the map's mapsets by date added
         /// </summary>

--- a/Quaver.Shared/Graphics/Containers/PoolableSprite.cs
+++ b/Quaver.Shared/Graphics/Containers/PoolableSprite.cs
@@ -46,7 +46,7 @@ namespace Quaver.Shared.Graphics.Containers
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
-            if (RectangleF.Intersect(ScreenRectangle, Container.ScreenRectangle).IsEmpty)
+            if (Container != null && RectangleF.Intersect(ScreenRectangle, Container.ScreenRectangle).IsEmpty)
                 return;
 
             base.Draw(gameTime);

--- a/Quaver.Shared/Graphics/Menu/Border/Components/DrawableSessionTime.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/DrawableSessionTime.cs
@@ -8,7 +8,7 @@ using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Managers;
 
-namespace Quaver.Shared.Graphics.Menu.Border
+namespace Quaver.Shared.Graphics.Menu.Border.Components
 {
     public class DrawableSessionTime : Sprite, IMenuBorderItem
     {

--- a/Quaver.Shared/Graphics/Menu/Border/Components/IconTextButton.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/IconTextButton.cs
@@ -9,7 +9,7 @@ using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
 
-namespace Quaver.Shared.Graphics.Menu.Border
+namespace Quaver.Shared.Graphics.Menu.Border.Components
 {
     public class IconTextButton : ImageButton
     {

--- a/Quaver.Shared/Graphics/Menu/Border/Components/IconTextButton.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/IconTextButton.cs
@@ -16,12 +16,12 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components
         /// <summary>
         ///     The sprite that displays the icon
         /// </summary>
-        private Sprite Icon { get; }
+        public Sprite Icon { get; }
 
         /// <summary>
         ///     The displayed text
         /// </summary>
-        private SpriteTextPlus Text { get; }
+        public SpriteTextPlus Text { get; }
 
         /// <summary>
         ///     The spacing between the icon and text
@@ -37,6 +37,11 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components
         ///     The color when the button is hovered
         /// </summary>
         private Color HoveredColor { get; }
+
+        /// <summary>
+        ///     If the text tint should be set to the icon's
+        /// </summary>
+        public bool SetTextTint { get; set; } = true;
 
         /// <inheritdoc />
         /// <summary>
@@ -84,9 +89,15 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components
         public override void Update(GameTime gameTime)
         {
             Icon.FadeToColor(IsHovered ? HoveredColor : BaseColor, GameBase.Game.TimeSinceLastFrame, 30);
-            Text.Tint = Icon.Tint;
+
+            if (SetTextTint)
+                Text.Tint = Icon.Tint;
 
             base.Update(gameTime);
+        }
+
+        public override void DrawToSpriteBatch()
+        {
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Menu/Border/Components/MenuBorderLogo.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/MenuBorderLogo.cs
@@ -1,11 +1,8 @@
-using System;
-using Microsoft.Xna.Framework.Graphics;
 using Quaver.Shared.Assets;
-using Wobble.Assets;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Buttons;
 
-namespace Quaver.Shared.Graphics.Menu.Border
+namespace Quaver.Shared.Graphics.Menu.Border.Components
 {
     /// <summary>
     ///     Logo that goes in the left side of a menu header.

--- a/Quaver.Shared/Graphics/Menu/Border/Components/MenuBorderUser.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/MenuBorderUser.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Quaver.Server.Client.Structures;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Assets;
@@ -16,7 +15,7 @@ using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Managers;
 
-namespace Quaver.Shared.Graphics.Menu.Border
+namespace Quaver.Shared.Graphics.Menu.Border.Components
 {
     public class MenuBorderUser : ImageButton, IMenuBorderItem
     {

--- a/Quaver.Shared/Graphics/Menu/Border/DrawableSessionTime.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/DrawableSessionTime.cs
@@ -52,7 +52,8 @@ namespace Quaver.Shared.Graphics.Menu.Border
         public DrawableSessionTime()
         {
             Size = new ScalableVector2(114, 30);
-            Image = UserInterface.SessionTimeBackground;
+            Image = UserInterface.DropdownClosed;
+            Tint = ColorHelper.HexToColor($"#363636");
 
             Clock = TimeSpan.FromMilliseconds(GameBase.Game.TimeRunning);
 

--- a/Quaver.Shared/Graphics/Menu/Border/MenuBorderUser.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/MenuBorderUser.cs
@@ -78,8 +78,8 @@ namespace Quaver.Shared.Graphics.Menu.Border
             CreateUsername();
             UpdateUser();
 
-            Alpha = 0.50f;
-            Tint = Colors.MainAccent;
+            Alpha = 0;
+            Tint = Color.White;
 
             Hovered += OnHover;
             LeftHover += OnHoverLeft;
@@ -98,8 +98,6 @@ namespace Quaver.Shared.Graphics.Menu.Border
                 Image = UserInterface.UnknownAvatar,
                 X = 8
             };
-
-            Avatar.AddBorder(Color.White, 2);
         }
 
         /// <summary>
@@ -139,7 +137,7 @@ namespace Quaver.Shared.Graphics.Menu.Border
         private void OnHover(object sender, EventArgs e)
         {
             SkinManager.Skin?.SoundHover.CreateChannel().Play();
-            
+
             ClearAnimations();
             FadeTo(0.70f, Easing.OutQuint, 300);
         }

--- a/Quaver.Shared/Helpers/ColorHelper.cs
+++ b/Quaver.Shared/Helpers/ColorHelper.cs
@@ -19,15 +19,23 @@ namespace Quaver.Shared.Helpers
         /// <returns></returns>
         internal static Color DifficultyToColor(float rating)
         {
+            // Beginner
+            if (rating < 2)
+                return HexToColor("#5EFFEE");
             // Easy
-            if (rating < 15)
-                return Color.Green;
-            // Medium
-            if (rating < 30)
-                return new Color(255, 255, 0);
-
+            if (rating < 5)
+                return HexToColor("#5EFF75");
+            // Normal
+            if (rating < 10)
+                return HexToColor("#5EC4FF");
             // Hard
-            return new Color(255, 0, 0);
+            if (rating < 20)
+                return HexToColor("#F5B25B");
+            // Insane
+            if (rating < 30)
+                return HexToColor("#F9645D");
+            // Expert
+            return HexToColor("#9B51E0");
         }
 
         /// <summary>

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -121,6 +121,17 @@ namespace Quaver.Shared
         /// </summary>
         private Type LastVisualTestScreenType { get; set; }
 
+        /// <summary>
+        /// </summary>
+        private Dictionary<string, Type> VisualTests { get; } = new Dictionary<string, Type>()
+        {
+            {"Dropdown", typeof(DropdownTestScreen)},
+            {"MenuBorder", typeof(MenuBorderTestScreen)},
+            {"SelectFilterPanel", typeof(FilterPanelTestScreen)},
+            {"SelectJukebox", typeof(TestSelectJukeboxScreen)},
+            {"DrawableMapset", typeof(TestMapsetScreen)}
+        };
+
         public QuaverGame(HotLoader hl) : base(hl)
 #else
         public QuaverGame()
@@ -320,8 +331,8 @@ namespace Quaver.Shared
 
 #if VISUAL_TESTS
             DiscordHelper.Presence.StartTimestamp = (long) (TimeHelper.GetUnixTimestampMilliseconds() / 1000);
+            DiscordHelper.Presence.State = "Visual Testing";
 #endif
-
             DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
 
             // Create bindable for selected map.
@@ -532,14 +543,7 @@ namespace Quaver.Shared
         }
 
 #if VISUAL_TESTS
-        protected override HotLoaderScreen InitializeHotLoaderScreen() => new HotLoaderScreen(new Dictionary<string, Type>()
-        {
-            {"Dropdowns", typeof(DropdownTestScreen)},
-            {"Menu Border", typeof(MenuBorderTestScreen)},
-            {"Select Filter Panel", typeof(FilterPanelTestScreen)},
-            {"Select Jukebox", typeof(TestSelectJukeboxScreen)},
-            {"Mapsets (Individual)", typeof(TestMapsetScreen)}
-        });
+        protected override HotLoaderScreen InitializeHotLoaderScreen() => new HotLoaderScreen(VisualTests);
 
         private void SetVisualTestingPresence()
         {
@@ -554,15 +558,9 @@ namespace Quaver.Shared
 
             if (LastVisualTestScreenType == null || LastVisualTestScreenType != type)
             {
-                var str = type.ToString();
+                var val = VisualTests.FirstOrDefault(x => x.Value.ToString() == type.ToString()).Key;
 
-                int index = str.LastIndexOf(".");
-
-                if (index > 0)
-                    str = str.Substring(index + 1);
-
-                DiscordHelper.Presence.Details = str;
-                DiscordHelper.Presence.State = "Visual Testing";
+                DiscordHelper.Presence.Details = val;
                 DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
             }
 

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -39,6 +39,7 @@ using Quaver.Shared.Screens.Tests.Border;
 using Quaver.Shared.Screens.Tests.Dropdowns;
 using Quaver.Shared.Screens.Tests.FilterPanel;
 using Quaver.Shared.Screens.Tests.Jukebox;
+using Quaver.Shared.Screens.Tests.Mapsets;
 using Quaver.Shared.Skinning;
 using Steamworks;
 using Wobble;
@@ -522,7 +523,8 @@ namespace Quaver.Shared
             {"Dropdowns", typeof(DropdownTestScreen)},
             {"Menu Border", typeof(MenuBorderTestScreen)},
             {"Select Filter Panel", typeof(FilterPanelTestScreen)},
-            {"Select Jukebox", typeof(TestSelectJukeboxScreen)}
+            {"Select Jukebox", typeof(TestSelectJukeboxScreen)},
+            {"Mapsets (Individual)", typeof(TestMapsetScreen)}
         });
 #endif
     }

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/Dropdowns/FilterDropdownSorting.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/Dropdowns/FilterDropdownSorting.cs
@@ -44,7 +44,8 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.Dropdowns
             "Title",
             "Creator",
             "Date Added",
-            "Status"
+            "Status",
+            "BPM"
         };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/FilterPanelBanner.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/FilterPanelBanner.cs
@@ -130,6 +130,9 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
         /// <param name="e"></param>
         private void OnBackgroundLoaded(object sender, BackgroundLoadedEventArgs e)
         {
+            if (MapManager.Selected?.Value != e.Map)
+                return;
+
             Background.Image = e.Texture;
             FadeIn();
         }

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/FilterPanelMapInfo.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/FilterPanelMapInfo.cs
@@ -1,7 +1,11 @@
+using Microsoft.Xna.Framework.Media;
 using Quaver.API.Helpers;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -15,17 +19,32 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
         /// <summary>
         ///     Displays the title of the song
         /// </summary>
-        private SpriteTextPlus Title { get; set; }
-
-        /// <summary>
-        ///     Displays the artist of the song
-        /// </summary>
-        private SpriteTextPlus Artist { get; set; }
+        private SpriteTextPlus ArtistTitle { get; set; }
 
         /// <summary>
         ///     Displays the difficulty and mods
         /// </summary>
         private SpriteTextPlus DifficultyMods { get; set; }
+
+        /// <summary>
+        ///     Displays the game mode of the current map
+        /// </summary>
+        private FilterMetadataGameMode GameMode { get; set; }
+
+        /// <summary>
+        ///     Displays the length of the map
+        /// </summary>
+        private FilterMetadataLength Length { get; set; }
+
+        /// <summary>
+        ///     Displays the BPM of the map
+        /// </summary>
+        private FilterMetadataBpm Bpm { get; set; }
+
+        /// <summary>
+        ///     Displays the LN% of the map
+        /// </summary>
+        private FilterMetadataLongNotePercentage LongNotePercentage { get; set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -35,9 +54,9 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
             Alpha = 0f;
             InputEnabled = false;
 
-            CreateTitleText();
-            CreateArtistText();
+            CreateArtistTitleText();
             CreateDifficultyModsText();
+            CreateMetadata();
 
             UpdateText(MapManager.Selected.Value);
 
@@ -60,24 +79,11 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
         /// <summary>
         ///     Creates the text that displays the title of the song
         /// </summary>
-        private void CreateTitleText()
+        private void CreateArtistTitleText()
         {
-            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "Title", 22);
+            ArtistTitle = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "Artist - Title", 20);
 
-            AddContainedDrawable(Title);
-        }
-
-        /// <summary>
-        ///     Creates the text that displays the song artist
-        /// </summary>
-        private void CreateArtistText()
-        {
-            Artist = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "Artist", 22)
-            {
-                Y = Title.Height + 3,
-            };
-
-            AddContainedDrawable(Artist);
+            AddContainedDrawable(ArtistTitle);
         }
 
         /// <summary>
@@ -87,10 +93,41 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
         {
             DifficultyMods = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "[Difficulty] + Mods", 20)
             {
-                Y = Artist.Y + Artist.Height + 3
+                Y = ArtistTitle.Height + 6,
             };
 
             AddContainedDrawable(DifficultyMods);
+        }
+
+        private void CreateMetadata()
+        {
+            GameMode = new FilterMetadataGameMode
+            {
+                Parent = this,
+                Y = DifficultyMods.Y + DifficultyMods.Height + 6,
+                X = ArtistTitle.X
+            };
+
+            Length = new FilterMetadataLength
+            {
+                Parent = this,
+                Y = GameMode.Y,
+                X = GameMode.X + GameMode.Width + 35
+            };
+
+            Bpm = new FilterMetadataBpm
+            {
+                Parent = this,
+                Y = GameMode.Y,
+                X = Length.X + Length.Width + 35
+            };
+
+            LongNotePercentage = new FilterMetadataLongNotePercentage()
+            {
+                Parent = this,
+                Y = GameMode.Y,
+                X = Bpm.X + Bpm.Width + 35
+            };
         }
 
         /// <summary>
@@ -102,18 +139,14 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
             if (map == null)
                 return;
 
-            Title.Text = map.Title;
-            Artist.Text = map.Artist;
+            ArtistTitle.Text = map.Artist + " - " + map.Title;
 
             var mods = ModManager.CurrentModifiersList.Count > 0 ? $" + {ModHelper.GetModsString(ModManager.Mods)}": "";
             DifficultyMods.Text = $"[{map.DifficultyName}]{mods}";
 
             //  Reset positions of the text
-            Title.ClearAnimations();
-            Title.X = 0;
-
-            Artist.ClearAnimations();
-            Artist.X = 0;
+            ArtistTitle.ClearAnimations();
+            ArtistTitle.X = 0;
 
             DifficultyMods.ClearAnimations();
             DifficultyMods.X = 0;

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/FilterPanelMapInfo.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/FilterPanelMapInfo.cs
@@ -101,6 +101,8 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
 
         private void CreateMetadata()
         {
+            const int spacing = 25;
+
             GameMode = new FilterMetadataGameMode
             {
                 Parent = this,
@@ -112,21 +114,21 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation
             {
                 Parent = this,
                 Y = GameMode.Y,
-                X = GameMode.X + GameMode.Width + 35
+                X = GameMode.X + GameMode.Width + 25
             };
 
             Bpm = new FilterMetadataBpm
             {
                 Parent = this,
                 Y = GameMode.Y,
-                X = Length.X + Length.Width + 35
+                X = Length.X + Length.Width + 25
             };
 
             LongNotePercentage = new FilterMetadataLongNotePercentage()
             {
                 Parent = this,
                 Y = GameMode.Y,
-                X = Bpm.X + Bpm.Width + 35
+                X = Bpm.X + Bpm.Width + 25
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataBpm.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataBpm.cs
@@ -1,0 +1,40 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
+{
+    public class FilterMetadataBpm : TextKeyValue
+    {
+        public FilterMetadataBpm() : base("BPM:", "000", 20, ColorHelper.HexToColor($"#ffe76b"))
+        {
+            if (MapManager.Selected.Value != null)
+                Value.Text = $"{GetBpm()}";
+
+            ModManager.ModsChanged += OnModsChanged;
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+            ModManager.ModsChanged -= OnModsChanged;
+
+            base.Destroy();
+        }
+
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+            => Value.Text = GetBpm().ToString();
+
+        private void OnModsChanged(object sender, ModsChangedEventArgs e) => Value.Text = GetBpm().ToString();
+
+        private int GetBpm() => (int) (MapManager.Selected.Value.Bpm * ModHelper.GetRateFromMods(ModManager.Mods));
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataGameMode.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataGameMode.cs
@@ -1,0 +1,34 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
+{
+    public class FilterMetadataGameMode : TextKeyValue
+    {
+        public FilterMetadataGameMode() : base("Mode:", "0K", 20, ColorHelper.HexToColor($"#ffe76b"))
+        {
+            if (MapManager.Selected.Value != null)
+                Value.Text = ModeHelper.ToShortHand(MapManager.Selected.Value.Mode);
+
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+
+            base.Destroy();
+        }
+
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+            => Value.Text = ModeHelper.ToShortHand(MapManager.Selected.Value.Mode);
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataLength.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataLength.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
+{
+    public class FilterMetadataLength : TextKeyValue
+    {
+        public FilterMetadataLength() : base("Length:", "00:00", 20, ColorHelper.HexToColor($"#ffe76b"))
+        {
+            if (MapManager.Selected.Value != null)
+                Value.Text = $"{GetLength()}";
+
+            ModManager.ModsChanged += OnModsChanged;
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+            ModManager.ModsChanged -= OnModsChanged;
+
+            base.Destroy();
+        }
+
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+            => Value.Text = GetLength();
+
+        private void OnModsChanged(object sender, ModsChangedEventArgs e) => Value.Text = GetLength();
+
+        private string GetLength()
+        {
+            var length = TimeSpan.FromMilliseconds(MapManager.Selected.Value.SongLength / ModHelper.GetRateFromMods(ModManager.Mods));
+            return length.Hours > 0 ? length.ToString(@"hh\:mm\:ss") : length.ToString(@"mm\:ss");
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataLongNotePercentage.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataLongNotePercentage.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Globalization;
+using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
+{
+    public class FilterMetadataLongNotePercentage : TextKeyValue
+    {
+        public FilterMetadataLongNotePercentage() : base("LN%", "100%", 20, ColorHelper.HexToColor($"#ffe76b"))
+        {
+            if (MapManager.Selected.Value != null)
+                Value.Text = $"{GetPercentage()}";
+
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+
+            base.Destroy();
+        }
+
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+            => Value.Text = GetPercentage();
+
+        private string GetPercentage() => ((int) MapManager.Selected.Value.LNPercentage).ToString(CultureInfo.InvariantCulture) + "%";
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
@@ -1,0 +1,72 @@
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
+{
+    public class TextKeyValue : Container
+    {
+        /// <summary>
+        ///     Displays the key of the metadata
+        /// </summary>
+        protected SpriteTextPlus Key { get; private set; }
+
+        /// <summary>
+        ///     Displays the value of the metadata
+        /// </summary>
+        protected SpriteTextPlus Value { get; private set; }
+
+        /// <summary>
+        ///     The size of the font
+        /// </summary>
+        private int FontSize { get; }
+
+        /// <summary>
+        ///     The color of the key
+        /// </summary>
+        private Color KeyColor { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="fontSize"></param>
+        /// <param name="keyColor"></param>
+        public TextKeyValue(string key, string value, int fontSize, Color keyColor)
+        {
+            FontSize = fontSize;
+            KeyColor = keyColor;
+
+            CreateKey(key);
+            CreateValue(value);
+
+            Size = new ScalableVector2(Key.Width + Value.Width + 6, Key.Height);
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Key"/>
+        /// </summary>
+        private void CreateKey(string key)
+        {
+            Key = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), key, FontSize)
+            {
+                Parent = this,
+            };
+        }
+
+        /// <summary>
+        ///      Creases <see cref="Value"/>
+        /// </summary>
+        private void CreateValue(string value)
+        {
+            Value = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), value, FontSize)
+            {
+                Parent = this,
+                X = Key.Width  + 6,
+                Tint = KeyColor
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMap.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMap.cs
@@ -1,19 +1,26 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Menu;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
+using Wobble;
+using Wobble.Assets;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 {
-    public class DrawableMap : Sprite, IDrawableMapsetComponent
+    public class DrawableMap : ImageButton, IDrawableMapsetComponent, IDrawableMapMetadata
     {
         /// <summary>
         ///     The parent drawable mapset
@@ -38,12 +45,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// <summary>
         ///     The height when the map is selected
         /// </summary>
-        public static int SelectedHeight { get; } = 84;
+        public static int SelectedHeight { get; } = 90;
 
         /// <summary>
         ///     The height when the map is deselected
         /// </summary>
-        public static int DeselectedHeight { get; } = 41;
+        public static int DeselectedHeight { get; } = 50;
 
         /// <summary>
         ///     Displays the name of the difficulty
@@ -51,12 +58,17 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         private SpriteTextPlus Difficulty { get; set; }
 
         /// <summary>
+        ///     Displays all the metadata for the map
+        /// </summary>
+        private DrawableMapMetadataContainer MetadataContainer { get; set; }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="drawableMapset"></param>
         /// <param name="map"></param>
         /// <param name="index"></param>
-        public DrawableMap(DrawableMapset drawableMapset, Map map, int index)
+        public DrawableMap(DrawableMapset drawableMapset, Map map, int index) : base(WobbleAssets.WhiteBox)
         {
             Parent = DrawableMapset;
             DrawableMapset = drawableMapset;
@@ -68,9 +80,23 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             SetSize(false);
             SetTint();
             CreateTextDifficulty();
+            CreateMetadataContainer();
 
             UpdateContent(Map, Index);
             MapManager.Selected.ValueChanged += OnMapChanged;
+            Clicked += OnMapClicked;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            IsClickable = DrawableMapset.IsSelected;
+            HandleHoverAnimation(gameTime);
+
+            base.Update(gameTime);
         }
 
         /// <inheritdoc />
@@ -117,33 +143,57 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         /// <summary>
+        ///     Creases <see cref="MetadataContainer"/>
+        /// </summary>
+        private void CreateMetadataContainer()
+        {
+            MetadataContainer = new DrawableMapMetadataContainer(this, new List<DrawableMapMetadata>
+            {
+                new DrawableMapMetadataDifficulty(Map),
+                new DrawableMapMetadataDifficulty(Map),
+                new DrawableMapMetadataDifficulty(Map),
+                new DrawableMapMetadataDifficulty(Map),
+                new DrawableMapMetadataDifficulty(Map)
+            });
+        }
+
+        /// <summary>
         /// </summary>
         public void Open()
         {
             ClearAnimations();
 
+            // Make the entire sprite visible and fade in the background
             Wait(200);
             FadeTo(1, Easing.Linear, 250);
             Visible = true;
 
+            // Fade in difficulty text
             Difficulty.ClearAnimations();
             Difficulty.Wait(200);
             Difficulty.FadeTo(1, Easing.Linear, 250);
+
+            MetadataContainer.Open();
         }
 
         /// <summary>
         /// </summary>
         public void Close()
         {
-            Width = DrawableMapset.Width - DrawableMapset.Border.Thickness * 2;
-
+            // Make sure the sizes are all up-to-date since we're now closing it
             SetSize(true);
-            ClearAnimations();
-            FadeTo(0, Easing.OutQuint, 1);
 
-            Difficulty.ClearAnimations();
+            // Fade to 0 instantly and make it invisible
+            ClearAnimations();
+            Alpha = 0;
             Visible = false;
-            Difficulty.FadeTo(0, Easing.OutQuint, 1);
+
+            // Make difficulty text invisible
+            Difficulty.ClearAnimations();
+            Difficulty.Alpha = 0;
+            Difficulty.Visible = false;
+
+            MetadataContainer.Close();
         }
 
         /// <inheritdoc />
@@ -151,7 +201,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Select()
         {
-
+            Tint = ColorHelper.HexToColor("#293943");
         }
 
         /// <inheritdoc />
@@ -159,10 +209,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Deselect()
         {
+            if (!IsHovered)
+                Tint = GetDefaultcolor();
         }
 
         /// <summary>
-        ///     Sets the size of the map
+        ///     Sets the size of the map.
+        ///
+        ///     The selected map will have a different height to deselected ones.
         /// </summary>
         public void SetSize(bool animate)
         {
@@ -178,18 +232,68 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         /// <summary>
-        ///     Sets the tint of the map based on its index
+        ///     Sets the tint of the map based on its index (Light, Dark, Light, Dark, etc...)
         /// </summary>
-        private void SetTint() => Tint = Index % 2 == 0 ? ColorHelper.HexToColor("#363636") : ColorHelper.HexToColor("#242424");
+        private void SetTint() => Tint = GetDefaultcolor();
 
         /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private Color GetDefaultcolor() => Index % 2 == 0 ? ColorHelper.HexToColor("#363636") : ColorHelper.HexToColor("#242424");
+
+        /// <summary>
+        ///     Called when a new map has changed
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
         {
+            // Update the size of the map, so that it is up-to-date and aligned properly.
             SetSize(true);
-            DrawableMapset.RealignY();
+
+            if (MapManager.Selected.Value == Map)
+                Select();
+            else
+                Deselect();
+        }
+
+        /// <summary>
+        ///     Called when the map has been clicked.
+        ///
+        ///     Either changes the map, or goes to play
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnMapClicked(object sender, EventArgs e)
+        {
+            if (MapManager.Selected.Value == Map)
+            {
+                Logger.Important($"User clicked on DrawableMap: {Map}. Heading to gameplay", LogType.Runtime, false);
+                return;
+            }
+
+            MapManager.Selected.Value = Map;
+            Logger.Important($"User selected DrawableMap: {Map}", LogType.Runtime, false);
+        }
+
+        /// <summary>
+        ///     Performs an animation when hovering over the map
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void HandleHoverAnimation(GameTime gameTime)
+        {
+            if (IsSelected)
+                return;
+
+            Color targetColor;
+
+            if (IsHovered)
+                // targetColor = Index % 2 == 0 ? ColorHelper.HexToColor("#3F3F3F") : ColorHelper.HexToColor("#4D4D4D");
+                targetColor = ColorHelper.HexToColor("#4D4D4D");
+            else
+                targetColor = GetDefaultcolor();
+
+            FadeToColor(targetColor, GameBase.Game.TimeSinceLastFrame, 60);
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMap.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMap.cs
@@ -1,0 +1,195 @@
+using System;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class DrawableMap : Sprite, IDrawableMapsetComponent
+    {
+        /// <summary>
+        ///     The parent drawable mapset
+        /// </summary>
+        private DrawableMapset DrawableMapset { get; }
+
+        /// <summary>
+        ///     The map this represents
+        /// </summary>
+        private Map Map { get; set; }
+
+        /// <summary>
+        ///     The index this map is in the mapset
+        /// </summary>
+        private int Index { get; set; }
+
+        /// <summary>
+        ///     Dictates if the map is selected
+        /// </summary>
+        private bool IsSelected => MapManager.Selected?.Value == Map;
+
+        /// <summary>
+        ///     The height when the map is selected
+        /// </summary>
+        public static int SelectedHeight { get; } = 84;
+
+        /// <summary>
+        ///     The height when the map is deselected
+        /// </summary>
+        public static int DeselectedHeight { get; } = 41;
+
+        /// <summary>
+        ///     Displays the name of the difficulty
+        /// </summary>
+        private SpriteTextPlus Difficulty { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="drawableMapset"></param>
+        /// <param name="map"></param>
+        /// <param name="index"></param>
+        public DrawableMap(DrawableMapset drawableMapset, Map map, int index)
+        {
+            Parent = DrawableMapset;
+            DrawableMapset = drawableMapset;
+            Map = map;
+            Index = index;
+
+            Alpha = 0;
+            SetChildrenVisibility = true;
+            SetSize(false);
+            SetTint();
+            CreateTextDifficulty();
+
+            UpdateContent(Map, Index);
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="index"></param>
+        public void UpdateContent(Map map, int index)
+        {
+            Map = map;
+            Index = index;
+
+            Alpha = IsSelected ? 1 : 0;
+            SetTint();
+
+            Difficulty.Text = Map.DifficultyName;
+            Difficulty.Tint = ColorHelper.DifficultyToColor((float) Map.DifficultyFromMods(ModManager.Mods));
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Difficulty"/>
+        /// </summary>
+        private void CreateTextDifficulty()
+        {
+            Difficulty = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoHeavy), "Difficulty", 22)
+            {
+                Parent = this,
+                Alignment = Alignment.MidLeft,
+                X = 15,
+                Visible = false,
+                Alpha = 0,
+                SetChildrenAlpha = true
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Open()
+        {
+            ClearAnimations();
+
+            Wait(200);
+            FadeTo(1, Easing.Linear, 250);
+            Visible = true;
+
+            Difficulty.ClearAnimations();
+            Difficulty.Wait(200);
+            Difficulty.FadeTo(1, Easing.Linear, 250);
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Close()
+        {
+            Width = DrawableMapset.Width - DrawableMapset.Border.Thickness * 2;
+
+            SetSize(true);
+            ClearAnimations();
+            FadeTo(0, Easing.OutQuint, 1);
+
+            Difficulty.ClearAnimations();
+            Visible = false;
+            Difficulty.FadeTo(0, Easing.OutQuint, 1);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Select()
+        {
+
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Deselect()
+        {
+        }
+
+        /// <summary>
+        ///     Sets the size of the map
+        /// </summary>
+        public void SetSize(bool animate)
+        {
+            var width = DrawableMapset.Width - DrawableMapset.Border.Thickness * 2;
+            var height = IsSelected ? SelectedHeight - DrawableMapset.Border.Thickness - 1 : DeselectedHeight;
+
+            var size = new ScalableVector2(width, height);
+
+            if (animate)
+                ChangeSizeTo(new Vector2(width, height), Easing.OutQuint, 300);
+            else
+                Size = size;
+        }
+
+        /// <summary>
+        ///     Sets the tint of the map based on its index
+        /// </summary>
+        private void SetTint() => Tint = Index % 2 == 0 ? ColorHelper.HexToColor("#363636") : ColorHelper.HexToColor("#242424");
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+        {
+            SetSize(true);
+            DrawableMapset.RealignY();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadata.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadata.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using MonoGame.Extended.BitmapFonts;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Menu;
+using Quaver.Shared.Graphics.Menu.Border.Components;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class DrawableMapMetadata : IconTextButton, IDrawableMapMetadata
+    {
+        /// <summary>
+        /// </summary>
+        protected Map Map { get; }
+
+        /// <summary>
+        /// </summary>
+        private bool IsOpening { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="icon"></param>
+        public DrawableMapMetadata(Map map, Texture2D icon) : base(icon, FontManager.GetWobbleFont(Fonts.LatoBlack), "00:00")
+        {
+            Map = map;
+            IsClickable = false;
+
+            Icon.Alpha = 0;
+
+            Text.Visible = false;
+            Icon.Visible = false;
+            SetTextTint = false;
+
+            Text.SetChildrenAlpha = true;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            if (Text.Animations.Count == 0)
+                Text.Alpha = MathHelper.Lerp(Text.Alpha, IsOpening ? 1 : 0, (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 60, 1));
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Open()
+        {
+            IsOpening = true;
+
+            Icon.ClearAnimations();
+            Icon.Visible = true;
+            Icon.Wait(200);
+            Icon.FadeTo(1, Easing.Linear, 250);
+
+            Text.Visible = true;
+            Text.Wait(200);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Close()
+        {
+            IsOpening = false;
+
+            // Make difficulty text invisible
+            ClearAnimations();
+
+            Text.Visible = false;
+            Text.ClearAnimations();
+            Text.Alpha = 0;
+
+            Icon.ClearAnimations();
+            Icon.Visible = false;
+            Icon.Alpha = 0;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadataContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadataContainer.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class DrawableMapMetadataContainer : IDrawableMapMetadata
+    {
+        /// <summary>
+        /// </summary>
+        private List<DrawableMapMetadata> Metadata { get; }
+
+        /// <summary>
+        /// </summary>
+        public DrawableMapMetadataContainer(Drawable parent, List<DrawableMapMetadata> metadata)
+        {
+            Metadata = metadata;
+
+            for (var i = 0; i < Metadata.Count; i++)
+            {
+                var m = Metadata[i];
+                m.Parent = parent;
+                m.Alignment = Alignment.MidRight;
+                m.X = -100 * i - 18;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Open() => Metadata.ForEach(x => x.Open());
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Close() => Metadata.ForEach(x => x.Close());
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadataDifficulty.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapMetadataDifficulty.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class DrawableMapMetadataDifficulty : DrawableMapMetadata
+    {
+        public DrawableMapMetadataDifficulty(Map map) : base(map, FontAwesome.Get(FontAwesomeIcon.fa_stethoscope))
+        {
+            UpdateText();
+            ModManager.ModsChanged += OnModsChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            ModManager.ModsChanged -= OnModsChanged;
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void UpdateText()
+        {
+            var rating = Map.DifficultyFromMods(ModManager.Mods);
+
+            Text.Text = StringHelper.RatingToString(rating);
+            Text.Tint = ColorHelper.DifficultyToColor((float) rating);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnModsChanged(object sender, ModsChangedEventArgs e) => UpdateText();
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Enums;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Containers;
+using Quaver.Shared.Helpers;
+using Wobble.Assets;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Input;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public sealed class DrawableMapset : PoolableSprite<Mapset>
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override int HEIGHT { get; } = 86;
+
+        /// <summary>
+        ///     Contains the actual mapset
+        /// </summary>
+        private DrawableMapsetContainer DrawableContainer { get; }
+
+        /// <summary>
+        ///     If this mapset is currently selected
+        /// </summary>
+        public bool IsSelected { get; private set; }
+
+        /// <summary>
+        ///     The maps that are in the set
+        /// </summary>
+        private List<DrawableMap> Maps { get; set; } = new List<DrawableMap>();
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public DrawableMapset(PoolableScrollContainer<Mapset> container, Mapset item, int index) : base(container, item, index)
+        {
+            Size = new ScalableVector2(1188, HEIGHT);
+            DrawableContainer = new DrawableMapsetContainer(this) {Parent = this};
+
+            Alpha = 0;
+            AddBorder(ColorHelper.HexToColor("#0587e5"), 2);
+            UpdateContent(item, index);
+
+            MapManager.Selected.ValueChanged += OnMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            HandleInput();
+
+            if (IsSelected)
+                RealignY();
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+
+            base.Destroy();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public override void UpdateContent(Mapset item, int index)
+        {
+            if (IsSelected)
+                Select();
+            else
+                Deselect();
+
+            DrawableContainer.UpdateContent(item, index);
+
+            Maps?.ForEach(x=> x.Destroy());
+            Maps = new List<DrawableMap>();
+
+            for (var i = 0; i < Item.Maps.Count; i++)
+            {
+                float height = HEIGHT;
+
+                if (i != 0)
+                    height = Maps[i - 1].Height + Maps[i - 1].Y;
+
+                Maps.Add(new DrawableMap(this, Item.Maps[i], i)
+                {
+                    Parent = this,
+                    Y = height,
+                    Alignment = Alignment.TopCenter
+                });
+            }
+        }
+
+        /// <summary>
+        ///     Selects the mapset
+        /// </summary>
+        public void Select()
+        {
+            IsSelected = true;
+
+            var total = DrawableMap.SelectedHeight + DrawableMap.DeselectedHeight * (Item.Maps.Count - 1) + HEIGHT;
+            ChangeHeightTo(total, Easing.OutQuint, 500);
+
+            Maps.ForEach(x => x.Open());
+        }
+
+        /// <summary>
+        ///     Deselects the mapset
+        /// </summary>
+        public void Deselect()
+        {
+            IsSelected = false;
+
+            ChangeHeightTo(HEIGHT, Easing.OutQuint, 500);
+
+            Maps.ForEach(x => x.Close());
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleInput()
+        {
+            if (!IsSelected)
+                return;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Up))
+            {
+                var mapIndex = Item.Maps.FindIndex(x => x == MapManager.Selected.Value);
+
+                if (mapIndex - 1 < 0)
+                    return;
+
+                MapManager.Selected.Value = Item.Maps[mapIndex - 1];
+            }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Down))
+            {
+                var mapIndex = Item.Maps.FindIndex(x => x == MapManager.Selected.Value);
+
+                if (mapIndex + 1 > Item.Maps.Count - 1)
+                    return;
+
+                MapManager.Selected.Value = Item.Maps[mapIndex + 1];
+            }
+        }
+
+        /// <summary>
+        ///     Realigns all the maps to the correct height
+        /// </summary>
+        public void RealignY()
+        {
+            for (var i = 0; i < Item.Maps.Count; i++)
+            {
+                float height = HEIGHT;
+
+                if (i != 0)
+                    height = Maps[i - 1].Height + Maps[i - 1].Y;
+
+                Maps[i].Y = height;
+            }
+        }
+
+        /// <summary>
+        ///     Handles opening/closing the mapset when the map has changed
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+        {
+            if (!Item.Maps.Contains(e.Value))
+                Deselect();
+            else if (!IsSelected)
+            {
+                Select();
+                Maps.ForEach(x => x.SetSize(false));
+            }
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
@@ -93,16 +93,21 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// <param name="index"></param>
         public override void UpdateContent(Mapset item, int index)
         {
+            // Make sure the mapset is properly selected/deselected when updating the content
             if (IsSelected)
                 Select();
             else
                 Deselect();
 
+            // Update all the values in the mapset
             DrawableContainer.UpdateContent(item, index);
 
+            // If any mapsets exist currently, then dispose of them properly
             Maps?.ForEach(x=> x.Destroy());
+
             Maps = new List<DrawableMap>();
 
+            // Add new mapsets
             for (var i = 0; i < Item.Maps.Count; i++)
             {
                 float height = HEIGHT;
@@ -120,7 +125,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         /// <summary>
-        ///     Selects the mapset
+        ///     Selects the mapset and performs an animation
+        ///
+        ///     TODO: Add argument to change size immediately.
         /// </summary>
         public void Select()
         {
@@ -133,7 +140,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         /// <summary>
-        ///     Deselects the mapset
+        ///     Deselects the mapset and performs an animation
+        ///
+        ///     TODO: Add argument to change size immediately.
         /// </summary>
         public void Deselect()
         {

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Enums;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using TagLib.Ape;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class DrawableMapsetContainer : Sprite, IDrawableMapsetComponent
+    {
+        /// <summary>
+        ///     The parent mapset
+        /// </summary>
+        public DrawableMapset ParentMapset { get; }
+
+        /// <summary>
+        ///     The button/clickable area of the mapset
+        /// </summary>
+        private ImageButton Button { get; set; }
+
+        /// <summary>
+        ///     Displays the map background/banner for the mapset
+        /// </summary>
+        private Sprite Banner { get; set; }
+
+        /// <summary>
+        ///     The title of the map
+        /// </summary>
+        private SpriteTextPlus Title { get; set; }
+
+        /// <summary>
+        ///     Displays the artist of the song
+        /// </summary>
+        private SpriteTextPlus Artist { get; set; }
+
+        /// <summary>
+        ///     The divider line between <see cref="Artist"/> and <see cref="Creator"/>
+        /// </summary>
+        private SpriteTextPlus DividerLine { get; set; }
+
+        /// <summary>
+        ///    Displays the creator of the map
+        /// </summary>
+        private SpriteTextPlus Creator { get; set; }
+
+        /// <summary>
+        ///     The amount of x axis spacing between the artist and creator
+        /// </summary>
+        private const int ArtistCreatorSpacingX = 4;
+
+        /// <summary>
+        ///     The ranked status of the map
+        /// </summary>
+        private Sprite RankedStatusSprite { get; set; }
+
+        /// <summary>
+        ///     The game modes the mapset has
+        /// </summary>
+        private Sprite GameModes { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus ByText { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="mapset"></param>
+        public DrawableMapsetContainer(DrawableMapset mapset)
+        {
+            ParentMapset = mapset;
+            Parent = ParentMapset;
+
+            Size = new ScalableVector2(1188, ParentMapset.HEIGHT);
+            Tint = ColorHelper.HexToColor("#242424");
+            AddBorder(ColorHelper.HexToColor("#0587e5"), 2);
+
+            CreateButton();
+            CreateTitle();
+            CreateArtist();
+            CreateDividerLine();
+            CreateCreator();
+            CreateBannerImage();
+            CreateRankedStatus();
+            CreateGameModes();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            PerformHoverAnimation(gameTime);
+            base.Update(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public void UpdateContent(Mapset item, int index)
+        {
+            Title.Text = item.Title.ToUpper();
+            Artist.Text = $"{item.Artist}";
+            Creator.Text = $"{item.Creator}";
+
+            DividerLine.X = Artist.X + Artist.Width + ArtistCreatorSpacingX;
+            ByText.X = DividerLine.X + DividerLine.Width + ArtistCreatorSpacingX;
+            Creator.X = ByText.X + ByText.Width + ArtistCreatorSpacingX;
+
+            RankedStatusSprite.Image = GetRankedStatusImage();
+            GameModes.Image = GetGameModeImage();
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Button"/>
+        /// </summary>
+        private void CreateButton()
+        {
+            Button = new ImageButton(WobbleAssets.WhiteBox)
+            {
+                Parent = this,
+                Size = Size,
+                Alpha = 0,
+                Alignment = Alignment.MidCenter
+            };
+        }
+
+        /// <summary>
+        ///    Creates <see cref="Banner"/>
+        /// </summary>
+        private void CreateBannerImage()
+        {
+            Banner = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(421, 82),
+                X = -Border.Thickness,
+                Image = UserInterface.MenuBackgroundNormal
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Title"/>
+        /// </summary>
+        private void CreateTitle()
+        {
+            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "SONG TITLE", 26)
+            {
+                Parent = this,
+                Position = new ScalableVector2(26, 18)
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Artist"/>
+        /// </summary>
+        private void CreateArtist()
+        {
+            Artist = new SpriteTextPlus(Title.Font, "Artist", 20)
+            {
+                Parent = this,
+                Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
+                Tint = ColorHelper.HexToColor("#0587e5")
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="DividerLine"/>
+        /// </summary>
+        private void CreateDividerLine()
+        {
+            DividerLine = new SpriteTextPlus(Artist.Font, "|", Artist.FontSize)
+            {
+                Parent = this,
+                Position = new ScalableVector2(Artist.X + Artist.Width + ArtistCreatorSpacingX, Artist.Y),
+                Tint = ColorHelper.HexToColor("#808080")
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Creator"/>
+        /// </summary>
+        private void CreateCreator()
+        {
+            ByText = new SpriteTextPlus(Title.Font, "By:", Artist.FontSize)
+            {
+                Parent = this,
+                Position = new ScalableVector2(DividerLine.X + DividerLine.Width + ArtistCreatorSpacingX, Artist.Y),
+                Tint = ColorHelper.HexToColor("#757575")
+            };
+
+            Creator = new SpriteTextPlus(Title.Font, "Creator", Artist.FontSize)
+            {
+                Parent = this,
+                Position = new ScalableVector2(ByText.X + ByText.Width + ArtistCreatorSpacingX, Artist.Y),
+                Tint = Artist.Tint
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="RankedStatusSprite"/>
+        /// </summary>
+        private void CreateRankedStatus()
+        {
+            RankedStatusSprite = new Sprite()
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(115, 28),
+                X = Banner.X - Banner.Width - 18,
+                Image = UserInterface.StatusPanel
+            };
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        private void CreateGameModes()
+        {
+            GameModes = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(71, 28),
+                X = RankedStatusSprite.X - RankedStatusSprite.Width - 18
+            };
+        }
+
+        /// <summary>
+        ///     Retrieves the color of a map's ranked status
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private Texture2D GetRankedStatusImage()
+        {
+            switch (ParentMapset.Item.Maps.Max(x => x.RankedStatus))
+            {
+                case RankedStatus.NotSubmitted:
+                    return UserInterface.StatusNotSubmitted;
+                case RankedStatus.Unranked:
+                    return UserInterface.StatusUnranked;
+                case RankedStatus.Ranked:
+                    return UserInterface.StatusRanked;
+                case RankedStatus.DanCourse:
+                    return UserInterface.StatusNotSubmitted;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        ///     Gets the image for the game mode(s)
+        /// </summary>
+        /// <returns></returns>
+        private Texture2D GetGameModeImage()
+        {
+            var has4k = false;
+            var has7K = false;
+
+            foreach (var map in ParentMapset.Item.Maps)
+            {
+                switch (map.Mode)
+                {
+                    case GameMode.Keys4:
+                        has4k = true;
+                        break;
+                    case GameMode.Keys7:
+                        has7K = true;
+                        break;
+                }
+            }
+
+            if (has4k && !has7K)
+                return UserInterface.Keys4Panel;
+            if (has7K && !has4k)
+                return UserInterface.Keys7Panel;
+
+            return UserInterface.BothModesPanel;
+        }
+
+        /// <summary>
+        ///     Performs an animation when hovered over the button
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void PerformHoverAnimation(GameTime gameTime)
+        {
+            var targetAlpha = Button.IsHovered ? 0.35f : 0;
+
+            Button.Alpha = MathHelper.Lerp(Button.Alpha, targetAlpha,
+                (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 30, 1));
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Select()
+        {
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Deselect()
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -12,6 +12,7 @@ using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Selection.UI.Mapsets
@@ -134,6 +135,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 Alpha = 0,
                 Alignment = Alignment.MidCenter
             };
+
+            Button.Clicked += (sender, args) => OnMapsetClicked();
         }
 
         /// <summary>
@@ -314,6 +317,22 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Deselect()
         {
+        }
+
+        /// <summary>
+        ///     Called when the mapset has been clicked
+        /// </summary>
+        private void OnMapsetClicked()
+        {
+            // Mapset is already selected, so go play the current map.
+            if (ParentMapset.IsSelected)
+            {
+                Logger.Important($"User clicked on mapset to play: {MapManager.Selected.Value}", LogType.Runtime, false);
+                return;
+            }
+
+            Logger.Important($"User opened mapset: {ParentMapset.Item.Artist} - {ParentMapset.Item.Title}", LogType.Runtime, false);
+            MapManager.Selected.Value = ParentMapset.Item.Maps.First();
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/IDrawableMapMetadata.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/IDrawableMapMetadata.cs
@@ -1,0 +1,15 @@
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public interface IDrawableMapMetadata
+    {
+        /// <summary>
+        ///     Called when the mapset has opened
+        /// </summary>
+        void Open();
+
+        /// <summary>
+        ///     Called when the mapset has closed
+        /// </summary>
+        void Close();
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/IDrawableMapsetComponent.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/IDrawableMapsetComponent.cs
@@ -1,0 +1,15 @@
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public interface IDrawableMapsetComponent
+    {
+        /// <summary>
+        ///     Called when the mapset/map is selected
+        /// </summary>
+        void Select();
+
+        /// <summary>
+        ///     Called when the mapset/map is deselected
+        /// </summary>
+        void Deselect();
+    }
+}

--- a/Quaver.Shared/Screens/Tests/FilterPanel/FilterPanelTestScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/FilterPanel/FilterPanelTestScreenView.cs
@@ -62,7 +62,7 @@ namespace Quaver.Shared.Screens.Tests.FilterPanel
             {
                 if (ModManager.Mods == 0)
                 {
-                    ModManager.AddMod(ModIdentifier.Speed05X);
+                    ModManager.AddMod(ModIdentifier.Speed075X);
                     ModManager.AddMod(ModIdentifier.Autoplay);
                     ModManager.AddMod(ModIdentifier.Mirror);
                 }

--- a/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreen.cs
+++ b/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreen.cs
@@ -1,0 +1,9 @@
+using Quaver.Shared.Screens.Tests.FilterPanel;
+
+namespace Quaver.Shared.Screens.Tests.Mapsets
+{
+    public class TestMapsetScreen : FilterPanelTestScreen
+    {
+        public TestMapsetScreen() : base(true) => View = new TestMapsetScreenView(this);
+    }
+}

--- a/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreenView.cs
@@ -26,7 +26,37 @@ namespace Quaver.Shared.Screens.Tests.Mapsets
 
         public TestMapsetScreenView(TestMapsetScreen screen) : base(screen)
         {
-            for (var i = 0; i < 5; i++)
+            // ReSharper disable once ObjectCreationAsStatement
+            new SelectJukebox() {Parent = Container};
+
+            SeedMapset(TestMapset, 6);
+
+            Drawable = new DrawableMapset(null, TestMapset, 0)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter
+            };
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Home))
+            {
+                if (Drawable.IsSelected)
+                    Drawable.Deselect();
+                else
+                    Drawable.Select();
+            }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Delete))
+                MapManager.Selected.Value = TestMapset.Maps.First();
+
+            base.Update(gameTime);
+        }
+
+        private void SeedMapset(Mapset mapset, int num)
+        {
+            for (var i = 0; i < num; i++)
             {
                 var difficulty = 0f;
 
@@ -52,7 +82,7 @@ namespace Quaver.Shared.Screens.Tests.Mapsets
                         break;
                 }
 
-                TestMapset.Maps.Add(new Map
+                mapset.Maps.Add(new Map
                 {
                     Id = 1,
                     Md5Checksum = "test",
@@ -72,31 +102,6 @@ namespace Quaver.Shared.Screens.Tests.Mapsets
                     LongNoteCount = 200
                 });
             }
-
-            // ReSharper disable once ObjectCreationAsStatement
-            new SelectJukebox() {Parent = Container};
-
-            Drawable = new DrawableMapset(null, TestMapset, 0)
-            {
-                Parent = Container,
-                Alignment = Alignment.MidCenter
-            };
-        }
-
-        public override void Update(GameTime gameTime)
-        {
-            if (KeyboardManager.IsUniqueKeyPress(Keys.Home))
-            {
-                if (Drawable.IsSelected)
-                    Drawable.Deselect();
-                else
-                    Drawable.Select();
-            }
-
-            if (KeyboardManager.IsUniqueKeyPress(Keys.Delete))
-                MapManager.Selected.Value = TestMapset.Maps.First();
-
-            base.Update(gameTime);
         }
     }
 }

--- a/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/Mapsets/TestMapsetScreenView.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FontStashSharp;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Enums;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Screens.Selection.Components;
+using Quaver.Shared.Screens.Selection.UI.Mapsets;
+using Quaver.Shared.Screens.Tests.FilterPanel;
+using Wobble.Bindables;
+using Wobble.Input;
+using Alignment = Wobble.Graphics.Alignment;
+
+namespace Quaver.Shared.Screens.Tests.Mapsets
+{
+    public class TestMapsetScreenView : FilterPanelTestScreenView
+    {
+        private Mapset TestMapset { get; } = new Mapset()
+        {
+            Maps = new List<Map>()
+        };
+
+        private DrawableMapset Drawable { get; }
+
+        public TestMapsetScreenView(TestMapsetScreen screen) : base(screen)
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                var difficulty = 0f;
+
+                switch (i)
+                {
+                    case 0:
+                        difficulty = 1.5f;
+                        break;
+                    case 1:
+                        difficulty = 4f;
+                        break;
+                    case 2:
+                        difficulty = 8f;
+                        break;
+                    case 3:
+                        difficulty = 15f;
+                        break;
+                    case 4:
+                        difficulty = 25f;
+                        break;
+                    case 5:
+                        difficulty = 30;
+                        break;
+                }
+
+                TestMapset.Maps.Add(new Map
+                {
+                    Id = 1,
+                    Md5Checksum = "test",
+                    Artist = "Swan",
+                    Title = "Left Right",
+                    Creator = "AiAe",
+                    DifficultyName = "Offset Calibrator " + (i + 1),
+                    AudioPreviewTime = 2000,
+                    Bpm = 120,
+                    DateAdded = DateTime.Now,
+                    MapId = -1,
+                    MapSetId = -1,
+                    Difficulty10X = difficulty,
+                    RankedStatus = RankedStatus.Ranked,
+                    Mode = GameMode.Keys4,
+                    RegularNoteCount = 5000,
+                    LongNoteCount = 200
+                });
+            }
+
+            // ReSharper disable once ObjectCreationAsStatement
+            new SelectJukebox() {Parent = Container};
+
+            Drawable = new DrawableMapset(null, TestMapset, 0)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter
+            };
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Home))
+            {
+                if (Drawable.IsSelected)
+                    Drawable.Deselect();
+                else
+                    Drawable.Select();
+            }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Delete))
+                MapManager.Selected.Value = TestMapset.Maps.First();
+
+            base.Update(gameTime);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderFooter.cs
+++ b/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderFooter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Menu.Border;
+using Quaver.Shared.Graphics.Menu.Border.Components;
 using Wobble.Graphics;
 using Wobble.Managers;
 

--- a/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderHeader.cs
+++ b/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderHeader.cs
@@ -20,7 +20,6 @@ namespace Quaver.Shared.Screens.Tests.UI.Borders
             new List<Drawable>
             {
                 new IconButton(FontAwesome.Get(FontAwesomeIcon.fa_reorder_option)) { Size = new ScalableVector2(30, 30)},
-                new MenuBorderUser(),
                 new DrawableSessionTime()
             })
         {

--- a/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderHeader.cs
+++ b/Quaver.Shared/Screens/Tests/UI/Borders/TestMenuBorderHeader.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Menu.Border;
+using Quaver.Shared.Graphics.Menu.Border.Components;
 using Quaver.Shared.Screens.Menu.UI.Jukebox;
 using Wobble.Graphics;
 using Wobble.Managers;


### PR DESCRIPTION
- Adds a `DrawableMapset` sprite + visual test 
- Adds map metadata (Mode, Length, BPM, LN%) to `FilterPanelMapInfo`
- Adds Discord Rich Presence when running visual tests
- Adds more colors to represent difficulty rating
- Added a property to `IconTextButton` to optionally opt-out of tinting its text
- Fixed a bug where `FilterPanelBanner` would change its texture while not being the currently select map