### PR TITLE
BackgroundHelper: fix busy loop in a thread

### DIFF
--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -207,13 +207,13 @@ namespace Quaver.Shared.Graphics.Backgrounds
         {
             while (true)
             {
+                Thread.Sleep(100);
+
                 if (MapsetBannersToLoad.Count == 0 && PlaylistBannersToLoad.Count == 0)
                     continue;
 
                 LoadAllMapsetBanners();
                 LoadAllPlaylistBanners();
-
-                Thread.Sleep(50);
             }
         }
 


### PR DESCRIPTION
Since banners aren't loaded as frequently (definitely not during gameplay), this should ideally use a condvar or something and not just loop constantly. But this fix is very simple and improves it significantly already.