### PR TITLE
Implement Playlists (Display & Functionality)

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -31,6 +31,8 @@ namespace Quaver.Shared.Assets
         public static Texture2D StatusNotSubmitted => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-not-submitted.png");
         public static Texture2D StatusDanCourse => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-dancourse.png");
         public static Texture2D StatusOtherGameOsu => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-other-game-osu.png");
+        public static Texture2D StatusVarious => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-various.png");
+        public static Texture2D StatusNone => TextureManager.Load("Quaver.Resources/Textures/UI/RankedStatus/status-none.png");
         public static Texture2D SelectButtonBackground => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/select-button-background.png");
         public static Texture2D HorizontalSelectorLeft => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/horizontal-selector-left.png");
         public static Texture2D HorizontalSelectorRight => TextureManager.Load("Quaver.Resources/Textures/UI/Elements/horizontal-selector-right.png");
@@ -90,6 +92,7 @@ namespace Quaver.Shared.Assets
         public static Texture2D SearchBox => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/search-box.png");
         public static Texture2D Keys4Panel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/keys4.png");
         public static Texture2D Keys7Panel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/keys7.png");
+        public static Texture2D KeysNonePanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/keys-none.png");
         public static Texture2D BothModesPanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/both-modes-panel.png");
         public static Texture2D ModePanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/mode-panel.png");
         public static Texture2D EditPlayButton => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/edit-play-button.png");

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -203,6 +203,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<OrderMapsetsBy> SelectOrderMapsetsBy { get; private set; }
 
         /// <summary>
+        ///     Dictates how to group mapsets in song select
+        /// </summary>
+        internal static Bindable<GroupMapsetsBy> SelectGroupMapsetsBy { get; private set; }
+
+        /// <summary>
         ///     Dictates how to filter song select mpas
         /// </summary>
         internal static Bindable<SelectFilterGameMode> SelectFilterGameModeBy { get; private set; }
@@ -677,6 +682,8 @@ namespace Quaver.Shared.Config
             SelectFilterGameModeBy = ReadValue(@"SelectFilterGameModeBy", SelectFilterGameMode.All, data);
             DisplayUnbeatableScoresDuringGameplay = ReadValue(@"DisplayUnbeatableScoresDuringGameplay", true, data);
             JudgementWindows = ReadValue("JudgementWindows", "", data);
+            SelectGroupMapsetsBy = ReadValue(@"SelectGroupMapsetsBy", GroupMapsetsBy.None, data);
+
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
                 Username.Value = "Player";
@@ -787,6 +794,7 @@ namespace Quaver.Shared.Config
                     SelectFilterGameModeBy.ValueChanged += AutoSaveConfiguration;
                     DisplayUnbeatableScoresDuringGameplay.ValueChanged += AutoSaveConfiguration;
                     JudgementWindows.ValueChanged += AutoSaveConfiguration;
+                    SelectGroupMapsetsBy.ValueChanged += AutoSaveConfiguration;
                 });
         }
 

--- a/Quaver.Shared/Config/GroupMapsetsBy.cs
+++ b/Quaver.Shared/Config/GroupMapsetsBy.cs
@@ -1,0 +1,8 @@
+namespace Quaver.Shared.Config
+{
+    public enum GroupMapsetsBy
+    {
+        None,
+        Playlists
+    }
+}

--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -53,8 +53,8 @@ namespace Quaver.Shared.Database.Maps
             var quaFiles = Directory.GetFiles(ConfigManager.SongDirectory.Value, "*.qua", SearchOption.AllDirectories).ToList();
             Logger.Important($"Found {quaFiles.Count} .qua files inside the song directory", LogType.Runtime);
 
-            SyncMissingOrUpdatedFiles(quaFiles);
-            AddNonCachedFiles(quaFiles);
+            //SyncMissingOrUpdatedFiles(quaFiles);
+            //AddNonCachedFiles(quaFiles);
 
             OrderAndSetMapsets();
         }

--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -29,7 +29,7 @@ namespace Quaver.Shared.Database.Playlists
         ///     The maps that are inside of the playlist
         /// </summary>
         [Ignore]
-        public List<Map> Maps { get; set; }
+        public List<Map> Maps { get; set; } = new List<Map>();
 
         /// <summary>
         ///     The game the playlist is from

