### PR TITLE
Implement Tournament Screen, Local Co-op, Theater Mode

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -460,13 +460,31 @@ namespace Quaver.Shared.Config
         ///     Keybindings for 7K
         /// </summary>
         internal static Bindable<Keys> KeyMania7K1 { get; private set; }
-
         internal static Bindable<Keys> KeyMania7K2 { get; private set; }
         internal static Bindable<Keys> KeyMania7K3 { get; private set; }
         internal static Bindable<Keys> KeyMania7K4 { get; private set; }
         internal static Bindable<Keys> KeyMania7K5 { get; private set; }
         internal static Bindable<Keys> KeyMania7K6 { get; private set; }
         internal static Bindable<Keys> KeyMania7K7 { get; private set; }
+
+        /// <summary>
+        ///     Keybindings for 4K (co-op 2 player)
+        /// </summary>
+        internal static Bindable<Keys> KeyCoop2P4K1 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P4K2 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P4K3 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P4K4 { get; private set; }
+
+        /// <summary>
+        ///     Keybindings for 7K (co-op 2 player)
+        /// </summary>
+        internal static Bindable<Keys> KeyCoop2P7K1 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K2 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K3 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K4 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K5 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K6 { get; private set; }
+        internal static Bindable<Keys> KeyCoop2P7K7 { get; private set; }
 
         /// <summary>
         ///     The key pressed to pause and menu-back.
@@ -650,6 +668,18 @@ namespace Quaver.Shared.Config
             KeyMania7K5 = ReadValue(@"KeyMania7K5", Keys.J, data);
             KeyMania7K6 = ReadValue(@"KeyMania7K6", Keys.K, data);
             KeyMania7K7 = ReadValue(@"KeyMania7K7", Keys.L, data);
+            KeyCoop2P4K1 = ReadValue(@"KeyCoop2P4K1", Keys.Z, data);
+            KeyCoop2P4K2 = ReadValue(@"KeyCoop2P4K2", Keys.X, data);
+            KeyCoop2P4K3 = ReadValue(@"KeyCoop2P4K3", Keys.OemComma, data);
+            KeyCoop2P4K4 = ReadValue(@"KeyCoop2P4K4", Keys.OemPeriod, data);
+            KeyCoop2P7K1 = ReadValue(@"KeyCoop2P7K1", Keys.Z, data);
+            KeyCoop2P7K2 = ReadValue(@"KeyCoop2P7K2", Keys.X, data);
+            KeyCoop2P7K3 = ReadValue(@"KeyCoop2P7K3", Keys.C, data);
+            KeyCoop2P7K4 = ReadValue(@"KeyCoop2P7K4", Keys.V, data);
+            KeyCoop2P7K5 = ReadValue(@"KeyCoop2P7K5", Keys.M, data);
+            KeyCoop2P7K6 = ReadValue(@"KeyCoop2P7K6", Keys.OemComma, data);
+            KeyCoop2P7K7 = ReadValue(@"KeyCoop2P7K7", Keys.OemPeriod, data);
+
             KeySkipIntro = ReadValue(@"KeySkipIntro", Keys.RightAlt, data);
             KeyPause = ReadValue(@"KeyPause", Keys.Escape, data);
             KeyToggleOverlay = ReadValue(@"KeyToggleOverlay", Keys.F8, data);
@@ -767,6 +797,17 @@ namespace Quaver.Shared.Config
                     KeyMania7K5.ValueChanged += AutoSaveConfiguration;
                     KeyMania7K6.ValueChanged += AutoSaveConfiguration;
                     KeyMania7K7.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P4K1.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P4K2.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P4K3.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P4K4.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K1.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K2.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K3.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K4.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K5.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K6.ValueChanged += AutoSaveConfiguration;
+                    KeyCoop2P7K7.ValueChanged += AutoSaveConfiguration;
                     KeySkipIntro.ValueChanged += AutoSaveConfiguration;
                     KeyPause.ValueChanged += AutoSaveConfiguration;
                     KeyToggleOverlay.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -138,6 +138,9 @@ namespace Quaver.Shared.Database.Maps
                         case QuaverScreenType.Results:
                         case QuaverScreenType.Select:
                             break;
+                        // Replay imports are handled by the screen itself
+                        case QuaverScreenType.Theatre:
+                            return;
                         default:
                             NotificationManager.Show(NotificationLevel.Error, "Please exit this screen before loading a replay");
                             return;

--- a/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonTheater.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonTheater.cs
@@ -1,0 +1,27 @@
+using Quaver.API.Enums;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Download;
+using Quaver.Shared.Screens.Settings;
+using Quaver.Shared.Screens.Theater;
+using Wobble;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Graphics.Menu.Border.Components.Buttons
+{
+    public class IconTextButtonTheater: IconTextButton
+    {
+        public IconTextButtonTheater() : base(FontAwesome.Get(FontAwesomeIcon.fa_photo_camera),
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Theater", (sender, args) =>
+            {
+                var game = (QuaverGame) GameBase.Game;
+                game.CurrentScreen.Exit(() => new TheaterScreen());
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Graphics/Menu/Border/MenuHeaderMain.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/MenuHeaderMain.cs
@@ -27,6 +27,7 @@ namespace Quaver.Shared.Graphics.Menu.Border
                     }),
                 new IconTextButtonDownloadMaps(),
                 new IconTextButtonMusicPlayer(),
+                new IconTextButtonTheater(),
                 new IconTextButtonLeaderboards(),
             },
             new List<Drawable>

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -115,6 +115,9 @@ namespace Quaver.Shared.Modifiers
                 case ModIdentifier.Mirror:
                     gameplayModifier = new ModMirror();
                     break;
+                case ModIdentifier.Coop:
+                    gameplayModifier = new ModCoop();
+                    break;
                 default:
                     return;
             }

