### PR TITLE
Fix UnknownAvatar notification spam

### DIFF
--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/DrawableOnlineUser.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/DrawableOnlineUser.cs
@@ -215,7 +215,7 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Scrolling
                 Alignment = Alignment.MidLeft,
                 Size = new ScalableVector2(40, 40),
                 X = 16,
-                Image = UserInterface.YouAvatar,
+                Image = UserInterface.UnknownAvatar,
                 UsePreviousSpriteBatchOptions = true,
                 SetChildrenAlpha = true,
             };


### PR DESCRIPTION
More of an indirect fix to the notification spam when first opening the OnlineHub. Ideally [TextureManager](https://github.com/Quaver/Wobble/blob/master/Wobble/Managers/TextureManager.cs) should be thread-safe