--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -6,6 +6,7 @@ using osu_database_reader.BinaryFiles;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using SQLite;
+using Wobble.Bindables;
 using Wobble.Logging;
 
 namespace Quaver.Shared.Database.Playlists
@@ -21,6 +22,11 @@ namespace Quaver.Shared.Database.Playlists
         ///     The available playlists
         /// </summary>
         public static List<Playlist> Playlists { get; private set; } = new List<Playlist>();
+
+        /// <summary>
+        ///     The currently selected playlist
+        /// </summary>
+        public static Bindable<Playlist> Selected { get; } = new Bindable<Playlist>(null);
 
         /// <summary>
         ///     Loads all of the maps in the database and groups them into mapsets to use

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -46,6 +46,7 @@ using Quaver.Shared.Screens.Tests.DrawableLeaderboardScores;
 using Quaver.Shared.Screens.Tests.DrawableMaps;
 using Quaver.Shared.Screens.Tests.DrawableMapsets;
 using Quaver.Shared.Screens.Tests.DrawableMapsetsMultiple;
+using Quaver.Shared.Screens.Tests.DrawablePlaylists;
 using Quaver.Shared.Screens.Tests.Dropdowns;
 using Quaver.Shared.Screens.Tests.FilterPanel;
 using Quaver.Shared.Screens.Tests.Jukebox;
@@ -156,7 +157,8 @@ namespace Quaver.Shared
             {"ModifierSelector", typeof(TestModifierSelectorScreen)},
             {"CreatePlaylistDialog", typeof(TestScreenCreatePlaylist)},
             {"SelectionScreen", typeof(SelectionScreen)},
-            {"YesNoDialog", typeof(TestYesNoDialogScreen)}
+            {"YesNoDialog", typeof(TestYesNoDialogScreen)},
+            {"DrawablePlaylist", typeof(TestScreenDrawablePlaylist)}
         };
 
         public QuaverGame(HotLoader hl) : base(hl)

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/Dropdowns/FilterDropdownGroupBy.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/Dropdowns/FilterDropdownGroupBy.cs
@@ -49,7 +49,10 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.Dropdowns
         /// <returns></returns>
         private static int GetSelectedIndex()
         {
-            return 0;
+            if (ConfigManager.SelectGroupMapsetsBy == null)
+                return 0;
+
+            return (int) ConfigManager.SelectGroupMapsetsBy.Value;
         }
 
         /// <summary>
@@ -58,6 +61,10 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.Dropdowns
         /// <param name="e"></param>
         private void OnItemSelected(object sender, DropdownClickedEventArgs e)
         {
+            if (ConfigManager.SelectGroupMapsetsBy == null)
+                return;
+
+            ConfigManager.SelectGroupMapsetsBy.Value = (GroupMapsetsBy) e.Index;
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
@@ -1,6 +1,8 @@
 using Microsoft.Xna.Framework;
 using Quaver.Shared.Assets;
 using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Managers;
 
@@ -67,6 +69,36 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
                 X = Key.Width  + 6,
                 Tint = KeyColor
             };