--- a/Quaver.Shared/Modifiers/Mods/ModCoop.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModCoop.cs
@@ -1,0 +1,31 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Enums;
+using Quaver.Shared.Helpers;
+
+namespace Quaver.Shared.Modifiers.Mods
+{
+    public class ModCoop : IGameplayModifier
+    {
+        public string Name { get; set; } = "Co-op";
+
+        public ModIdentifier ModIdentifier { get; set; } = ModIdentifier.Coop;
+
+        public ModType Type { get; set; } = ModType.Special;
+
+        public string Description { get; set; } = "Grab a friend, and play together. You do have friends... right?";
+
+        public bool Ranked { get; set; } = false;
+
+        public bool AllowedInMultiplayer { get; set; } = false;
+
+        public bool OnlyMultiplayerHostCanCanChange { get; set; } = false;
+
+        public ModIdentifier[] IncompatibleMods { get; set; } = { };
+
+        public Color ModColor { get; } = ColorHelper.HexToColor("#44d6f5");
+
+        public void InitializeMod()
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -72,37 +72,37 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     The progress bar that displays the current song time.
         /// </summary>
-        private SongTimeProgressBar ProgressBar { get; set; }
+        public SongTimeProgressBar ProgressBar { get; private set; }
 
         /// <summary>
         ///     The display for the user's score.
         /// </summary>
-        private NumberDisplay ScoreDisplay { get; set; }
+        public NumberDisplay ScoreDisplay { get; private set; }
 
         /// <summary>
         ///     The display for the user's rating.
         /// </summary>
-        private NumberDisplay RatingDisplay { get; set; }
+        public NumberDisplay RatingDisplay { get; private set; }
 
         /// <summary>
         ///     The display for the user's accuracy
         /// </summary>
-        private NumberDisplay AccuracyDisplay { get; set; }
+        public NumberDisplay AccuracyDisplay { get; private set; }
 
         /// <summary>
         ///     The keys per second display.
         /// </summary>
-        public KeysPerSecond KpsDisplay { get; set; }
+        public KeysPerSecond KpsDisplay { get; private set; }
 
         /// <summary>
         ///     Displays the current judgement counts.
         /// </summary>
-        private JudgementCounter JudgementCounter { get; set; }
+        public JudgementCounter JudgementCounter { get; private set; }
 
         /// <summary>
         ///     Displays the user's current grade.
         /// </summary>
-        private GradeDisplay GradeDisplay { get; set; }
+        public GradeDisplay GradeDisplay { get; private set; }
 
         /// <summary>
         ///     The scoreboard on the left side of the screern
@@ -311,10 +311,7 @@ namespace Quaver.Shared.Screens.Gameplay
             Screen.Ruleset?.Update(gameTime);
             Container?.Update(gameTime);
 
-            // Update the position and size of the grade display.
-            GradeDisplay.X = AccuracyDisplay.X - AccuracyDisplay.Width - 8;
-            GradeDisplay.Height = AccuracyDisplay.Height;
-            GradeDisplay.UpdateWidth();
+            UpdateGradeDisplay();
 
             if (SpectatorDialog != null)
             {
@@ -378,7 +375,8 @@ namespace Quaver.Shared.Screens.Gameplay
                 skin.SongTimeProgressInactiveColor, skin.SongTimeProgressActiveColor)
             {
                 Parent = Container,
-                Alignment = Alignment.BotLeft
+                Alignment = Alignment.BotLeft,
+                DestroyIfParentIsNull = false
             };
         }
 
@@ -768,6 +766,16 @@ namespace Quaver.Shared.Screens.Gameplay
                 // Change background dim before switching screens.
                 BackgroundManager.Background.Dim = 0;
             }
