### PR TITLE
Custom Judgement Window Improvements & Bug Fixes

### DIFF
--- a/Quaver.Shared/Database/Scores/Score.cs
+++ b/Quaver.Shared/Database/Scores/Score.cs
@@ -175,6 +175,11 @@ namespace Quaver.Shared.Database.Scores
         public float JudgementWindowMiss { get; set; }
 
         /// <summary>
+        ///     The score's ranked/standardized accuracy
+        /// </summary>
+        public double RankedAccuracy { get; set; }
+
+        /// <summary>
         ///     If the score is an online score.
         /// </summary>
         [Ignore]

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
@@ -84,7 +84,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets
             HitObjectManager = CreateHitObjectManager();
 
             StandardizedReplayPlayer = new VirtualReplayPlayer(new Replay(Map.Mode,
-                ConfigManager.Username.Value, ModManager.Mods, Screen.MapHash), map, true);
+                ConfigManager.Username.Value, ModManager.Mods, Screen.MapHash), map, null, true);
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -12,6 +12,7 @@ using Quaver.API.Maps.Processors.Scoring;
 using Quaver.API.Maps.Processors.Scoring.Data;
 using Quaver.API.Replays;
 using Quaver.API.Replays.Virtual;
+using Quaver.Shared.Database.Judgements;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
@@ -69,7 +70,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             Screen = screen;
             Replay = Screen.LoadedReplay;
 
-            VirtualPlayer = new VirtualReplayPlayer(Replay, Screen.Map);
+            VirtualPlayer = new VirtualReplayPlayer(Replay, Screen.Map, JudgementWindowsDatabaseCache.Selected.Value);
             VirtualPlayer.PlayAllFrames();
 
             // Populate unique key presses/releases.

--- a/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
@@ -10,6 +10,7 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Helpers;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Audio;
+using Quaver.Shared.Database.Judgements;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
@@ -127,6 +128,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             // Get a formatted string of the activated mods.
             var modsString = "Mods: " + (ModManager.CurrentModifiersList.Count > 0 ? $"{ModHelper.GetModsString(ModManager.Mods)}" : "None");
+
+            modsString += $" ({JudgementWindowsDatabaseCache.Selected.Value.Name})";
+
             Mods = new SpriteText(Fonts.SourceSansProSemiBold, modsString, 13)
             {
                 Parent = this,

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -425,6 +425,7 @@ namespace Quaver.Shared.Screens.Result
                     Gameplay.PauseCount, Gameplay.Map.RandomizeModifierSeed);
 
                 localScore.RatingProcessorVersion = RatingProcessorKeys.Version;
+                localScore.RankedAccuracy = Gameplay.Ruleset.StandardizedReplayPlayer.ScoreProcessor.Accuracy;
 
                 var windows = JudgementWindowsDatabaseCache.Selected.Value;
 

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -850,7 +850,23 @@ namespace Quaver.Shared.Screens.Result
             var qua = Map.LoadQua();
             qua.ApplyMods(replay.Mods);
 
-            var player = new VirtualReplayPlayer(replay, qua);
+            JudgementWindows windows = null;
+
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (Score.JudgementWindowPreset != JudgementWindowsDatabaseCache.Standard.Name && Score.JudgementWindowMarv != 0)
+            {
+                windows = new JudgementWindows()
+                {
+                    Marvelous = Score.JudgementWindowMarv,
+                    Perfect = Score.JudgementWindowPerf,
+                    Great = Score.JudgementWindowGreat,
+                    Good = Score.JudgementWindowGood,
+                    Okay = Score.JudgementWindowOkay,
+                    Miss = Score.JudgementWindowMiss
+                };
+            }
+
+            var player = new VirtualReplayPlayer(replay, qua, windows);
             player.PlayAllFrames();
 
             return player.ScoreProcessor;

--- a/Quaver.Shared/Screens/Result/UI/ResultJudgementBreakdown.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultJudgementBreakdown.cs
@@ -103,7 +103,7 @@ namespace Quaver.Shared.Screens.Result.UI
                 };
 
                 if (Container.StandardizedProcessor != null)
-                    windows.Text = $" - {Processor.JudgementWindow[j] / ModHelper.GetRateFromMods(Processor.Mods)}ms";
+                    windows.Text = $" - {Processor.JudgementWindow[j] / ModHelper.GetRateFromMods(Processor.Mods)} ms";
                 else if (Container.Screen.ResultsType == ResultScreenType.Score
                          && Container.Screen.Score.JudgementWindowPreset != JudgementWindowsDatabaseCache.Standard.Name
                          && Container.Screen.Score.JudgementWindowPreset != null)