+        }
+
+        /// <summary>
+        ///     Changes the value of the container
+        /// </summary>
+        /// <param name="value"></param>
+        public void ChangeValue(string value)
+        {
+            Value.Text = value;
+            UpdateSize();
+        }
+
+        /// <summary>
+        ///     Updates the size of the container
+        /// </summary>
+        public virtual void UpdateSize() => Size = new ScalableVector2(Key.Width + Value.Width + 6, Key.Height);
+
+        public void RemoveAnimations()
+        {
+            ClearAnimations();
+            Children.ForEach(x => x.ClearAnimations());
+        }
+
+        public void FadeTo(float fade, Easing easing, int time)
+        {
+            Children.ForEach(x =>
+            {
+                if (x is Sprite s)
+                    s.FadeTo(fade, easing, time);
+            });
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
@@ -135,6 +135,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         /// <summary>
+        ///     Difficulty name is only visible on mapsets for playlists
+        /// </summary>
+        public bool IsPlaylistMapset() => DrawableContainer.DifficultyName.Visible;
+
+        /// <summary>
         ///     Handles opening/closing the mapset when the map has changed
         /// </summary>
         /// <param name="sender"></param>

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -87,12 +87,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         ///     When the mapsets are sorted by difficulty/grade achieved
         ///     this will display the difficulty rating & name to make it act as an individual map
         /// </summary>
-        private SpriteTextPlus DifficultyName { get; set; }
+        public SpriteTextPlus DifficultyName { get; private set; }
 
         /// <summary>
         ///     The highest online grade that the user has achieved
         /// </summary>
-        private Sprite OnlineGrade { get; set; }
+        public Sprite OnlineGrade { get; set; }
 
         /// <summary>
         /// </summary>
@@ -178,6 +178,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 
                 DifficultyName.Text = $"{StringHelper.RatingToString(diff)} - {map.DifficultyName}";
                 DifficultyName.Tint = ColorHelper.DifficultyToColor((float) diff);
+                DifficultyName.Visible = true;
 
                 if (DifficultyName.Width >= 260 || DifficultyName.Text.Length >= 40)
                 {
@@ -215,6 +216,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 DividerLine.X = Artist.X + Artist.Width + ArtistCreatorSpacingX;
                 Artist.Visible = true;
                 OnlineGrade.Visible = false;
+                DifficultyName.Visible = false;
             }
 
             ByText.X = DividerLine.X + DividerLine.Width + ArtistCreatorSpacingX;

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetContainerInitializedEventArgs.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetContainerInitializedEventArgs.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class MapsetContainerInitializedEventArgs : EventArgs
+    {
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -48,7 +48,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// <summary>
         ///     If the mapsets have reinitialized
         /// </summary>
-        private bool HasReinitialized { get; set; } = false;
+        private bool HasReinitialized { get; set; }
+
+        /// <summary>
+        ///     Event invoked when the mapset container has had its maps initialized
+        /// </summary>
+        public event EventHandler<MapsetContainerInitializedEventArgs> ContainerInitialized;
 
         /// <inheritdoc />
         /// <summary>
@@ -87,6 +92,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             MapManager.Selected.ValueChanged -= OnMapChanged;
             AvailableMapsets.ValueChanged -= OnAvailableMapsetsChanged;
             SelectionScreen.RandomMapsetSelected -= OnRandomMapsetSelected;
+
+            ContainerInitialized = null;
 
             base.Destroy();
         }
@@ -172,6 +179,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             }
 
             HasReinitialized = true;
+            ContainerInitialized?.Invoke(this, new MapsetContainerInitializedEventArgs());
         }
 
         /// <summary>
@@ -215,6 +223,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             // the mapset has changed in any way.
             if (oldValue == SelectedIndex.Value)
                 SelectedIndex.TriggerChangeEvent();
