### PR TITLE
Zoom Out Generated Mapset Banners

### DIFF
--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -305,6 +305,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 }
 
                 CreateBanner(mapTexture, mapset);
+
                 bannersToRemove.Add(mapset);
             }
 
@@ -383,6 +384,28 @@ namespace Quaver.Shared.Graphics.Backgrounds
             // Mask the image and draw it to a RenderTarget
             GameBase.Game.ScheduledRenderTargetDraws.Add(() =>
             {
+                // Create a RenderTarget with mipmapping with the original texuture.
+                var mipmapped = new RenderTarget2D(GameBase.Game.GraphicsDevice, mapTexture.Width, mapTexture.Height, true,
+                    GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None);
+
+                GameBase.Game.GraphicsDevice.SetRenderTarget(mipmapped);
+                GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
+
+                var textureSprite = new Sprite
+                {
+                    Size = new ScalableVector2(mapTexture.Width, mapTexture.Height),
+                    Image = mapTexture,
+                    SpriteBatchOptions = new SpriteBatchOptions()
+                    {
+                        DoNotScale = true,
+                        SamplerState = SamplerState.PointClamp
+                    }
+                };
+
+                textureSprite.Draw(new GameTime());
+                GameBase.Game.SpriteBatch.End();
+
+                // Cache a smaller version of the texture to a RenderTarget
                 var size = new ScalableVector2(421, 82);
                 var scrollContainer = new ScrollContainer(size, size);
 
@@ -391,7 +414,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
                     Alignment = Alignment.MidCenter,
                     // Small 16:9 resolution size to make backgrounds look a bit better and zoomed out
                     Size = new ScalableVector2(448, 252),
-                    Image = mapTexture
+                    Image = mipmapped
                 };
 
                 scrollContainer.AddContainedDrawable(maskedSprite);
@@ -412,6 +435,10 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 GameBase.Game.GraphicsDevice.SetRenderTarget(null);
                 scrollContainer?.Destroy();
                 maskedSprite?.Destroy();
+
+                textureSprite.Destroy();
+                mipmapped?.Dispose();
+                mapTexture.Dispose();
 
                 if (mapset != null)
                 {

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -390,9 +390,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 {
                     Alignment = Alignment.MidCenter,
                     // Small 16:9 resolution size to make backgrounds look a bit better and zoomed out
-                    Size = new ScalableVector2(1024, 576),
-                    // This y offset usually captures the best part of the image (such as faces or text)
-                    Y = 100,
+                    Size = new ScalableVector2(448, 252),
                     Image = mapTexture
                 };
 

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -386,7 +386,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
             {
                 // Create a RenderTarget with mipmapping with the original texuture.
                 var mipmapped = new RenderTarget2D(GameBase.Game.GraphicsDevice, mapTexture.Width, mapTexture.Height, true,
-                    GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None);
+                    SurfaceFormat.Bgr565, DepthFormat.Depth24Stencil8);
 
                 GameBase.Game.GraphicsDevice.SetRenderTarget(mipmapped);
                 GameBase.Game.GraphicsDevice.Clear(Color.Transparent);


### PR DESCRIPTION
Makes generated mapset banners appear more zoomed out to display more of the image. This should help with identifying maps solely by their backgrounds if they don't already have a custom banner.

![image](https://user-images.githubusercontent.com/20389565/67295496-3495c800-f4b5-11e9-917d-9983a75189ca.png)

![image](https://user-images.githubusercontent.com/20389565/67294986-8be76880-f4b4-11e9-9d47-581a243cdecd.png)
