### PR TITLE
Fix soft-lock while play testing in the editor

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -303,6 +303,7 @@ namespace Quaver.Shared.Screens.Gameplay
             {
                 var testingQua = ObjectHelper.DeepClone(map);
                 testingQua.HitObjects.RemoveAll(x => x.StartTime < playTestTime);
+                Qua.RestoreDefaultValues(testingQua);
 
                 Map = testingQua;
                 OriginalEditorMap = map;


### PR DESCRIPTION
It was caused from the editor saving the .qua and not restoring default values before test playing. This caused an infinite loop while creating timing lines because the time signature was 0 instead of being defaulted back to 4/4