+        }
+
+        /// <summary>
+        /// </summary>
+        public void DestroyPool()
+        {
+            Pool.ForEach(x => x.Destroy());
+            Pool.Clear();
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/SelectScrollContainerType.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/SelectScrollContainerType.cs
@@ -3,6 +3,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
     public enum SelectScrollContainerType
     {
         Mapsets,
-        Maps
+        Maps,
+        Playlists
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/Dialogs/PlaylistDifficultyDisplay.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/Dialogs/PlaylistDifficultyDisplay.cs
@@ -1,0 +1,51 @@
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Helpers;
+using Wobble.Graphics.Sprites.Text;
+
+namespace Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs
+{
+    public class PlaylistDifficultyDisplay : PlaylistKeyValueDisplay
+    {
+        private SpriteTextPlus Dash { get; }
+
+        private SpriteTextPlus MaxDifficulty { get; }
+
+        public PlaylistDifficultyDisplay() : base("Difficulty:", "0", Color.White, false)
+        {
+            Dash = new SpriteTextPlus(Key.Font, "-", Key.FontSize)
+            {
+                Parent = this,
+                UsePreviousSpriteBatchOptions = true,
+                Tint = Key.Tint
+            };
+
+            MaxDifficulty = new SpriteTextPlus(Value.Font, "0", Value.FontSize)
+            {
+                Parent = this,
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        ///     Changes the min/max difficulty values
+        /// </summary>
+        /// <param name="min"></param>
+        /// <param name="max"></param>
+        public void ChangeValue(double min, double max)
+        {
+            const int spacing = 4;
+
+            Value.Text = StringHelper.RatingToString(min);
+            Value.Tint = ColorHelper.DifficultyToColor((float) min);
+
+            Dash.X = Value.X + Value.Width + spacing;
+
+            MaxDifficulty.Text = StringHelper.RatingToString(max);
+            MaxDifficulty.Tint = ColorHelper.DifficultyToColor((float) max);
+
+            MaxDifficulty.X = Dash.X + Dash.Width + spacing;
+
+            base.UpdateSize();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylist.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylist.cs
@@ -1,0 +1,99 @@
+using Quaver.Shared.Database.Playlists;
+using Quaver.Shared.Graphics.Containers;
+using Quaver.Shared.Screens.Selection.UI.Mapsets;
+using Wobble.Bindables;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.Selection.UI.Playlists
+{
+    public sealed class DrawablePlaylist : PoolableSprite<Playlist>
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override int HEIGHT { get; } = DrawableMapset.MapsetHeight;
+
+        /// <summary>
+        /// </summary>
+        private DrawablePlaylistContainer DrawableContainer { get; }
+
+        /// <summary>
+        ///     If the playlist is selected
+        /// </summary>
+        public bool IsSelected => PlaylistManager.Selected.Value == Item;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public DrawablePlaylist(PoolableScrollContainer<Playlist> container, Playlist item, int index) : base(container, item, index)
+        {
+            Size = new ScalableVector2(DrawableMapset.WIDTH, HEIGHT);
+
+            DrawableContainer = new DrawablePlaylistContainer(this)
+            {
+                Parent = this,
+                Alignment = Alignment.BotRight,
+                UsePreviousSpriteBatchOptions = true
+            };
+
+            Alpha = 0;
+            UsePreviousSpriteBatchOptions = true;
+
+            UpdateContent(item, index);
+
+            PlaylistManager.Selected.ValueChanged += OnPlaylistChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public override void UpdateContent(Playlist item, int index)
+        {
+            Item = item;
+            Index = index;
+
+            DrawableContainer.UpdateContent(Item, Index);
+
+            if (IsSelected)
+                Select();
+            else
+                Deselect();
+        }
+
+        /// <summary>
+        /// </summary>
+        // ReSharper disable once InheritdocConsiderUsage
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            PlaylistManager.Selected.ValueChanged -= OnPlaylistChanged;
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Select() => DrawableContainer.Select();
+
+        /// <summary>
+        /// </summary>
+        public void Deselect() => DrawableContainer.Deselect();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnPlaylistChanged(object sender, BindableValueChangedEventArgs<Playlist> e)
+        {
+            if (IsSelected)
+                Select();
+            else
+                Deselect();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -145,7 +145,23 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 Depth = 1
             };
 
-            Button.Clicked += (sender, args) => PlaylistManager.Selected.Value = Playlist.Item;
+            Button.Clicked += (sender, args) =>
+            {
+                var wasSelectedPrior = Playlist.IsSelected;
+
+                if (!wasSelectedPrior)
+                    PlaylistManager.Selected.Value = Playlist.Item;
+
+                if (Playlist.Container == null)
+                    return;
+
+                var container = (PlaylistContainer) Playlist.Container;
+
+                container.SelectedIndex.Value = Playlist.Index;
+
+                if (wasSelectedPrior)
+                    container.ActiveScrollContainer.Value = SelectScrollContainerType.Mapsets;
+            };
         }
 
         /// <summary>
@@ -233,7 +249,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         private void CreateCreator()
         {
-            Creator = new PlaylistKeyValueDisplay("Creator:", "Me", ColorHelper.HexToColor("#0587E5"))
+            Creator = new PlaylistKeyValueDisplay("By:", "Me", ColorHelper.HexToColor("#0587E5"))
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, MapCount.Y),

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Enums;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Database.Playlists;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Modifiers;
+using Quaver.Shared.Screens.Selection.UI.Mapsets;
+using Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Selection.UI.Playlists
+{
+    public class DrawablePlaylistContainer : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        private DrawablePlaylist Playlist { get; }
+
+        /// <summary>
+        /// </summary>
+        private ImageButton Button { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public SpriteTextPlus Title { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        private Sprite Banner { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private PlaylistKeyValueDisplay MapCount { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private PlaylistKeyValueDisplay Creator { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private PlaylistDifficultyDisplay DifficultyDisplay { get; set; }
+
+        /// <summary>
+        ///     The ranked status of the map
+        /// </summary>
+        private Sprite RankedStatusSprite { get; set; }
+
+        /// <summary>
+        ///     The game modes the mapset has
+        /// </summary>
+        private Sprite GameModes { get; set; }
+
+        /// <summary>
+        ///     The X position of the title/first element
+        /// </summary>
+        private const int TitleX = 26;
+
+        /// <summary>
+        /// </summary>
+        public DrawablePlaylistContainer(DrawablePlaylist playlist)
+        {
+            Playlist = playlist;
+            Parent = Playlist;
+
+            Size = new ScalableVector2(Playlist.Width, 86);
+            UsePreviousSpriteBatchOptions = true;
+
+            CreateButton();
+            CreateTitle();
+            CreateBannerImage();
+            CreateMapCount();
+            CreateCreator();
+            CreateDifficultyDisplay();
+            CreateRankedStatus();
+            CreateGameModes();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Button.Width = Width;
+
+            PerformHoverAnimation(gameTime);
+            base.Update(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        public void UpdateContent(Playlist item, int index)
+        {
+            Title.Text = item.Name;
+            MapCount.ChangeValue(item.Maps.Count.ToString("n0"));
+
+            const int metadataSpacing = 4;
+
+            Creator.ChangeValue(item.Creator);
+            Creator.X = MapCount.X + MapCount.Width + metadataSpacing;
+
+            if (item.Maps.Count != 0)
+            {
+                DifficultyDisplay.ChangeValue(item.Maps.Min(x => x.DifficultyFromMods(ModManager.Mods)),
+                    item.Maps.Max(x => x.DifficultyFromMods(ModManager.Mods)));
+            }
+            else
+                DifficultyDisplay.ChangeValue(0, 0);
+
+            DifficultyDisplay.X = Creator.X + Creator.Width + metadataSpacing;
+
+            RankedStatusSprite.Image = GetRankedStatusImage();
+            GameModes.Image = GetGameModeImage();
+
+            if (Playlist.IsSelected)
+                Select(true);
+            else
+                Deselect(true);
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Button"/>
+        /// </summary>
+        private void CreateButton()
+        {
+            Button = new ImageButton(WobbleAssets.WhiteBox)
+            {
+                Parent = this,
+                Size = Size,
+                Alpha = 0,
+                Alignment = Alignment.MidCenter,
+                UsePreviousSpriteBatchOptions = true,
+                Depth = 1
+            };
+
+            Button.Clicked += (sender, args) => PlaylistManager.Selected.Value = Playlist.Item;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void PerformHoverAnimation(GameTime gameTime)
+        {
+            var targetAlpha = Button.IsHovered ? 0.35f : 0;
+
+            Button.Alpha = MathHelper.Lerp(Button.Alpha, targetAlpha,
+                (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / 30, 1));
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Select(bool changeWidthInstantly = false)
+        {
+            Image = UserInterface.SelectedMapset;
+
+            const int time = 200;
+            AnimateSprites(1, 200);
+
+            if (changeWidthInstantly)
+                Width = Playlist.Width;
+            else
+                ChangeWidthTo((int) Playlist.Width, Easing.OutQuint, time + 400);
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Deselect(bool changeWidthInstantly = false)
+        {
+            Image = UserInterface.DeselectedMapset;
+
+            const int time = 200;
+            AnimateSprites(0.85f, 200);
+
+            if (changeWidthInstantly)
+                Width = Playlist.Width - 50;
+            else
+                ChangeWidthTo((int) Playlist.Width - 50, Easing.OutQuint, time + 400);
+        }
+
+        /// <summary>
+        ///     Creates <see cref="Title"/>
+        /// </summary>
+        private void CreateTitle()
+        {
+            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "PLAYLIST TITLE", 26)
+            {
+                Parent = this,
+                Position = new ScalableVector2(TitleX, 18),
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        ///    Creates <see cref="Banner"/>
+        /// </summary>
+        private void CreateBannerImage()
+        {
+            Banner = new Sprite()
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(421, 82),
+                Image = UserInterface.DefaultBanner,
+                X = -2,
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateMapCount()
+        {
+            MapCount = new PlaylistKeyValueDisplay("Maps:", "0", ColorHelper.HexToColor("#00FFDE"))
+            {
+                Parent = this,
+                Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateCreator()
+        {
+            Creator = new PlaylistKeyValueDisplay("Creator:", "Me", ColorHelper.HexToColor("#0587E5"))
+            {
+                Parent = this,
+                Position = new ScalableVector2(Title.X, MapCount.Y),
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        private void CreateDifficultyDisplay()
+        {
+            DifficultyDisplay = new PlaylistDifficultyDisplay()
+            {
+                Parent = this,
+                UsePreviousSpriteBatchOptions = true,
+                Y = MapCount.Y
+            };
+        }
+
+        /// <summary>
+        ///     Creates <see cref="RankedStatusSprite"/>
+        /// </summary>
+        private void CreateRankedStatus()
+        {
+            RankedStatusSprite = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(115, 28),
+                X = Banner.X - Banner.Width - 18,
+                Image = UserInterface.StatusPanel,
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateGameModes()
+        {
+            GameModes = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                Size = new ScalableVector2(71, 28),
+                X = RankedStatusSprite.X - RankedStatusSprite.Width - 18,
+                UsePreviousSpriteBatchOptions = true
+            };
+        }
+
+        /// <summary>
+        ///     Retrieves the color of a map's ranked status
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private Texture2D GetRankedStatusImage()
+        {
+            if (Playlist.Item.Maps.Count == 0)
+                return UserInterface.StatusNone;
+
+            if (Playlist.Item.PlaylistGame == MapGame.Osu)
+                return UserInterface.StatusOtherGameOsu;
+
+            if (Playlist.Item.Maps.Any(o => o.RankedStatus != Playlist.Item.Maps.First().RankedStatus))
+                return UserInterface.StatusVarious;
+
+            switch (Playlist.Item.Maps.Max(x => x.RankedStatus))
+            {
+                case RankedStatus.NotSubmitted:
+                    return UserInterface.StatusNotSubmitted;
+                case RankedStatus.Unranked:
+                    return UserInterface.StatusUnranked;
+                case RankedStatus.Ranked:
+                    return UserInterface.StatusRanked;
+                case RankedStatus.DanCourse:
+                    return UserInterface.StatusNotSubmitted;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        /// <summary>
+        ///     Gets the image for the game mode(s)
+        /// </summary>
+        /// <returns></returns>
+        private Texture2D GetGameModeImage()
+        {
+            if (Playlist.Item.Maps.Count == 0)
+                return UserInterface.KeysNonePanel;
+
+            var has4k = false;
+            var has7K = false;
+
+            foreach (var map in Playlist.Item.Maps)
+            {
+                switch (map.Mode)
+                {
+                    case GameMode.Keys4:
+                        has4k = true;
+                        break;
+                    case GameMode.Keys7:
+                        has7K = true;
+                        break;
+                }
+            }
+
+            if (has4k && !has7K)
+                return UserInterface.Keys4Panel;
+            if (has7K && !has4k)
+                return UserInterface.Keys7Panel;
+
+            return UserInterface.BothModesPanel;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="fade"></param>
+        /// <param name="time"></param>
+        private void AnimateSprites(float fade, int time)
+        {
+            Title.ClearAnimations();
+            Title.FadeTo(fade, Easing.Linear, time);
+
+            MapCount.RemoveAnimations();
+            MapCount.FadeTo(fade, Easing.Linear, time);
+
+            Creator.RemoveAnimations();
+            Creator.FadeTo(fade, Easing.Linear, time);
+
+            DifficultyDisplay.RemoveAnimations();
+            DifficultyDisplay.FadeTo(fade, Easing.Linear, time);
+
+            RankedStatusSprite.ClearAnimations();
+            RankedStatusSprite.FadeTo(fade, Easing.Linear, time);
+
+            GameModes.ClearAnimations();
+            GameModes.FadeTo(fade, Easing.Linear, time);
+
+            ClearAnimations();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Database.Playlists;
+using Quaver.Shared.Graphics.Containers;
+using Quaver.Shared.Screens.Selection.UI.Mapsets;
+using Wobble.Bindables;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Selection.UI.Playlists
+{
+    public class PlaylistContainer : SongSelectContainer<Playlist>
+    {
+        /// <summary>
+        /// </summary>
+        public override SelectScrollContainerType Type { get; } = SelectScrollContainerType.Playlists;
+
+        /// <summary>
+        /// </summary>
+        public Bindable<SelectScrollContainerType> ActiveScrollContainer { get; }
+
+        /// <summary>
+        ///     The amount of time that has elapsed since the user requested to initialize the mapsets
+        /// </summary>
+        private double TimeElapsedUntilInitializationRequest { get; set; } = ReinitializeTime;
+
+        /// <summary>
+        ///     The time it takes until the mapsets will reinitialize
+        /// </summary>
+        private const int ReinitializeTime = 250;
+
+        /// <summary>
+        ///     If the mapsets have reinitialized
+        /// </summary>
+        private bool HasReinitialized { get; set; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="activeScrollContainer"></param>
+        public PlaylistContainer(Bindable<SelectScrollContainerType> activeScrollContainer) : base(PlaylistManager.Playlists, 12)
+        {
+            ActiveScrollContainer = activeScrollContainer;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            TimeElapsedUntilInitializationRequest += gameTime.ElapsedGameTime.TotalMilliseconds;
+            InitializePlaylists(false);
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        protected override float GetSelectedPosition() => (-SelectedIndex.Value + 4) * DrawableMapset.MapsetHeight;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        protected override PoolableSprite<Playlist> CreateObject(Playlist item, int index) => new DrawablePlaylist(this, item, index);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        protected override void HandleInput(GameTime gameTime)
+        {
+            if (ActiveScrollContainer.Value != SelectScrollContainerType.Playlists)
+                return;
+
+            // Move to the next mapset
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
+            {
+                if (SelectedIndex.Value + 1 >= AvailableItems.Count)
+                    return;
+
+                PlaylistManager.Selected.Value = AvailableItems[SelectedIndex.Value + 1];
+                SelectedIndex.Value++;
+
+                ScrollToSelected();
+            }
+            // Move to the previous mapset
+            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left))
+            {
+                if (SelectedIndex.Value - 1 < 0)
+                    return;
+
+                PlaylistManager.Selected.Value = AvailableItems[SelectedIndex.Value - 1];
+
+                SelectedIndex.Value--;
+                ScrollToSelected();
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        protected override void SetSelectedIndex()
+        {
+            SelectedIndex.Value = AvailableItems.FindIndex(x => x == PlaylistManager.Selected.Value);
+
+            var oldValue = SelectedIndex.Value;
+
+            if (SelectedIndex.Value == -1)
+                SelectedIndex.Value = 0;
+
+            // Manually trigger the change event in the case that the selected index is still the same value.
+            // Other components that rely on the bindable will want to update their state in case
+            // the mapset has changed in any way.
+            if (oldValue == SelectedIndex.Value)
+                SelectedIndex.TriggerChangeEvent();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private void InitializePlaylists(bool restart)
+        {
+            if (restart)
+            {
+                TimeElapsedUntilInitializationRequest = 0;
+                HasReinitialized = false;
+                return;
+            }
+
+            if (TimeElapsedUntilInitializationRequest < ReinitializeTime || HasReinitialized)
+                return;
+
+            lock (Pool)
+            {
+                DestroyAndClearPool();
+
+                AvailableItems = PlaylistManager.Playlists;
+
+                SetSelectedIndex();
+
+                // Reset the starting index so we can be aware of the mapsets that are needed
+                PoolStartingIndex = GetPoolStartingIndex();
+
+                // Recreate the object pool
+                CreatePool();
+                PositionAndContainPoolObjects();
+
+                // Snap to it immediately
+                SnapToSelected();
+            }
+
+            HasReinitialized = true;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistKeyValueDisplay.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistKeyValueDisplay.cs
@@ -1,0 +1,54 @@
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+
+namespace Quaver.Shared.Screens.Selection.UI.Playlists
+{
+    public class PlaylistKeyValueDisplay : TextKeyValue
+    {
+        /// <summary>
+        /// </summary>
+        public Sprite DividerLine { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="value"></param>
+        /// <param name="keyColor"></param>
+        public PlaylistKeyValueDisplay(string key, string value, Color keyColor, bool displayDividerLine = true) : base(key, value, 20, keyColor)
+        {
+            UsePreviousSpriteBatchOptions = true;
+            Key.UsePreviousSpriteBatchOptions = true;
+            Value.UsePreviousSpriteBatchOptions = true;
+
+            Key.Tint = ColorHelper.HexToColor("#808080");
+
+            DividerLine = new SpriteTextPlus(Key.Font, "|", Key.FontSize)
+            {
+                Parent = this,
+                Position = new ScalableVector2(Value.X + Value.Width + 4, 0),
+                Tint = ColorHelper.HexToColor("#808080"),
+                UsePreviousSpriteBatchOptions = true,
+                Visible = displayDividerLine,
+                Y = Value.Y
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void UpdateSize()
+        {
+            base.UpdateSize();
+
+            if (DividerLine.Visible)
+            {
+                DividerLine.X = Value.X + Value.Width + 4;
+                Width += DividerLine.Width + 4;
+            }
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Tests/DrawablePlaylists/TestScreenDrawablePlaylist.cs
+++ b/Quaver.Shared/Screens/Tests/DrawablePlaylists/TestScreenDrawablePlaylist.cs
@@ -1,0 +1,11 @@
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Tests.DrawablePlaylists
+{
+    public sealed class TestScreenDrawablePlaylist : Screen
+    {
+        public override ScreenView View { get; protected set; }
+
+        public TestScreenDrawablePlaylist() => View = new TestScreenDrawablePlaylistView(this);
+    }
+}

--- a/Quaver.Shared/Screens/Tests/DrawablePlaylists/TestScreenDrawablePlaylistView.cs
+++ b/Quaver.Shared/Screens/Tests/DrawablePlaylists/TestScreenDrawablePlaylistView.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Quaver.API.Enums;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Database.Playlists;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Selection.UI.Playlists;
+using Wobble;
+using Wobble.Graphics;
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Tests.DrawablePlaylists
+{
+    public class TestScreenDrawablePlaylistView : ScreenView
+    {
+        public TestScreenDrawablePlaylistView(Screen screen) : base(screen)
+        {
+            var mapset = new Mapset()
+            {
+                Maps = new List<Map>()
+                {
+                    new Map()
+                    {
+                        Artist = "Swan",
+                        Title = "Left Right",
+                        Creator = "Test",
+                        DifficultyName = "Offset Calibrator",
+                        Md5Checksum = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
+                        Difficulty10X = 12.34,
+                        Mode = GameMode.Keys4,
+                        RankedStatus = RankedStatus.Ranked
+                    },
+                    new Map()
+                    {
+                        Artist = "Swan",
+                        Title = "Left Right",
+                        Creator = "Test2",
+                        DifficultyName = "Offset Calibrator",
+                        Md5Checksum = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
+                        Difficulty10X = 42.69,
+                        Mode = GameMode.Keys4,
+                        RankedStatus = RankedStatus.Unranked
+                    },
+                }
+            };
+
+            var playlist = new Playlist()
+            {
+                Name = "Favorite Maps",
+                Creator = "Test User",
+                Description = "???",
+                Maps = mapset.Maps,
+                PlaylistGame = MapGame.Quaver,
+            };
+
+            var playlist2 = new Playlist()
+            {
+                Name = "Maps To Clear",
+                Creator = "Player",
+                Description = "???",
+                Maps = playlist.Maps,
+                PlaylistGame = MapGame.Quaver,
+            };
+
+            // ReSharper disable once ObjectCreationAsStatement
+            new DrawablePlaylist(null, playlist, 0)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter
+            };
+
+            // ReSharper disable once ObjectCreationAsStatement
+            new DrawablePlaylist(null, new Playlist()
+            {
+                Name = "Maps To Clear",
+                Creator = "Player",
+                Maps = new List<Map>()
+                {
+                    new Map()
+                    {
+                        Mode = GameMode.Keys7,
+                        Difficulty10X = 24.60,
+                        RankedStatus = RankedStatus.Unranked
+                    }
+                }
+            }, 1)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter,
+                Y = 100
+            };
+
+            // ReSharper disable once ObjectCreationAsStatement
+            new DrawablePlaylist(null, new Playlist()
+            {
+                Name = "Empty Playlist",
+                Creator = "Player",
+                Maps = new List<Map>()
+            }, 1)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter,
+                Y = 200
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime) => Container?.Update(gameTime);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(ColorHelper.HexToColor("#2f2f2f"));
+            Container?.Draw(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy() => Container?.Destroy();
+    }
+}


### PR DESCRIPTION
- Implements the first step of #354 .
- Adds a `DrawablePlaylist` component + visual test
- Adds a `PlaylistContainer` in the new song select screen to view and interact with Quaver-created playlists & osu! collections if the user has their db linked.