### PR TITLE
Playfield Tilt Config (Prototype)

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -174,6 +174,16 @@ namespace Quaver.Shared.Config
         internal static Bindable<ScrollDirection> ScrollDirection7K { get; private set; }
 
         /// <summary>
+        ///     Determines how much tilt is applied to the 4K Playfield.
+        /// </summary>
+        internal static BindableInt PlayfieldTilt4K { get; private set; }
+
+        /// <summary>
+        ///     Determines how much tilt is applied to the 7K Playfield.
+        /// </summary>
+        internal static BindableInt PlayfieldTilt7K { get; private set; }
+
+        /// <summary>
         ///     The offset of the notes compared to the song start.
         /// </summary>
         internal static BindableInt GlobalAudioOffset { get; private set; }
@@ -654,6 +664,8 @@ namespace Quaver.Shared.Config
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 15, 5, 100, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);
             ScrollDirection7K = ReadValue(@"ScrollDirection7K", ScrollDirection.Down, data);
+            PlayfieldTilt4K = ReadInt(@"PlayfieldTilt4K", 0, -100, 100, data);
+            PlayfieldTilt7K = ReadInt(@"PlayfieldTilt7K", 0, -100, 100, data);
             GlobalAudioOffset = ReadInt(@"GlobalAudioOffset", 0, -300, 300, data);
             Skin = ReadSpecialConfigType(SpecialConfigType.Skin, @"Skin", "", data);
             DefaultSkin = ReadValue(@"DefaultSkin", DefaultSkins.Bar, data);
@@ -789,6 +801,8 @@ namespace Quaver.Shared.Config
                     DisplaySongTimeProgress.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed4K.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed7K.ValueChanged += AutoSaveConfiguration;
+                    PlayfieldTilt4K.ValueChanged += AutoSaveConfiguration;
+                    PlayfieldTilt7K.ValueChanged += AutoSaveConfiguration;
                     ScrollDirection4K.ValueChanged += AutoSaveConfiguration;
                     ScrollDirection7K.ValueChanged += AutoSaveConfiguration;
                     GlobalAudioOffset.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -326,6 +326,8 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
+            Screen.Ruleset?.PreDraw(gameTime);
+
             GameBase.Game.GraphicsDevice.Clear(Color.Black);
 
             Background.Draw(gameTime);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
@@ -107,6 +107,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets
         /// <param name="gameTime"></param>
         public void HandleInput(GameTime gameTime) => InputManager.HandleInput(gameTime.ElapsedGameTime.TotalMilliseconds);
 
+        /// <summary>
+        ///     This will handle anything that has to be rendered before the actual Draw() method.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public void PreDraw(GameTime gameTime) => Playfield.PreDraw(gameTime);
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/IGameplayPlayfield.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/IGameplayPlayfield.cs
@@ -22,5 +22,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets
         /// </summary>
         /// <param name="gameTime"></param>
         void HandleFailure(GameTime gameTime);
+
+        /// <summary>
+        ///     This will handle anything that has to be rendered before the actual Draw() method.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        void PreDraw(GameTime gameTime);
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -37,7 +37,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
         /// <inheritdoc />
         /// <summary>
-        /// </summary>
+        /// </summary>1
         public Container Container { get; set; }
 
         /// <summary>
@@ -341,14 +341,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             if (!PerspectiveEnabled)
                 return;
 
-            // Create Renderers and reference Viewport Size
-            var width = GameBase.Game.GraphicsDevice.Viewport.Width;
-            var height = GameBase.Game.GraphicsDevice.Viewport.Height;
+            // Create Renderers and reference Window Size
+            var width = (int)WindowManager.Width;
+            var height = (int)WindowManager.Height;
+            Console.WriteLine($"width: {width}, height: {height}");
 