+        }
+
+        /// <summary>
+        /// Update the position and size of the grade display.
+        /// </summary>
+        public void UpdateGradeDisplay()
+        {
+            GradeDisplay.X = AccuracyDisplay.X - AccuracyDisplay.Width - 8;
+            GradeDisplay.Height = AccuracyDisplay.Height;
+            GradeDisplay.UpdateWidth();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -16,6 +16,8 @@ using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
+using Quaver.Shared.Screens.Tournament.Gameplay;
+using Wobble.Bindables;
 using Wobble.Input;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
@@ -25,7 +27,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
         /// <summary>
         ///     The list of button containers for these keys.
         /// </summary>
-        internal List<InputBindingKeys> BindingStore { get; }
+        internal List<InputBindingKeys> BindingStore { get; private set; }
 
         /// <summary>
         ///     Reference to the ruleset
@@ -44,36 +46,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
         /// <param name="mode"></param>
         internal KeysInputManager(GameplayRulesetKeys ruleset, GameMode mode)
         {
-            switch (mode)
-            {
-                case GameMode.Keys4:
-                    // Initialize 4K Input button container.
-                    BindingStore = new List<InputBindingKeys>
-                    {
-                        new InputBindingKeys(ConfigManager.KeyMania4K1),
-                        new InputBindingKeys(ConfigManager.KeyMania4K2),
-                        new InputBindingKeys(ConfigManager.KeyMania4K3),
-                        new InputBindingKeys(ConfigManager.KeyMania4K4)
-                    };
-                    break;
-                case GameMode.Keys7:
-                    // Initialize 7K input button container.
-                    BindingStore = new List<InputBindingKeys>
-                    {
-                        new InputBindingKeys(ConfigManager.KeyMania7K1),
-                        new InputBindingKeys(ConfigManager.KeyMania7K2),
-                        new InputBindingKeys(ConfigManager.KeyMania7K3),
-                        new InputBindingKeys(ConfigManager.KeyMania7K4),
-                        new InputBindingKeys(ConfigManager.KeyMania7K5),
-                        new InputBindingKeys(ConfigManager.KeyMania7K6),
-                        new InputBindingKeys(ConfigManager.KeyMania7K7)
-                    };
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
-            }
-
             Ruleset = ruleset;
+
+            SetInputKeybinds(mode);
 
             // Init replay
             if (Ruleset.Screen != null && Ruleset.Screen.InReplayMode)
@@ -353,7 +328,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
         private void ChangeScrollSpeed()
         {
             // Only allow scroll speed changes if the map hasn't started or if we're on a break
-            if (Ruleset.Screen.Timing.Time >= 5000 && !Ruleset.Screen.EligibleToSkip)
+            if (Ruleset.Screen.Timing.Time >= 5000 && !Ruleset.Screen.EligibleToSkip && !(Ruleset.Screen is TournamentGameplayScreen))
                 return;
 
             // Decrease
@@ -388,6 +363,89 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                         break;
                 }
                 ((HitObjectManagerKeys)Ruleset.HitObjectManager).ForceUpdateLNSize();
+            }
+        }
+
+        /// <summary>
+        ///     Sets input keybinds based on which player is playing
+        /// </summary>
+        /// <param name="mode"></param>
+        private void SetInputKeybinds(GameMode mode)
+        {
+            if (Ruleset.Screen.TournamentOptions == null || Ruleset.Screen.TournamentOptions?.Index == 0)
+                SetPlayer1Keybinds(mode);
+            else if (Ruleset.Screen.TournamentOptions != null)
+                SetPlayer2Keybinds(mode);
+        }
+
+        /// <summary>
+        ///     Sets the keybinds for player 1
+        /// </summary>
+        /// <param name="mode"></param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private void SetPlayer1Keybinds(GameMode mode)
+        {
+            switch (mode)
+            {
+                case GameMode.Keys4:
+                    // Initialize 4K Input button container.
+                    BindingStore = new List<InputBindingKeys>
+                    {
+                        new InputBindingKeys(ConfigManager.KeyMania4K1),
+                        new InputBindingKeys(ConfigManager.KeyMania4K2),
+                        new InputBindingKeys(ConfigManager.KeyMania4K3),
+                        new InputBindingKeys(ConfigManager.KeyMania4K4)
+                    };
+                    break;
+                case GameMode.Keys7:
+                    // Initialize 7K input button container.
+                    BindingStore = new List<InputBindingKeys>
+                    {
+                        new InputBindingKeys(ConfigManager.KeyMania7K1),
+                        new InputBindingKeys(ConfigManager.KeyMania7K2),
+                        new InputBindingKeys(ConfigManager.KeyMania7K3),
+                        new InputBindingKeys(ConfigManager.KeyMania7K4),
+                        new InputBindingKeys(ConfigManager.KeyMania7K5),
+                        new InputBindingKeys(ConfigManager.KeyMania7K6),
+                        new InputBindingKeys(ConfigManager.KeyMania7K7)
+                    };
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
+            }
+        }
+
+        /// <summary>
+        ///     Sets the keybinds for player 1
+        /// </summary>
+        /// <param name="mode"></param>
+        private void SetPlayer2Keybinds(GameMode mode)
+        {
+            switch (mode)
+            {
+                case GameMode.Keys4:
+                    BindingStore = new List<InputBindingKeys>()
+                    {
+                        new InputBindingKeys(ConfigManager.KeyCoop2P4K1),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P4K2),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P4K3),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P4K4),
+                    };
+                    break;
+                case GameMode.Keys7:
+                    BindingStore = new List<InputBindingKeys>()
+                    {
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K1),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K2),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K3),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K4),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K5),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K6),
+                        new InputBindingKeys(ConfigManager.KeyCoop2P7K7),
+                    };
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
             }
         }
     }

--- a/Quaver.Shared/Screens/QuaverScreenType.cs
+++ b/Quaver.Shared/Screens/QuaverScreenType.cs
@@ -21,6 +21,7 @@ namespace Quaver.Shared.Screens
         Download,
         Lobby,
         Multiplayer,
-        Music
+        Music,
+        Theatre
     }
 }

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -43,6 +43,7 @@ using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Result.UI;
 using Quaver.Shared.Screens.Select;
 using Quaver.Shared.Screens.Selection;
+using Quaver.Shared.Screens.Tournament.Gameplay;
 using Wobble;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
@@ -362,6 +363,14 @@ namespace Quaver.Shared.Screens.Result
             // Don't submit scores at all if the user has ALL misses for their judgements.
             // They basically haven't actually played the map.
             if (Gameplay.Ruleset.ScoreProcessor.CurrentJudgements[Judgement.Miss] == Gameplay.Ruleset.ScoreProcessor.TotalJudgementCount)
+                return;
+
+            // Don't submit if we're coming from tournament mode
+            if (Gameplay is TournamentGameplayScreen)
+                return;
+
+            // Prevent co-op mode from submitting scores
+            if (ModManager.IsActivated(ModIdentifier.Coop))
                 return;
 
             ThreadScheduler.Run(SaveLocalScore);

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -32,6 +32,8 @@ using Quaver.Shared.Screens.Selection.UI;
 using Quaver.Shared.Screens.Selection.UI.FilterPanel.Search;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;
+using Quaver.Shared.Screens.Tournament;
+using Wobble;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Dialogs;
@@ -118,7 +120,6 @@ namespace Quaver.Shared.Screens.Selection
             MapManager.MapDeleted += OnMapDeleted;
             MapManager.MapUpdated += OnMapUpdated;
             MapManager.SongRequestPlayed += OnSongRequestPlayed;
-
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
 
             View = new SelectionScreenView(this);
@@ -129,11 +130,13 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         public override void OnFirstUpdate()
         {
+            GameBase.Game.GlobalUserInterface.Cursor.Alpha = 1;
             FadeAudioTrackIn();
             base.OnFirstUpdate();
         }
 
         /// <inheritdoc />
+        /// <summary>
         /// <summary>
         /// </summary>
         /// <param name="gameTime"></param>
@@ -531,6 +534,12 @@ namespace Quaver.Shared.Screens.Selection
 
             if (OnlineManager.IsSpectatingSomeone)
                 OnlineManager.Client?.StopSpectating();