@@ -111,24 +111,26 @@ namespace Quaver.Shared.Screens.Result.UI
                     switch (j)
                     {
                         case Judgement.Marv:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowMarv + "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowMarv;
                             break;
                         case Judgement.Perf:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowPerf + "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowPerf;
                             break;
                         case Judgement.Great:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowGreat + "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowGreat;
                             break;
                         case Judgement.Good:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowGood+ "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowGood;
                             break;
                         case Judgement.Okay:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowOkay + "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowOkay;
                             break;
                         case Judgement.Miss:
-                            windows.Text = " - " + Container.Screen.Score.JudgementWindowMiss + "ms";
+                            windows.Text = " - " + Container.Screen.Score.JudgementWindowMiss;
                             break;
                     }
+
+                    windows.Text += " ms";
                 }
 
                 i++;

--- a/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
@@ -281,12 +281,22 @@ namespace Quaver.Shared.Screens.Result.UI
                     throw new ArgumentOutOfRangeException();
             }
 
-            var standardized = StandardizedProcessor != null
-                ? new ResultKeyValueItem(ResultKeyValueItemType.Vertical, "RANKED ACCURACY",StringHelper.AccuracyToString(StandardizedProcessor.Accuracy))
-                : null;
+            ResultKeyValueItem standardized = null;
 
-            var beginPosition = 40;
-            var spacing = StandardizedProcessor != null ? 44 : 100;
+            int spacing;
+            const int beginPosition = 40;
+
+            if (StandardizedProcessor != null || Screen.ResultsType == ResultScreenType.Score && !Screen.Score.IsOnline)
+            {
+                var acc = StandardizedProcessor?.Accuracy ?? Screen.Score.RankedAccuracy;
+
+                standardized = new ResultKeyValueItem(ResultKeyValueItemType.Vertical, "RANKED ACCURACY",
+                    StringHelper.AccuracyToString((float) acc));
+
+                spacing = 44;
+            }
+            else
+                spacing = 100;
 
             ResultKeyValueItems = new List<ResultKeyValueItem>()
             {

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
@@ -216,6 +216,28 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
             };
 
             DeleteButton.Size = new ScalableVector2(DeleteButton.Width * 0.85f, DeleteButton.Height * 0.85f);
+
+            var resetToDefaultButton = new BorderedTextButton("Reset", Color.Orange, (sender, args) =>
+                {
+                    Sliders[Judgement.Marv].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Marvelous;
+                    Sliders[Judgement.Perf].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Perfect;
+                    Sliders[Judgement.Great].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Great;
+                    Sliders[Judgement.Good].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Good;
+                    Sliders[Judgement.Okay].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Okay;
+                    Sliders[Judgement.Miss].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Miss;
+                })
+            {
+                Parent = SubHeaderBackground,
+                Alignment = Alignment.MidRight,
+                X = DeleteButton.X - DeleteButton.Width - 12,
+                Text =
+                {
+                    FontSize = 14,
+                    Font = Fonts.Exo2SemiBold
+                }
+            };
+
+            resetToDefaultButton .Size = new ScalableVector2(resetToDefaultButton .Width * 0.85f, resetToDefaultButton .Height * 0.85f);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
@@ -156,9 +156,10 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                     Name = "Preset"
                 };
 
-                var id = JudgementWindowsDatabaseCache.Insert(windows);
+                var presetCount = JudgementWindowsDatabaseCache.Presets.FindAll(x => !x.IsDefault).Count;
+                JudgementWindowsDatabaseCache.Insert(windows);
 
-                windows.Name = $"Preset {windows.Id}";
+                windows.Name = $"Preset {presetCount + 1}";
                 JudgementWindowsDatabaseCache.Update(windows);
 
                 WindowContainer.AddObject(windows);

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
@@ -141,12 +141,12 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
             };
 
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteTextBitmap(FontsBitmap.GothamBold, "Presets")
+            new SpriteTextBitmap(FontsBitmap.GothamRegular, "Presets")
             {
                 Parent = SubHeaderBackground,
                 Alignment = Alignment.MidLeft,
                 X = 18,
-                FontSize = 20
+                FontSize = 18
             };
 
             var addButton = new BorderedTextButton("Add", Color.Lime, (sender, args) =>

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
@@ -43,6 +43,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
 
         private Button DeleteButton { get; set; }
 
+        public BorderedTextButton ResetToDefaultButton { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -217,7 +219,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
 
             DeleteButton.Size = new ScalableVector2(DeleteButton.Width * 0.85f, DeleteButton.Height * 0.85f);
 
-            var resetToDefaultButton = new BorderedTextButton("Reset", Color.Orange, (sender, args) =>
+            ResetToDefaultButton = new BorderedTextButton("Reset", Color.Orange, (sender, args) =>
                 {
                     Sliders[Judgement.Marv].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Marvelous;
                     Sliders[Judgement.Perf].BindedValue.Value = (int) JudgementWindowsDatabaseCache.Standard.Perfect;
@@ -237,7 +239,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                 }
             };
 
-            resetToDefaultButton .Size = new ScalableVector2(resetToDefaultButton .Width * 0.85f, resetToDefaultButton .Height * 0.85f);
+            ResetToDefaultButton .Size = new ScalableVector2(ResetToDefaultButton .Width * 0.85f, ResetToDefaultButton .Height * 0.85f);
         }
 
         /// <summary>
@@ -393,6 +395,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                     EditButton.IsClickable = false;
                     DeleteButton.Visible = false;
                     DeleteButton.IsClickable = false;
+                    ResetToDefaultButton.Visible = false;
+                    ResetToDefaultButton.IsClickable = false;
                 }
                 else
                 {
@@ -404,6 +408,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                     EditButton.IsClickable = true;
                     DeleteButton.Visible = true;
                     DeleteButton.IsClickable = true;
+                    ResetToDefaultButton.Visible = true;
+                    ResetToDefaultButton.IsClickable = true;
                 }
             }
         }

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/CustomizeJudgementWindowsDialog.cs
@@ -72,8 +72,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
             CreateContainer();
             CreateHeader();
             CreateSubHeaders();
