### PR TITLE
Right Click Options Component + DrawableMapset Right Click Options

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -482,7 +482,7 @@ namespace Quaver.Shared.Database.Maps
         /// </summary>
         public void OpenFolder()
         {
-            if (MapManager.Selected.Value.Game != MapGame.Quaver)
+            if (Game != MapGame.Quaver)
             {
                 NotificationManager.Show(NotificationLevel.Error, "You cannot open a folder for a map loaded from another game.");
                 return;

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Maps.Parsers;
 using Quaver.Shared.Config;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Helpers;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Database.Maps
@@ -135,6 +137,23 @@ namespace Quaver.Shared.Database.Maps
                 default:
                     return "";
             }
+        }
+
+        /// <summary>
+        ///     Views the online listing page on the website
+        /// </summary>
+        public static void ViewOnlineListing()
+        {
+            if (Selected.Value == null)
+                return;
+
+            if (Selected.Value.MapId == -1)
+            {
+                NotificationManager.Show(NotificationLevel.Error, "This map is not submitted online!");
+                return;
+            }
+
+            BrowserHelper.OpenURL($"https://quavergame.com/mapsets/map/{Selected.Value.MapId}");
         }
     }
 }

--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -33,7 +33,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <summary>
         ///     The chevron pointing down on the dropdown
         /// </summary>
-        private Sprite Chevron { get; set; }
+        public Sprite Chevron { get; private set; }
 
         /// <summary>
         ///     The text of the selected item
@@ -57,7 +57,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         ///     When the dropdown is opened/closed, this will give it a clipping rectangle effect, so that
         ///     the dropdown gradually is opening/closing
         /// </summary>
-        public ScrollContainer ItemContainer { get; set; }
+        public ScrollContainer ItemContainer { get; private set; }
 
         /// <summary>
         ///     The clickable items in the dropdown
@@ -72,12 +72,12 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <summary>
         ///     The line that divides the top element from the items
         /// </summary>
-        private Sprite DividerLine { get; set; }
+        public Sprite DividerLine { get; private set; }
 
         /// <summary>
         ///     The sprite that lights up when hovered
         /// </summary>
-        private Sprite HoverSprite { get; set; }
+        public Sprite HoverSprite { get; private set; }
 
         /// <summary>
         ///     Event invoked when an item was selected in the dropdown
@@ -208,7 +208,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <summary>
         ///     Creates the items to be used in the dropdown
         /// </summary>
-        private void CreateItems()
+        public void CreateItems()
         {
             Items = new List<DropdownItem>();
 

--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <summary>
         ///     The index of the selected option in <see cref="Options"/>
         /// </summary>
-        private int SelectedIndex { get; set; }
+        public int SelectedIndex { get; protected set; }
 
         /// <summary>
         ///     The color of the text elements

--- a/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.Xna.Framework;
 using Quaver.Shared.Assets;
 using Wobble.Graphics;
+using Wobble.Graphics.UI.Buttons;
 
 namespace Quaver.Shared.Graphics.Form.Dropdowns.RightClick
 {
@@ -21,9 +22,12 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns.RightClick
             DividerLine.Visible = false;
             HoverSprite.Visible = false;
             Alpha = 0;
-            ItemContainer.Y = 0;
             IsClickable = false;
+            DestroyIfParentIsNull = false;
+            ItemContainer.Y = 0;
 
+            // Remove the button entirely to prevent depth collisions since the original dropdown opener isn't needed
+            ButtonManager.Remove(this);
 
             var i = 0;
 
@@ -37,6 +41,9 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns.RightClick
             }
 
             Open();
+
+            SelectedIndex = -1;
+            ItemSelected += (sender, args) => SelectedIndex = -1;
         }
     }
 }