+
+            if (ModManager.IsActivated(ModIdentifier.Coop))
+            {
+                Exit(() => new TournamentScreen(2));
+                return;
+            }
 
             Exit(() => new MapLoadingScreen(new List<Score>()));
         }

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
@@ -50,7 +50,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Components
         public SelectableModifier(int width, IGameplayModifier mod)
         {
             Mod = mod;
-            Size = new ScalableVector2(width, 59);
+            Size = new ScalableVector2(width, 53);
 
             const int paddingLeft = 10;
 

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
@@ -108,7 +108,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
             {
                 Parent = this,
                 Alignment = Alignment.BotLeft,
-                Size = new ScalableVector2(Width, 70),
+                Size = new ScalableVector2(Width, 72),
                 Tint = ColorHelper.HexToColor("#181818")
             };
 

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelectorContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelectorContainer.cs
@@ -107,6 +107,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
                             "Scores will not be submitted while using these", ColorHelper.HexToColor("#F2C94C"), new List<SelectableModifier>()
                         {
                             new SelectableModifierBool(width, new ModAutoplay()),
+                            new SelectableModifierBool(width, new ModCoop()),
                             new SelectableModifierBool(width, new ModNoFail()),
                             new SelectableModifierBool(width, new ModNoSliderVelocities()),
                             new SelectableModifierBool(width, new ModNoLongNotes()),

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -408,6 +408,23 @@ namespace Quaver.Shared.Screens.Settings
                         ConfigManager.KeyMania7K6,
                         ConfigManager.KeyMania7K7
                     }),
+                    new SettingsKeybindMultiple(this, "Co-op 2 Player Layout (4 Keys)", new List<Bindable<Keys>>
+                    {
+                        ConfigManager.KeyCoop2P4K1,
+                        ConfigManager.KeyCoop2P4K2,
+                        ConfigManager.KeyCoop2P4K3,
+                        ConfigManager.KeyCoop2P4K4,
+                    }),
+                    new SettingsKeybindMultiple(this, "Co-op 2 Player Layout (7 Keys)", new List<Bindable<Keys>>
+                    {
+                        ConfigManager.KeyCoop2P7K1,
+                        ConfigManager.KeyCoop2P7K2,
+                        ConfigManager.KeyCoop2P7K3,
+                        ConfigManager.KeyCoop2P7K4,
+                        ConfigManager.KeyCoop2P7K5,
+                        ConfigManager.KeyCoop2P7K6,
+                        ConfigManager.KeyCoop2P7K7,
+                    }),
                     new SettingsKeybind(this, "Pause", ConfigManager.KeyPause),
                     new SettingsKeybind(this, "Skip Intro", ConfigManager.KeySkipIntro),
                     new SettingsKeybind(this, "Restart Map", ConfigManager.KeyRestartMap),

--- a/Quaver.Shared/Screens/Theater/ReplayLoadedEventArgs.cs
+++ b/Quaver.Shared/Screens/Theater/ReplayLoadedEventArgs.cs
@@ -1,0 +1,12 @@
+using System;
+using Quaver.API.Replays;
+
+namespace Quaver.Shared.Screens.Theater
+{
+    public class ReplayLoadedEventArgs : EventArgs
+    {
+        public Replay Replay { get; }
+
+        public ReplayLoadedEventArgs(Replay replay) => Replay = replay;
+    }
+}