-            CreateFooter();
             CreateWindowContainer();
+            CreateFooter();
             CreateSliders();
         }
 
@@ -109,7 +109,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                 Parent = this,
                 Alignment = Alignment.MidCenter,
                 Size = new ScalableVector2(930, 500),
-                Tint = ColorHelper.HexToColor("#2f2f2f")
+                Tint = ColorHelper.HexToColor("#0f0f0f")
             };
 
             CustomizeContainer.AddBorder(Colors.MainAccent, 2);
@@ -137,7 +137,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                 Y = 2,
                 Alignment = Alignment.TopCenter,
                 Size = new ScalableVector2(CustomizeContainer.Width - 4, 47),
-                Tint = ColorHelper.HexToColor("#101010")
+                Tint = ColorHelper.HexToColor("#212121")
             };
 
             // ReSharper disable once ObjectCreationAsStatement
@@ -226,8 +226,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                 Parent = CustomizeContainer,
                 Y = -2,
                 Alignment = Alignment.BotCenter,
-                Size = new ScalableVector2(CustomizeContainer.Width - 4, 49),
-                Tint = ColorHelper.HexToColor("#101010")
+                Size = new ScalableVector2(CustomizeContainer.Width - 4, 52),
+                Tint = ColorHelper.HexToColor("#212121")
             };
 
             var closeButton = new BorderedTextButton("Close", Color.Crimson, (sender, args) => Close())
@@ -245,12 +245,12 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
             closeButton.Size = new ScalableVector2(closeButton.Width * 0.85f, closeButton.Height * 0.85f);
 
             // ReSharper disable once ObjectCreationAsStatement
-            new SpriteTextBitmap(FontsBitmap.GothamBold, "NOTE: Scores with custom windows must be passing on the Standard windows in order to be ranked.")
+            new SpriteTextBitmap(FontsBitmap.GothamRegular, "*Scores with custom windows must be passing on Standard* in order to be ranked.")
             {
                 Parent = FooterBackground,
                 Alignment = Alignment.MidLeft,
                 X = 15,
-                FontSize = 15
+                FontSize = 18
             };
         }
 
@@ -292,7 +292,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                     FontSize = 18
                 };
 
-                var slider = new Slider(BindableSliderValues[judgement], new Vector2(550, 3), FontAwesome.Get(FontAwesomeIcon.fa_circle))
+                var slider = new Slider(BindableSliderValues[judgement], new Vector2(530, 3), FontAwesome.Get(FontAwesomeIcon.fa_circle))
                 {
                     Parent = CustomizeContainer,
                     X = name.X + 70,
@@ -300,7 +300,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
                 };
 
                 Sliders.Add(judgement, slider);
-                var value = new SpriteTextBitmap(FontsBitmap.GothamRegular, BindableSliderValues[judgement].Value.ToString(), false)
+                var value = new SpriteTextBitmap(FontsBitmap.GothamRegular, BindableSliderValues[judgement].Value + " ms", false)
                 {
                     Parent = CustomizeContainer,
                     Alignment = Alignment.TopRight,
@@ -311,7 +311,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
 
                 slider.BindedValue.ValueChanged += (sender, args) =>
                 {
-                    value.Text = args.Value.ToString();
+                    value.Text = args.Value.ToString() + " ms";
 
                     switch (judgement)
                     {

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/JudgementWindowContainer.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/Windows/JudgementWindowContainer.cs
@@ -18,8 +18,8 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers.Windows
 
             InputEnabled = true;
             Scrollbar.Tint = Color.White;
-            Scrollbar.Width = 3;
-            Scrollbar.X = -Width - 6;
+            Scrollbar.Width = 4;
+            Scrollbar.X = -Width - 14;
             EasingType = Easing.OutQuint;
             ScrollSpeed = 150;
             TimeToCompleteScroll = 1200;


### PR DESCRIPTION
- Replays now play with the currently activated judgement windows
- The currently activated judgement window preset is now shown during gameplay in the song information
- Added a button to reset presets back to the default values
- Fixed local score hit difference graph not displaying the correct windows
- Fixed Ranked Accuracy not displaying when clicking on local scores
- Fixed a bug where creating new presets won't be named with the correct number