### PR TITLE
Fix incorrect map status being set & Add icon for other-game maps

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -30,6 +30,7 @@ namespace Quaver.Shared.Assets
         public static Texture2D StatusUnranked => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-unranked.png");
         public static Texture2D StatusNotSubmitted => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-not-submitted.png");
         public static Texture2D StatusDanCourse => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-dancourse.png");
+        public static Texture2D StatusOtherGameOsu => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-other-game-osu.png");
         public static Texture2D SelectButtonBackground => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/select-button-background.png");
         public static Texture2D HorizontalSelectorLeft => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/horizontal-selector-left.png");
         public static Texture2D HorizontalSelectorRight => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/horizontal-selector-right.png");

--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -450,7 +450,7 @@ namespace Quaver.Shared.Online
                 }
 
                 if ((int) e.Response.Code == -1)
-                    map.RankedStatus = RankedStatus.Unranked;
+                    map.RankedStatus = map.MapId == -1 ? RankedStatus.NotSubmitted : RankedStatus.Unranked;
 
                 // Update online grade
                 if (ConfigManager.LeaderboardSection.Value != LeaderboardType.Rate && e.Response.PersonalBest != null)

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -392,6 +392,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         private Texture2D GetRankedStatusImage()
         {
+            if (ParentMapset.Item.Maps.First().Game != MapGame.Quaver)
+                return UserInterface.StatusOtherGameOsu;
+
             switch (ParentMapset.Item.Maps.Max(x => x.RankedStatus))
             {
                 case RankedStatus.NotSubmitted:


### PR DESCRIPTION
- Fixes some unsubmitted maps displaying as unranked
- Addresses a part of #981 where the person requested a way to distinguish between mapsets loaded from external games