### PR TITLE
Fixed TaskHandler tasks bug

### DIFF
--- a/Quaver.Shared/Screens/Music/UI/Controller/Search/MusicControllerSearchPanel.cs
+++ b/Quaver.Shared/Screens/Music/UI/Controller/Search/MusicControllerSearchPanel.cs
@@ -220,7 +220,6 @@ namespace Quaver.Shared.Screens.Music.UI.Controller.Search
         {
             lock (AvailableSongs.Value)
             {
-                Logger.Important($"Filtering mapsets by -  Query: `{CurrentSearchQuery.Value}`", LogType.Runtime, false);
                 AvailableSongs.Value = MapsetHelper.FilterMapsets(CurrentSearchQuery, true);
             }
         }

--- a/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
+++ b/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
@@ -35,7 +35,6 @@ namespace Quaver.Shared.Screens.Selection.Components
 
             LoadTrackTask = new TaskHandler<int, int>((i, token) =>
             {
-                LogLoadingTrack();
                 AudioEngine.PlaySelectedTrackAtPreview();
                 AudioTrackStoppedInLastFrame = false;
                 return 0;
@@ -88,7 +87,10 @@ namespace Quaver.Shared.Screens.Selection.Components
                 return;
 
             if (AudioTrackStoppedInLastFrame && !LoadTrackTask.IsRunning)
+            {
+                LogLoadingTrack();
                 LoadTrackTask.Run(0);
+            }
 
             AudioTrackStoppedInLastFrame = AudioEngine.Track.HasPlayed && AudioEngine.Track.IsDisposed;
         }
@@ -114,6 +116,7 @@ namespace Quaver.Shared.Screens.Selection.Components
                 if (LoadTrackTask.IsRunning)
                     LoadTrackTask.Cancel();
 
+                LogLoadingTrack();
                 LoadTrackTask.Run(0);
             }
         }

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/SelectFilterPanel.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/SelectFilterPanel.cs
@@ -243,9 +243,8 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
         /// </summary>
         private void StartFilterMapsetsTask()
         {
-            if (FilterMapsetsTask.IsRunning)
-                FilterMapsetsTask.Cancel();
-
+            Logger.Important($"Filtering mapsets by -  Query: `{CurrentSearchQuery.Value}` | Sort By: {ConfigManager.SelectOrderMapsetsBy?.Value}",
+                LogType.Runtime, false);
             FilterMapsetsTask.Run(0);
         }
 
@@ -268,9 +267,6 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
         {
             lock (AvailableMapsets.Value)
             {
-                Logger.Important($"Filtering mapsets by -  Query: `{CurrentSearchQuery.Value}` | Sort By: {ConfigManager.SelectOrderMapsetsBy?.Value}",
-                    LogType.Runtime, false);
-
                 AvailableMapsets.Value = MapsetHelper.FilterMapsets(CurrentSearchQuery);
 
                 if (AvailableMapsets.Value.Count == 0)


### PR DESCRIPTION
Apparently logging inside a Task of a TaskHandler froze the game since it uses a different thread to run those tasks.