--- a/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Graphics.Form.Dropdowns.RightClick
+{
+    public class RightClickOptions : Dropdown
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="size"></param>
+        /// <param name="fontSize"></param>
+        public RightClickOptions(Dictionary<string, Color> options, ScalableVector2 size, int fontSize) : base(options.Keys.ToList(), size, fontSize, Color.White)
+        {
+            Chevron.Visible = false;
+            SelectedText.Visible = false;
+            DividerLine.Visible = false;
+            HoverSprite.Visible = false;
+            Alpha = 0;
+            ItemContainer.Y = 0;
+            IsClickable = false;
+
+
+            var i = 0;
+
+            foreach (var option in options)
+            {
+                if (i == 0)
+                    Items[i].Image = UserInterface.DropdownOpen;
+
+                Items[i].Text.Tint = option.Value;
+                i++;
+            }
+
+            Open();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/QuaverScreen.cs
+++ b/Quaver.Shared/Screens/QuaverScreen.cs
@@ -8,8 +8,12 @@
 using System;
 using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects;
+using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
+using Wobble.Graphics;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Input;
 using Wobble.Screens;
+using Wobble.Window;
 
 namespace Quaver.Shared.Screens
 {
@@ -40,6 +44,11 @@ namespace Quaver.Shared.Screens
         /// </summary>
         public event EventHandler<ScreenExitingEventArgs> ScreenExiting;
 
+        /// <summary>
+        ///     The currently active right click options for the screen
+        /// </summary>
+        private RightClickOptions ActiveRightClickOptions { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -68,6 +77,7 @@ namespace Quaver.Shared.Screens
         {
             Exiting = true;
             Button.IsGloballyClickable = false;
+            ActiveRightClickOptions?.Close();
 
             ScreenExiting?.Invoke(this, new ScreenExitingEventArgs());
 
@@ -77,6 +87,33 @@ namespace Quaver.Shared.Screens
                 QuaverScreenManager.ScheduleScreenChange(screen, false, type);
 
             ScreenExiting = null;
+        }
+
+        /// <summary>
+        ///     Activates right click options for the screen
+        /// </summary>
+        /// <param name="rco"></param>
+        public void ActivateRightClickOptions(RightClickOptions rco)
+        {
+            if (ActiveRightClickOptions != null)
+            {
+                ActiveRightClickOptions.Visible = false;
+                ActiveRightClickOptions.Parent = null;
+                ActiveRightClickOptions.Destroy();
+            }
+
+            ActiveRightClickOptions = rco;
+            ActiveRightClickOptions.Parent = View.Container;
+
+            ActiveRightClickOptions.ItemContainer.Height = 0;
+            ActiveRightClickOptions.Visible = true;
+
+            var x = MathHelper.Clamp(MouseManager.CurrentState.X - ActiveRightClickOptions.Width, 0,
+                WindowManager.Width - ActiveRightClickOptions.Width);
+
+            ActiveRightClickOptions.Position = new ScalableVector2(x, MouseManager.CurrentState.Y);
+
+            ActiveRightClickOptions.Open(350);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/QuaverScreen.cs
+++ b/Quaver.Shared/Screens/QuaverScreen.cs
@@ -6,6 +6,7 @@
 */
 
 using System;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
@@ -111,7 +112,10 @@ namespace Quaver.Shared.Screens
             var x = MathHelper.Clamp(MouseManager.CurrentState.X - ActiveRightClickOptions.Width, 0,
                 WindowManager.Width - ActiveRightClickOptions.Width);
 
-            ActiveRightClickOptions.Position = new ScalableVector2(x, MouseManager.CurrentState.Y);
+            var y = MathHelper.Clamp(MouseManager.CurrentState.Y, 0,
+                WindowManager.Height - ActiveRightClickOptions.Items.Count * ActiveRightClickOptions.Items.First().Height);
+
+            ActiveRightClickOptions.Position = new ScalableVector2(x, y);
 
             ActiveRightClickOptions.Open(350);
         }

--- a/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
+++ b/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
@@ -6,6 +6,7 @@ using Quaver.Shared.Scheduling;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Logging;
+using Wobble.Screens;
 
 namespace Quaver.Shared.Screens.Selection.Components
 {
@@ -14,6 +15,8 @@ namespace Quaver.Shared.Screens.Selection.Components
     /// </summary>
     public class SelectJukebox : Container
     {
+        private QuaverScreen Screen { get; }
+
         /// <summary>
         ///     If we're currently in the process of loading a track
         /// </summary>
@@ -21,8 +24,9 @@ namespace Quaver.Shared.Screens.Selection.Components
 
         /// <summary>
         /// </summary>
-        public SelectJukebox()
+        public SelectJukebox(QuaverScreen screen = null)
         {
+            Screen = screen;
             Size = new ScalableVector2(0, 0);
 
             if (MapManager.Selected != null)
@@ -56,6 +60,9 @@ namespace Quaver.Shared.Screens.Selection.Components
         /// </summary>
         private void KeepPlayingAudioTrackAtPreview()
         {
+            if (Screen != null && Screen.Exiting)
+                return;
+
             // No map is currently selected
             if (MapManager.Selected == null || MapManager.Selected.Value == null)
                 return;

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -460,7 +460,7 @@ namespace Quaver.Shared.Screens.Selection
                 return;
 
             if (AudioEngine.Track != null && AudioEngine.Track.IsPlaying)
-                AudioEngine.Track.Pause();
+                AudioEngine.Track.Stop();
 
             Exit(() => new EditorScreen(MapManager.Selected.Value.LoadQua()));
         }

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -160,7 +160,7 @@ namespace Quaver.Shared.Screens.Selection
         /// <summary>
         ///     Creates <see cref="Jukebox"/>
         /// </summary>
-        private void CreateJukebox() => Jukebox = new SelectJukebox { Parent = Container };
+        private void CreateJukebox() => Jukebox = new SelectJukebox(SelectScreen) { Parent = Container };
 
         /// <summary>
         ///     Creates <see cref="Background"/>

--- a/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonOnlineListing.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonOnlineListing.cs
@@ -15,19 +15,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Borders.Footer
     public class IconTextButtonOnlineListing : IconTextButton
     {
         public IconTextButtonOnlineListing() : base(FontAwesome.Get(FontAwesomeIcon.fa_earth_globe),
-            FontManager.GetWobbleFont(Fonts.LatoBlack),"Online Listing", (sender, args) =>
-            {
-                if (MapManager.Selected.Value == null)
-                    return;
-
-                if (MapManager.Selected.Value.MapId == -1)
-                {
-                    NotificationManager.Show(NotificationLevel.Error, "This map is not submitted online!");
-                    return;
-                }
-
-                BrowserHelper.OpenURL($"https://quavergame.com/mapsets/map/{MapManager.Selected.Value.MapId}");
-            })
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Online Listing", (sender, args) => MapManager.ViewOnlineListing())
         {
         }
     }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -230,6 +230,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             };
 
             Button.Clicked += (sender, args) => OnMapsetClicked();
+            Button.RightClicked += (sender, args) =>
+            {
+                var game = (QuaverGame) GameBase.Game;
+                game?.CurrentScreen?.ActivateRightClickOptions(new MapsetRightClickOptions(ParentMapset));
+            };
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Scheduling;
+using Wobble;
+using Wobble.Bindables;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.Selection.UI.Mapsets
+{
+    public class MapsetRightClickOptions : RightClickOptions
+    {
+        private DrawableMapset Mapset { get; }
+
+        private const string Play = "Play";
+
+        private const string Edit = "Edit";
+
+        private const string ViewOnlineListing = "Online Listing";
+
+        private const string AddToPlaylist = "Add To Playlist";
+
+        private const string Delete = "Delete";
+
+        private const string Export = "Export";
+
+        private const string OpenMapsetFolder = "Open Folder";
+
+        /// <summary>
+        /// </summary>
+        public MapsetRightClickOptions(DrawableMapset mapset) : base(new Dictionary<string, Color>()
+        {
+            {Play, Color.White},
+            {Edit, ColorHelper.HexToColor("#F2994A")},
+            {AddToPlaylist, ColorHelper.HexToColor("#27B06E")},
+            {Delete, ColorHelper.HexToColor($"#FF6868")},
+            {Export, ColorHelper.HexToColor("#0787E3")},
+            {OpenMapsetFolder, ColorHelper.HexToColor("#9B51E0")},
+            {ViewOnlineListing, ColorHelper.HexToColor("#FFE76B")},
+        }, new ScalableVector2(200, 40), 22)
+        {
+            Mapset = mapset;
+
+            ItemSelected += (sender, args) =>
+            {
+                var game = (QuaverGame) GameBase.Game;
+                var selectScreen = game.CurrentScreen as SelectionScreen;
+
+                switch (args.Text)
+                {
+                    case Play:
+                        if (!mapset.Item.Maps.Contains(MapManager.Selected.Value))
+                            SelectMap(mapset.Item.Maps.First());
+
+                        if (MapsetHelper.IsSingleDifficultySorted())
+                            selectScreen?.ExitToGameplay();
+                        else if (selectScreen != null)
+                            selectScreen.ActiveScrollContainer.Value = SelectScrollContainerType.Maps;
+                        break;
+                    case Edit:
+                        SelectMap(mapset.Item.Maps.First());
+                        selectScreen?.ExitToEditor();
+                        break;
+                    case ViewOnlineListing:
+                        MapManager.ViewOnlineListing();
+                        break;
+                    case Delete:
+                        break;
+                    case AddToPlaylist:
+                        break;
+                    case Export:
+                        ThreadScheduler.Run(() =>
+                        {
+                            NotificationManager.Show(NotificationLevel.Info, "Exporting mapset to zip archive. Please wait!");
+
+                            mapset.Item.Maps.First().Mapset.ExportToZip();
+
+                            NotificationManager.Show(NotificationLevel.Success,
+                                $"Successfully exported {MapManager.Selected.Value.Mapset.Artist} - {MapManager.Selected.Value.Mapset.Title}!");
+                        });
+                        break;
+                    case OpenMapsetFolder:
+                        mapset.Item.Maps.First().OpenFolder();
+                        break;
+                }
+            };
+        }
+
+        /// <summary>
+        ///     Selects a map and sets the appropriate index
+        /// </summary>
+        /// <param name="m"></param>
+        private void SelectMap(Map m)
+        {
+            MapManager.Selected.Value = m;
+
+            var container = (MapsetScrollContainer) Mapset.Container;
+            container.SelectedIndex.Value = Mapset.Index;
+            container.ScrollToSelected();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
@@ -15,7 +15,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 {
     public class MapsetRightClickOptions : RightClickOptions
     {
-        private DrawableMapset Mapset { get; }
+        private DrawableMapset DrawableMapset { get; }
+
+        private Mapset Mapset { get; }
 
         private const string Play = "Play";
 
@@ -33,7 +35,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 
         /// <summary>
         /// </summary>
-        public MapsetRightClickOptions(DrawableMapset mapset) : base(new Dictionary<string, Color>()
+        public MapsetRightClickOptions(DrawableMapset drawableMapset) : base(new Dictionary<string, Color>()
         {
             {Play, Color.White},
             {Edit, ColorHelper.HexToColor("#F2994A")},
@@ -44,7 +46,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {ViewOnlineListing, ColorHelper.HexToColor("#FFE76B")},
         }, new ScalableVector2(200, 40), 22)
         {
-            Mapset = mapset;
+            DrawableMapset = drawableMapset;
+            Mapset = DrawableMapset.Item;
 
             ItemSelected += (sender, args) =>
             {
@@ -54,8 +57,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 switch (args.Text)
                 {
                     case Play:
-                        if (!mapset.Item.Maps.Contains(MapManager.Selected.Value))
-                            SelectMap(mapset.Item.Maps.First());
+                        if (!Mapset.Maps.Contains(MapManager.Selected.Value))
+                            SelectMap(Mapset.Maps.First());
 
                         if (MapsetHelper.IsSingleDifficultySorted())
                             selectScreen?.ExitToGameplay();
@@ -63,7 +66,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                             selectScreen.ActiveScrollContainer.Value = SelectScrollContainerType.Maps;
                         break;
                     case Edit:
-                        SelectMap(mapset.Item.Maps.First());
+                        SelectMap(Mapset.Maps.First());
                         selectScreen?.ExitToEditor();
                         break;
                     case ViewOnlineListing:
@@ -78,14 +81,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                         {
                             NotificationManager.Show(NotificationLevel.Info, "Exporting mapset to zip archive. Please wait!");
 
-                            mapset.Item.Maps.First().Mapset.ExportToZip();
+                            Mapset.Maps.First().Mapset.ExportToZip();
 
                             NotificationManager.Show(NotificationLevel.Success,
                                 $"Successfully exported {MapManager.Selected.Value.Mapset.Artist} - {MapManager.Selected.Value.Mapset.Title}!");
                         });
                         break;
                     case OpenMapsetFolder:
-                        mapset.Item.Maps.First().OpenFolder();
+                        Mapset.Maps.First().OpenFolder();
                         break;
                 }
             };
@@ -99,8 +102,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         {
             MapManager.Selected.Value = m;
 
-            var container = (MapsetScrollContainer) Mapset.Container;
-            container.SelectedIndex.Value = Mapset.Index;
+            var container = (MapsetScrollContainer) DrawableMapset.Container;
+
+            var index = container.AvailableItems.IndexOf(Mapset);
+
+            if (index == -1)
+                return;
+            
+            container.SelectedIndex.Value = index;
             container.ScrollToSelected();
         }
     }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/SongSelectContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/SongSelectContainer.cs
@@ -138,7 +138,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// <summary>
         ///     Scrolls the container to the selected position
         /// </summary>
-        protected void ScrollToSelected()
+        public virtual void ScrollToSelected()
         {
             // Scroll the the place where the map is.
             var targetScroll = GetSelectedPosition();

--- a/Quaver.Shared/Screens/Tests/Dropdowns/DropdownTestScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/Dropdowns/DropdownTestScreenView.cs
@@ -2,14 +2,19 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Form;
 using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Graphics.Form.Dropdowns.Custom;
+using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
 using Quaver.Shared.Helpers;
 using Wobble;
 using Wobble.Graphics;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
 using Wobble.Input;
 using Wobble.Logging;
+using Wobble.Managers;
 using Wobble.Screens;
 
 namespace Quaver.Shared.Screens.Tests.Dropdowns
@@ -17,6 +22,8 @@ namespace Quaver.Shared.Screens.Tests.Dropdowns
     public class DropdownTestScreenView : ScreenView
     {
         private Dropdown Dropdown { get; }
+
+        private RightClickOptions RightClickOptions { get; }
 
         /// <inheritdoc />
         /// <summary>
@@ -56,6 +63,38 @@ namespace Quaver.Shared.Screens.Tests.Dropdowns
                 Parent = Container,
                 Alignment = Alignment.MidCenter,
                 X = 400
+            };
+
+            RightClickOptions = new RightClickOptions(new Dictionary<string, Color>()
+            {
+                {"Profile", Color.White},
+                {"Edit", Color.Yellow},
+                {"Add", Color.Green},
+                {"Delete", Color.Crimson},
+            }, new ScalableVector2(200, 40), 22)
+            {
+            };
+
+            var btn = new ImageButton(UserInterface.BlankBox)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidCenter,
+                Y = -300,
+                Size = new ScalableVector2(200, 50),
+                Tint = Color.DarkRed
+            };
+
+            btn.RightClicked += (o, args) =>
+            {
+                RightClickOptions.Parent = btn;
+                RightClickOptions.Alignment = Alignment.MidCenter;
+                RightClickOptions.Open();
+            };
+
+            new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoHeavy), "Right-Click Me", 22)
+            {
+                Parent = btn,
+                Alignment = Alignment.MidCenter
             };
         }
 


### PR DESCRIPTION
- Adds a component for right-click options
- Adds an `ActiveRightClickOptions` property to `QuaverScreen` - allowing it to keep track of one set of options.
- Adds right click options for DrawableMapset