-            PlayfieldRenderer = new RenderTarget2D(GameBase.Game.GraphicsDevice, width, height, false,
+            PlayfieldRenderer = new RenderTarget2D(GameBase.Game.GraphicsDevice, GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferWidth, GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferHeight, false,
                 GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
 
-            EffectRenderer = new RenderTarget2D(GameBase.Game.GraphicsDevice, width, height, false,
+            EffectRenderer = new RenderTarget2D(GameBase.Game.GraphicsDevice, GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferWidth, GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferHeight, false,
                 GameBase.Game.GraphicsDevice.PresentationParameters.BackBufferFormat, DepthFormat.None, 0, RenderTargetUsage.PreserveContents);
 
             // Compute for tilt.
@@ -356,7 +357,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             tilt = ScrollDirections[0] == ScrollDirection.Down ? tilt : tilt * -1;
 
             // Compute for warp.
-            var warp = 1 / ((-tilt / (width * TILT_MAX)) * TILT_EXP + 1);
+            var warp = 1f;
+            //var warp = 1 / ((-tilt / (width * TILT_MAX)) * TILT_EXP + 1);
 
             // Create Playfield Plane Points
             var points = new List<Vector2>();
@@ -369,7 +371,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                     points.Add(new Vector2((float)(i + 1) / PLANE_SUBDIVISIONS_COUNT_X, (float)j / PLANE_SUBDIVISIONS_COUNT_Y  ));
                     points.Add(new Vector2((float)i / PLANE_SUBDIVISIONS_COUNT_X, (float)(j + 1) / PLANE_SUBDIVISIONS_COUNT_Y  ));
 
-                    // Tri 2
+                    // Tri 2p
                     points.Add(new Vector2((float)i/ PLANE_SUBDIVISIONS_COUNT_X, (float)(j + 1) / PLANE_SUBDIVISIONS_COUNT_Y  ));
                     points.Add(new Vector2((float)(i + 1) / PLANE_SUBDIVISIONS_COUNT_X, (float)j / PLANE_SUBDIVISIONS_COUNT_Y  ));
                     points.Add(new Vector2((float)(i + 1) / PLANE_SUBDIVISIONS_COUNT_X, (float)(j + 1) / PLANE_SUBDIVISIONS_COUNT_Y  ));
@@ -380,9 +382,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             PlayfieldVertices = new VertexPositionTexture[PLANE_SUBDIVISIONS_COUNT_X * PLANE_SUBDIVISIONS_COUNT_Y * 6];
             for (var i = 0; i < points.Count; i++)
             {
-                var y = (float)Math.Pow(points[i].Y, warp);
-                var stretch = tilt * (2f * (y - 0.5f));
-                PlayfieldVertices[i].Position = new Vector3(points[i].X * (width + stretch  * 2) - stretch, y * height, 0);
+                var posY = ScrollDirections[0] == ScrollDirection.Down ? (float)Math.Pow(points[i].Y, warp) : (float)Math.Pow(points[i].Y, warp);
+                var posX = tilt * (2f * (points[i].Y - 0.5f));
+                PlayfieldVertices[i].Position = new Vector3(points[i].X * (width + posX * 2) - posX, posY * height, 0);
                 PlayfieldVertices[i].TextureCoordinate = points[i];
             }
 
@@ -400,9 +402,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             // Create Playfield Sprite. Image from Effect Renderer will be displayed on this.
             PlayfieldSprite = new Sprite()
             {
-                WidthScale = 1,
-                HeightScale = 1,
                 Parent = Container,
+                Size = new ScalableVector2(width, height),
                 Image = EffectRenderer
             };
         }
@@ -445,7 +446,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             // Reinitialize Sprite Batch for Draw()
             GameBase.Game.GraphicsDevice.SetRenderTarget(null);
-            GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied);
+            GameBase.DefaultSpriteBatchOptions.Begin();
+            //GameBase.Game.SpriteBatch.Begin();
+            //GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied);
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -345,7 +345,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 // Create individiaul receptor.
                 Receptors.Add(new Sprite
                 {
-                    Parent = Playfield.ForegroundContainer,
+                    Parent = Playfield.HitObjectContainer,
                     Size = new ScalableVector2(Playfield.LaneSize, Playfield.LaneSize * Skin.NoteReceptorsUp[i].Height / Skin.NoteReceptorsUp[i].Width),
                     Position = new ScalableVector2(posX, Playfield.ReceptorPositionY[i]),
                     Alignment = Alignment.TopLeft,
@@ -378,7 +378,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             Size = new ScalableVector2(Playfield.Width, 0, 0, 1),
             Alignment = Alignment.TopCenter,
-            Parent = Playfield.ForegroundContainer
+            Parent = Playfield.HitObjectContainer
         };
 
         /// <summary>
@@ -388,7 +388,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             Size = new ScalableVector2(Playfield.Width, 0, 0, 1),
             Alignment = Alignment.TopCenter,
-            Parent = Playfield.ForegroundContainer
+            Parent = Playfield.HitObjectContainer
         };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -349,6 +349,8 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsSlider(this, "Scroll Speed (7 Keys)", ConfigManager.ScrollSpeed7K),
                     new SettingsScrollDirection(this, "Scroll Direction 4K", ConfigManager.ScrollDirection4K),
                     new SettingsScrollDirection(this, "Scroll Direction 7K", ConfigManager.ScrollDirection7K),
+                    new SettingsSlider(this, "Playfield Tilt (4 Keys)", ConfigManager.PlayfieldTilt4K),
+                    new SettingsSlider(this, "Playfield Tilt (7 Keys)", ConfigManager.PlayfieldTilt7K),
                     new SettingsBool(this, "Blur Background In Gameplay", ConfigManager.BlurBackgroundInGameplay),
                     new SettingsBool(this, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                     new SettingsBool(this, "Display Song Time Progress", ConfigManager.DisplaySongTimeProgress),


### PR DESCRIPTION
# What is this?
This new feature will allow players to play the game at a simulated perspective (similar to guitar hero and stepmania hallway/distant)

If you would like to check out a video, click ![here](https://streamable.com/fpabs)

## Config
A `PlayfieldTilt4K` and `PlayfieldTilt7K` Config value was created for this feature.

## Image Plane
To render the Playfield, I've created a 2d plane in the form of a trapezoid. The plane is a simple geometry that consists of 4096 quads. Because of how UV maps work, this much detail is needed. Illustration below:

![](https://cdn.discordapp.com/attachments/502597245116350467/645961272667537408/zzz.png)

## PreDraw()
A `PreDraw` method was also created in the Playfield and Ruleset abstracts due to xna wiping the renderer everytime we change Render Targets. 