### PR TITLE
Prevent restart key from being pressed while spectating

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -889,7 +889,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         private void HandlePlayRestart(double dt)
         {
-            if (!IsPlayTesting && (IsPaused || Failed) || IsCalibratingOffset)
+            if (!IsPlayTesting && (IsPaused || Failed) || IsCalibratingOffset || SpectatorClient != null)
                 return;
 
             if (OnlineManager.CurrentGame != null)


### PR DESCRIPTION
Fixes #1252 