--- a/Quaver.Shared/Screens/Theater/TheaterScreen.cs
+++ b/Quaver.Shared/Screens/Theater/TheaterScreen.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Replays;
+using Quaver.Server.Common.Enums;
+using Quaver.Server.Common.Objects;
+using Quaver.Shared.Audio;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Backgrounds;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Main;
+using Quaver.Shared.Screens.Tournament;
+using Wobble;
+using Wobble.Input;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Screens.Theater
+{
+    public sealed class TheaterScreen : QuaverScreen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override QuaverScreenType Type { get; } = QuaverScreenType.Theatre;
+
+        /// <summary>
+        ///     The replays to be used when watching
+        /// </summary>
+        public List<Replay> Replays { get; } = new List<Replay>();
+
+        /// <summary>
+        ///     Invoked when a replay has been loaded
+        /// </summary>
+        public event EventHandler<ReplayLoadedEventArgs> ReplayLoaded;
+
+        /// <summary>
+        /// </summary>
+        public TheaterScreen()
+        {
+            GameBase.Game.Window.FileDropped += OnFileDropped;
+            View = new TheaterScreenView(this);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            HandleInput();
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            GameBase.Game.Window.FileDropped -= OnFileDropped;
+            ReplayLoaded = null;
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleInput()
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Escape))
+            {
+                Exit(() => new MainMenuScreen());
+                return;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnFileDropped(object sender, string e)
+        {
+            if (Replays.Count >= 4)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "You cannot watch more than 4 replays at a time!");
+                return;
+            }
+
+            if (!e.EndsWith(".qr"))
+                return;
+
+            ThreadScheduler.Run(() =>
+            {
+                try
+                {
+                    var replay = new Replay(e);
+
+                    // Check to see if the map actually exists
+                    var map = MapManager.FindMapFromMd5(replay.MapMd5);
+
+                    if (map == null)
+                    {
+                        NotificationManager.Show(NotificationLevel.Warning, "You do not have the map the replay is for.");
+                        return;
+                    }
+
+                    MapManager.Selected.Value = map;
+
+                    lock (Replays)
+                    {
+                        // Check if the replays are all from the same map
+                        if (Replays.Count != 0)
+                        {
+                            if (replay.MapMd5 != Replays.First().MapMd5)
+                            {
+                                NotificationManager.Show(NotificationLevel.Warning, "All replays must be from the same map!");
+                                return;
+                            }
+                        }
+
+                        // Add replay to the list
+                        if (Replays.Count != 4)
+                            Replays.Add(replay);
+
+                        ReplayLoaded?.Invoke(this, new ReplayLoadedEventArgs(replay));
+                        NotificationManager.Show(NotificationLevel.Info, $"Loaded replay from: {replay.PlayerName}");
+                    }
+
+                    // Start playing song
+                    if (AudioEngine.Map != map)
+                    {
+                        AudioEngine.LoadCurrentTrack();
+                        AudioEngine.Track.Play();
+                    }
+
+                    if (BackgroundHelper.Map != map)
+                        BackgroundHelper.Load(map);
+                }
+                catch (Exception ex)
+                {
+                    NotificationManager.Show(NotificationLevel.Error, "The replay file you have given cannot be read.");
+                    Logger.Error(ex, LogType.Runtime);
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public override UserClientStatus GetClientStatus() => new UserClientStatus(ClientStatus.InMenus, -1, "-1", 1, "", 0);
+    }
+}

--- a/Quaver.Shared/Screens/Theater/TheaterScreenView.cs
+++ b/Quaver.Shared/Screens/Theater/TheaterScreenView.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Menu.Border;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Theater.UI.Footer;
+using Quaver.Shared.Screens.Theater.UI.Players;
+using Wobble;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI;
+using Wobble.Managers;
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Theater
+{
+    public class TheaterScreenView : ScreenView
+    {
+        /// <summary>
+        /// </summary>
+        private BackgroundImage Background { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private MenuBorder Header { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private MenuBorder Footer { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus ExperimentalNotice { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus DragReplaysText { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private List<DrawableReplayPlayer> Players { get; } = new List<DrawableReplayPlayer>();
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TheaterScreenView(TheaterScreen screen) : base(screen)
+        {
+            CreateBackground();
+            CreateHeader();
+            CreateFooter();
+            CreateExperimentalNotice();
+            CreateDragReplaysText();
+
+            screen.ReplayLoaded += OnReplayLoaded;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime) => Container?.Update(gameTime);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(ColorHelper.HexToColor("#2F2F2F"));
+            Container?.Draw(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            var screen = (TheaterScreen) Screen;
+            screen.ReplayLoaded -= OnReplayLoaded;
+
+            Container?.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateBackground() => Background = new BackgroundImage(UserInterface.Triangles, 0, false)
+            {Parent = Container};
+
+        /// <summary>
+        /// </summary>
+        private void CreateHeader() => Header = new MenuHeaderMain {Parent = Container};
+
+        /// <summary>
+        /// </summary>
+        private void CreateFooter() => Footer = new TheaterFooter(Screen as TheaterScreen)
+        {
+            Parent = Container,
+            Alignment = Alignment.BotLeft
+        };
+
+        /// <summary>
+        /// </summary>
+        private void CreateExperimentalNotice()
+        {
+            ExperimentalNotice = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
+                "This feature is experimental and not complete. Some things may not work properly.", 28)
+            {
+                Parent = Container,
+                Alignment = Alignment.TopCenter,
+                Y = Header.Height + 50
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateDragReplaysText()
+        {
+            DragReplaysText = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
+                "To begin, drag up to 4 replays into the window...", 26)
+            {
+                Parent = Container,
+                Alignment = Alignment.TopCenter,
+                Y = ExperimentalNotice.Y + ExperimentalNotice.Height + 20
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnReplayLoaded(object sender, ReplayLoadedEventArgs e)
+        {
+            var player = new DrawableReplayPlayer(e.Replay)
+            {
+                Parent = Container,
+                Alignment = Alignment.MidLeft
+            };
+
+            player.X = (Players.Count) * (player.Width + 20) + 50;
+            Players.Add(player);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooter.cs
+++ b/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooter.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Quaver.Shared.Graphics.Menu.Border;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.Theater.UI.Footer
+{
+    public class TheaterFooter : MenuBorder
+    {
+        public TheaterFooter(TheaterScreen screen) : base(MenuBorderType.Footer, new List<Drawable>()
+        {
+            new TheaterFooterBackButton(screen)
+        }, new List<Drawable>()
+        {
+            new TheaterFooterPlayButton(screen)
+        })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooterBackButton.cs
+++ b/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooterBackButton.cs
@@ -1,0 +1,18 @@
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Menu.Border.Components;
+using Quaver.Shared.Screens.Main;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Theater.UI.Footer
+{
+    public class TheaterFooterBackButton : IconTextButton
+    {
+        public TheaterFooterBackButton(TheaterScreen screen) : base(FontAwesome.Get(FontAwesomeIcon.fa_chevron_pointing_to_the_left),
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Back", (sender, args) =>
+            {
+                screen.Exit(() => new MainMenuScreen());
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooterPlayButton.cs
+++ b/Quaver.Shared/Screens/Theater/UI/Footer/TheaterFooterPlayButton.cs
@@ -1,0 +1,26 @@
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Menu.Border.Components;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Screens.Main;
+using Quaver.Shared.Screens.Tournament;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Theater.UI.Footer
+{
+    public class TheaterFooterPlayButton : IconTextButton
+    {
+        public TheaterFooterPlayButton(TheaterScreen screen) : base(FontAwesome.Get(FontAwesomeIcon.fa_play_sign),
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Play", (sender, args) =>
+            {
+                if (screen.Replays.Count < 2)
+                {
+                    NotificationManager.Show(NotificationLevel.Warning, "You must load at least 2 replays in order to watch.");
+                    return;
+                }
+
+                screen.Exit(() => new TournamentScreen(screen.Replays));
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Theater/UI/Players/DrawableReplayPlayer.cs
+++ b/Quaver.Shared/Screens/Theater/UI/Players/DrawableReplayPlayer.cs
@@ -1,0 +1,140 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Helpers;
+using Quaver.API.Maps.Processors.Rating;
+using Quaver.API.Replays;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Helpers;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Theater.UI.Players
+{
+    public class DrawableReplayPlayer : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        private Replay Replay { get; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus PlayerName { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus Mods { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus PerformanceRating { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus Accuracy { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private SpriteTextPlus Judgements { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="replay"></param>
+        public DrawableReplayPlayer(Replay replay)
+        {
+            Replay = replay;
+            Size = new ScalableVector2(400, 180);
+
+            Tint = Color.Black;
+            Alpha = 0.45f;
+
+            CreatePlayerName();
+            CreateMods();
+            CreatePerformanceRating();
+            CreateAccuracy();
+            CreateJudgements();
+
+            ScheduleUpdate(UpdateContent);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void UpdateContent()
+        {
+            const int space = 12;
+            PlayerName.Text = $"Player: {Replay.PlayerName}";
+
+            Mods.Text = $"Mods: {ModHelper.GetModsString(Replay.Mods)}";
+            Mods.Y = PlayerName.Y + PlayerName.Height + space;
+
+            PerformanceRating.Text = $"Performance Rating: " +
+                                     $"{StringHelper.RatingToString(new RatingProcessorKeys(MapManager.Selected.Value.DifficultyFromMods(Replay.Mods)).CalculateRating(Replay.Accuracy))}";
+            PerformanceRating.Y = Mods.Y + Mods.Height + space;
+
+            Accuracy.Text = $"Accuracy: {StringHelper.AccuracyToString(Replay.Accuracy)}";
+            Accuracy.Y = PerformanceRating.Y + PerformanceRating.Height + space;
+
+            Judgements.Text = $"Judgements: {Replay.CountMarv} / {Replay.CountPerf} / {Replay.CountGreat} / {Replay.CountGood} / " +
+                              $"{Replay.CountOkay} / {Replay.CountMiss} / {Replay.MaxCombo}x";
+
+            Judgements.Y = Accuracy.Y + Accuracy.Height + space;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreatePlayerName()
+        {
+            PlayerName = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                X = 10,
+                Y = 12
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateMods()
+        {
+            Mods = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                X = PlayerName.X
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreatePerformanceRating()
+        {
+            PerformanceRating = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                X = PlayerName.X
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateAccuracy()
+        {
+            Accuracy = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                X = PlayerName.X
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateJudgements()
+        {
+            Judgements = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                X = PlayerName.X
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Tournament/Gameplay/TournamentGameplayScreen.cs
+++ b/Quaver.Shared/Screens/Tournament/Gameplay/TournamentGameplayScreen.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.API.Maps;
+using Quaver.API.Replays;
+using Quaver.Shared.Database.Scores;
+using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Gameplay;
+
+namespace Quaver.Shared.Screens.Tournament.Gameplay
+{
+    public class TournamentGameplayScreen : GameplayScreen
+    {
+        /// <summary>
+        /// </summary>
+        public TournamentScreenType Type { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        ///     Creating a tournament gameplay screen from a pre-made replay
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="md5"></param>
+        /// <param name="replay"></param>m&gt;
+        public TournamentGameplayScreen(Qua map, string md5, Replay replay) : base(map, md5, new List<Score>(), replay)
+        {
+            Type = TournamentScreenType.Replay;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        ///     Creating a tournament gameplay screen from a SpectatorClient (streaming)
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="md5"></param>
+        /// <param name="spectatorClient"></param>
+        public TournamentGameplayScreen(Qua map, string md5, SpectatorClient spectatorClient) : base(map, md5,
+            new List<Score>(), null, false, 0, false, spectatorClient)
+        {
+            Type = TournamentScreenType.Spectator;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        ///     Creating a playable gameplay tournament screen (Co-Op Mode)
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="md5"></param>
+        /// <param name="options"></param>
+        public TournamentGameplayScreen(Qua map, string md5, TournamentPlayerOptions options) : base(map, md5, new List<Score>(), 
+            null, false, 0, false, null, options)
+        {
+            Type = TournamentScreenType.Coop;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        protected override void HandleInput(GameTime gameTime) => Ruleset?.HandleInput(gameTime);
+    }
+}

--- a/Quaver.Shared/Screens/Tournament/Gameplay/TournamentPlayerOptions.cs
+++ b/Quaver.Shared/Screens/Tournament/Gameplay/TournamentPlayerOptions.cs
@@ -1,0 +1,18 @@
+namespace Quaver.Shared.Screens.Tournament.Gameplay
+{
+    public class TournamentPlayerOptions
+    {
+        /// <summary>
+        ///     The index of the player (player 1, player 2, player 3, etc)
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="index"></param>
+        public TournamentPlayerOptions(int index)
+        {
+            Index = index;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Tournament/Gameplay/TournamentScreenType.cs
+++ b/Quaver.Shared/Screens/Tournament/Gameplay/TournamentScreenType.cs
@@ -1,0 +1,9 @@
+namespace Quaver.Shared.Screens.Tournament.Gameplay
+{
+    public enum TournamentScreenType
+    {
+        Replay,
+        Spectator,
+        Coop
+    }
+}

--- a/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Helpers;
+using Quaver.API.Replays;
+using Quaver.Server.Common.Objects;
+using Quaver.Shared.Config;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Discord;
+using Quaver.Shared.Modifiers;
+using Quaver.Shared.Screens.Loading;
+using Quaver.Shared.Screens.Tournament.Gameplay;
+using Wobble;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Tournament
+{
+    public sealed class TournamentScreen : QuaverScreen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override QuaverScreenType Type { get; } = QuaverScreenType.Gameplay;
+
+        /// <summary>
+        ///     The type of tournament screen this is
+        /// </summary>
+        public TournamentScreenType TournamentType { get; }
+
+        /// <summary>
+        ///     The "main" first gameplay screen instance
+        /// </summary>
+        public TournamentGameplayScreen MainGameplayScreen { get; }
+
+        /// <summary>
+        ///     List of all gameplay screen instances for each player
+        /// </summary>
+        public List<TournamentGameplayScreen> GameplayScreens { get; }
+
+        /// <summary>
+        ///     Creating a tournament screen with pre-made replays to view
+        /// </summary>
+        /// <param name="replays"></param>
+        public TournamentScreen(IReadOnlyCollection<Replay> replays)
+        {
+            TournamentType = TournamentScreenType.Replay;
+
+            GameplayScreens = new List<TournamentGameplayScreen>();
+
+            // Go through each replay and create a gameplay screen for it.
+            foreach (var replay in replays)
+            {
+                // Load the .qua file and and make sure any mods that were used are applied
+                var qua = MapManager.Selected.Value.LoadQua();
+                qua.ApplyMods(replay.Mods);
+
+                // Change the selected Qua prior to creating the screen because GameplayScreen relies on it.
+                MapManager.Selected.Value.Qua = qua;
+                MapLoadingScreen.AddModsFromIdentifiers(replay.Mods);
+
+                var screen = new TournamentGameplayScreen(qua, MapManager.Selected.Value.GetAlternativeMd5(), replay);
+
+                if (GameplayScreens.Count == 0)
+                    MainGameplayScreen = screen;
+
+                GameplayScreens.Add(screen);
+            }
+
+            // Change the selected Qua back to a fresh version
+            MapManager.Selected.Value.Qua = MapManager.Selected.Value.LoadQua();
+
+            ModManager.RemoveAllMods();
+            ModManager.AddSpeedMods(ModHelper.GetRateFromMods(replays.First().Mods));
+
+            SetRichPresenceForTournamentViewer();
+            View = new TournamentScreenView(this);
+        }
+
+        /// <summary>
+        ///     Create a tournament screen (co-op mode)
+        /// </summary>
+        public TournamentScreen(int players)
+        {
+            TournamentType = TournamentScreenType.Coop;
+
+            if (players < 2 || players > 4)
+                throw new InvalidOperationException($"You can only create a tournament screen with 2-4 players. Got: {players}");
+
+            GameplayScreens = new List<TournamentGameplayScreen>();
+
+            for (var i = 0; i < players; i++)
+            {
+                var qua = MapManager.Selected.Value.LoadQua();
+                qua.ApplyMods(ModManager.Mods);
+
+                MapManager.Selected.Value.Qua = qua;
+
+                var screen = new TournamentGameplayScreen(qua, MapManager.Selected.Value.GetAlternativeMd5(), new TournamentPlayerOptions(i));
+
+                if (GameplayScreens.Count == 0)
+                    MainGameplayScreen = screen;
+
+                GameplayScreens.Add(screen);
+            }
+
+            View = new TournamentScreenView(this);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void OnFirstUpdate()
+        {
+            GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
+            base.OnFirstUpdate();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            if (!Exiting)
+            {
+                UpdateScreens(gameTime);
+
+                if (KeyboardManager.CurrentState.IsKeyDown(ConfigManager.KeyPause.Value))
+                    MainGameplayScreen.Pause(gameTime, false);
+
+                switch (MainGameplayScreen.Type)
+                {
+                    case TournamentScreenType.Spectator:
+                        break;
+                    case TournamentScreenType.Coop:
+                    case TournamentScreenType.Replay:
+                        if (MainGameplayScreen.EligibleToSkip && KeyboardManager.IsUniqueKeyPress(ConfigManager.KeySkipIntro.Value))
+                            MainGameplayScreen.SkipToNextObject();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            GameBase.Game.GlobalUserInterface.Cursor.Alpha = 1;
+
+            GameplayScreens.ForEach(x =>
+            {
+                x.Destroy();
+                x.Ruleset.Playfield.Destroy();
+            });
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void UpdateScreens(GameTime gameTime)
+        {
+            foreach (var screen in GameplayScreens)
+                screen.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public override UserClientStatus GetClientStatus() => null;
+
+        /// <summary>
+        /// </summary>
+        private void SetRichPresenceForTournamentViewer()
+        {
+            DiscordHelper.Presence.Details = MapManager.Selected.Value.ToString();
+            DiscordHelper.Presence.State = "Tournament Viewer";
+            DiscordHelper.Presence.PartySize = GameplayScreens.Count;
+            DiscordHelper.Presence.PartyMax = 4;
+            DiscordHelper.Presence.EndTimestamp = 0;
+            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
@@ -99,10 +99,6 @@ namespace Quaver.Shared.Screens.Tournament
         /// </summary>
         private void SetPlayfieldPositions()
         {
-            var mode = TournamentScreen.MainGameplayScreen.Map.Mode;
-            var keyCount = TournamentScreen.MainGameplayScreen.Map.GetKeyCount();
-            var skin = SkinManager.Skin.Keys[mode];
-
             var widthSum = TournamentScreen.GameplayScreens.Sum(x =>
             {
                 var playfield = (GameplayPlayfieldKeys) x.Ruleset.Playfield;

--- a/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
@@ -78,7 +78,6 @@ namespace Quaver.Shared.Screens.Tournament
             DrawPlayfields(gameTime);
             DrawProgressBar(gameTime);
             DrawSkipDisplay(gameTime);
-            DrawScreenTransitioner(gameTime);
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Backgrounds;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Gameplay;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
+using Quaver.Shared.Screens.Tournament.Gameplay;
+using Quaver.Shared.Skinning;
+using Wobble;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI;
+using Wobble.Managers;
+using Wobble.Screens;
+using Wobble.Window;
+
+namespace Quaver.Shared.Screens.Tournament
+{
+    public class TournamentScreenView : ScreenView
+    {
+        /// <summary>
+        /// </summary>
+        public TournamentScreen TournamentScreen => (TournamentScreen) Screen;
+
+        /// <summary>
+        /// </summary>
+        private BackgroundImage Background { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private List<SpriteTextPlus> Usernames { get; set; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TournamentScreenView(Screen screen) : base(screen)
+        {
+            CreateBackground();
+            SetPlayfieldPositions();
+            PositionPlayfieldItems();
+            CreateUsernames();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Container?.Update(gameTime);
+            Background?.Update(gameTime);
+
+            if (!TournamentScreen.Exiting)
+                UpdatePlayfields(gameTime);
+
+            UpdateProgressBar(gameTime);
+            UpdateSkipDisplay(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(Color.Black);
+
+            Container?.Draw(gameTime);
+            Background?.Draw(gameTime);
+            DrawPlayfields(gameTime);
+            DrawProgressBar(gameTime);
+            DrawSkipDisplay(gameTime);
+            DrawScreenTransitioner(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy() => Container?.Destroy();
+
+        /// <summary>
+        ///     Creates the <see cref="Background"/> for the map
+        /// </summary>
+        private void CreateBackground() => Background = new BackgroundImage(BackgroundHelper.RawTexture,
+            100 - ConfigManager.BackgroundBrightness.Value, false)
+        {
+        };
+
+        /// <summary>
+        ///     Sets the positions of each playfield
+        /// </summary>
+        private void SetPlayfieldPositions()
+        {
+            var mode = TournamentScreen.MainGameplayScreen.Map.Mode;
+            var keyCount = TournamentScreen.MainGameplayScreen.Map.GetKeyCount();
+            var skin = SkinManager.Skin.Keys[mode];
+
+            var widthSum = TournamentScreen.GameplayScreens.Sum(x =>
+            {
+                var playfield = (GameplayPlayfieldKeys) x.Ruleset.Playfield;
+                return playfield.Width + playfield.Stage.HealthBar.Width;
+            });
+
+            var widthPer = (WindowManager.Width - widthSum) / (TournamentScreen.GameplayScreens.Count + 1);
+
+            for (var i = 0; i < TournamentScreen.GameplayScreens.Count; i++)
+            {
+                var playfield = (GameplayPlayfieldKeys)  TournamentScreen.GameplayScreens[i].Ruleset.Playfield;
+                playfield.Container.Width = playfield.Width + playfield.Stage.HealthBar.Width;
+                playfield.Container.X = widthPer;
+
+                if (i != 0)
+                {
+                    var last = TournamentScreen.GameplayScreens[i - 1].Ruleset.Playfield;
+                    playfield.Container.X = last.Container.X + last.Container.Width + widthPer;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Positions the scores of each playfield
+        /// </summary>
+        private void PositionPlayfieldItems()
+        {
+            foreach (var screen in TournamentScreen.GameplayScreens)
+            {
+                var view = (GameplayScreenView) screen.View;
+
+                view.ScoreDisplay.Visible = false;
+                view.KpsDisplay.Visible = false;
+                view.JudgementCounter.Visible = false;
+
+                view.RatingDisplay.Parent = screen.Ruleset.Playfield.Container;
+                view.RatingDisplay.Alignment = Alignment.TopCenter;
+                view.RatingDisplay.Y = 200;
+                view.RatingDisplay.X = 0;
+
+                view.AccuracyDisplay.Parent = screen.Ruleset.Playfield.Container;
+                view.AccuracyDisplay.Alignment = Alignment.TopCenter;
+                view.AccuracyDisplay.Y = 250;
+                view.AccuracyDisplay.X = 0;
+
+                view.GradeDisplay.Parent = screen.Ruleset.Playfield.Container;
+                view.GradeDisplay.Alignment = Alignment.TopCenter;
+                view.GradeDisplay.Y = view.AccuracyDisplay.Y;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateUsernames()
+        {
+            Usernames = new List<SpriteTextPlus>();
+
+            for (var i = 0; i < TournamentScreen.GameplayScreens.Count; i++)
+            {
+                var screen = TournamentScreen.GameplayScreens[i];
+
+                var username = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
+                    screen.LoadedReplay?.PlayerName ?? $"Player {i + 1}", 24)
+                {
+                    Parent = screen.Ruleset.Playfield.Container,
+                    Alignment = Alignment.TopCenter,
+                    Y = 300
+                };
+
+                Usernames.Add(username);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void UpdatePlayfields(GameTime gameTime)
+        {
+            foreach (var screen in TournamentScreen.GameplayScreens)
+            {
+                var view = (GameplayScreenView) screen.View;
+
+               view.UpdateGradeDisplay();
+               screen.Ruleset?.Playfield.Update(gameTime);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawPlayfields(GameTime gameTime)
+        {
+            foreach (var screen in TournamentScreen.GameplayScreens)
+                screen.Ruleset?.Playfield.Draw(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawScreenTransitioner(GameTime gameTime)
+        {
+            var view = (GameplayScreenView) TournamentScreen.MainGameplayScreen.View;
+            view.Transitioner.Draw(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void UpdateSkipDisplay(GameTime gameTime)
+        {
+            if (TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Coop
+                && TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Replay)
+            {
+                return;
+            }
+
+            var view = (GameplayScreenView) TournamentScreen.MainGameplayScreen.View;
+            view.SkipDisplay.Update(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawSkipDisplay(GameTime gameTime)
+        {
+            if (TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Coop
+                && TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Replay)
+            {
+                return;
+            }
+            var view = (GameplayScreenView) TournamentScreen.MainGameplayScreen.View;
+            view.SkipDisplay.Draw(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void UpdateProgressBar(GameTime gameTime)
+        {
+            if (TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Coop)
+                return;
+
+            var view = (GameplayScreenView) TournamentScreen.MainGameplayScreen.View;
+            view.ProgressBar.Update(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawProgressBar(GameTime gameTime)
+        {
+            if (TournamentScreen.MainGameplayScreen.Type != TournamentScreenType.Coop)
+                return;
+
+            var view = (GameplayScreenView) TournamentScreen.MainGameplayScreen.View;
+            view.ProgressBar.Draw(gameTime);
+        }
+    }
+}


### PR DESCRIPTION
* Adds a `TournamentScreen` which is used to display multiple playfields on one screen.
* Adds an experimental Theater Mode which can be used to watch multiple replays at one time.
* Adds Co-op mode which can be accessed in the song select modifier menu.