### PR TITLE
Song Select Container Input Changes

### DIFF
--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -183,7 +183,7 @@ namespace Quaver.Shared.Screens.Selection
             HandleKeyPressF3();
             HandleKeyPressEnter();
             HandleKeyPressControlInput();
-            HandleRightMouseButtonClick();
+            HandleThumb1MouseButtonClick();
         }
 
         /// <summary>
@@ -309,12 +309,12 @@ namespace Quaver.Shared.Screens.Selection
         }
 
         /// <summary>
-        ///     Handles when the user clicks the right mouse button.
+        ///     Handles when the user clicks the thumb1 mouse button.
         ///     If the user has the maps container open, this'll bring back the mapset container
         /// </summary>
-        private void HandleRightMouseButtonClick()
+        private void HandleThumb1MouseButtonClick()
         {
-            if (!MouseManager.IsUniqueClick(MouseButton.Right))
+            if (!MouseManager.IsUniqueClick(MouseButton.Thumb1))
                 return;
 
             var view = (SelectionScreenView) View;

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/Maps/MapScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/Maps/MapScrollContainer.cs
@@ -88,7 +88,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets.Maps
                 return;
 
             // Move to the next mapset
-            if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Right) || KeyboardManager.IsUniqueKeyPress(Keys.Down))
             {
                 if (SelectedIndex.Value + 1 >= CurrentMapset.Maps.Count)
                     return;
@@ -99,7 +99,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets.Maps
                 ScrollToSelected();
             }
             // Move to the previous mapset
-            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left))
+            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left) || KeyboardManager.IsUniqueKeyPress(Keys.Up))
             {
                 if (SelectedIndex.Value - 1 < 0)
                     return;

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -121,7 +121,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 return;
 
             // Move to the next mapset
-            if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Right) || KeyboardManager.IsUniqueKeyPress(Keys.Down))
             {
                 if (SelectedIndex.Value + 1 >= AvailableMapsets.Value.Count)
                     return;
@@ -132,7 +132,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 ScrollToSelected();
             }
             // Move to the previous mapset
-            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left))
+            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left) || KeyboardManager.IsUniqueKeyPress(Keys.Up))
             {
                 if (SelectedIndex.Value - 1 < 0)
                     return;

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 return;
 
             // Move to the next mapset
-            if (KeyboardManager.IsUniqueKeyPress(Keys.Right))
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Right) || KeyboardManager.IsUniqueKeyPress(Keys.Down))
             {
                 if (SelectedIndex.Value + 1 >= AvailableItems.Count)
                     return;
@@ -92,7 +92,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 ScrollToSelected();
             }
             // Move to the previous mapset
-            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left))
+            else if (KeyboardManager.IsUniqueKeyPress(Keys.Left) || KeyboardManager.IsUniqueKeyPress(Keys.Up))
             {
                 if (SelectedIndex.Value - 1 < 0)
                     return;


### PR DESCRIPTION
- Changes the keybind to go from maps->mapsets or maps->playlists to thumb1 instead of right-click.
- Allows the song select containers to be controlled with up and down instead of only left and right.