### PR TITLE
Multiplayer Game Settings Panel & Handling Online Events

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -1003,12 +1003,8 @@ namespace Quaver.Shared.Online
                 return;
 
             CurrentGame.Ruleset = e.Ruleset;
-
-            if (CurrentGame.Ruleset != MultiplayerGameRuleset.Team)
-            {
-                CurrentGame.RedTeamPlayers.Clear();
-                CurrentGame.BlueTeamPlayers.Clear();
-            }
+            CurrentGame.RedTeamPlayers.Clear();
+            CurrentGame.BlueTeamPlayers.Clear();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Multi/UI/Chat/MultiplayerChatBox.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Chat/MultiplayerChatBox.cs
@@ -45,7 +45,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Chat
         private void CreateMessageContainer()
         {
             MessageContainer = new ChatMessageScrollContainer(GetChatChannel(),
-                new ScalableVector2(Textbox.Width, Height - 58), 0, 50)
+                new ScalableVector2(Textbox.Width, Height - 64), 0, 50)
             {
                 Parent = this,
                 Alignment = Alignment.TopCenter,

--- a/Quaver.Shared/Screens/Multi/UI/Settings/MultiplayerMatchSettings.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Settings/MultiplayerMatchSettings.cs
@@ -6,7 +6,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Settings
 {
     public class MultiplayerMatchSettings : SelectedGamePanel
     {
-        public MultiplayerMatchSettings(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerMatchSettings(Bindable<MultiplayerGame> game) : base(game, true)
         {
         }
     }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanel.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanel.cs
@@ -13,6 +13,10 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
     {
         /// <summary>
         /// </summary>
+        public bool IsMultiplayer { get; }
+
+        /// <summary>
+        /// </summary>
         private Bindable<MultiplayerGame> SelectedGame { get; }
 
         /// <summary>
@@ -33,9 +37,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
 
         /// <summary>
         /// </summary>
-        public SelectedGamePanel(Bindable<MultiplayerGame> selectedGame)
+        public SelectedGamePanel(Bindable<MultiplayerGame> selectedGame, bool isMultiplayer = false)
         {
             SelectedGame = selectedGame;
+            IsMultiplayer = isMultiplayer;
+
             Size = new ScalableVector2(564, 838);
             Alpha = 0;
 
@@ -84,7 +90,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
                 Image = UserInterface.LeaderboardScoresPanel
             };
 
-            Container = new SelectedGamePanelContainer(SelectedGame,
+            Container = new SelectedGamePanelContainer(SelectedGame, IsMultiplayer,
                 new ScalableVector2(PanelRectangle.Width - 4, PanelRectangle.Height - 4))
             {
                 Parent = PanelRectangle,

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelContainer.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelContainer.cs
@@ -12,6 +12,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
     public class SelectedGamePanelContainer : Sprite
     {
         /// <summary>
+        ///     If the container is for multiplayer. If not, then it'll be for the multiplayer lobby
+        /// </summary>
+        private bool IsMultiplayer { get; }
+
+        /// <summary>
         /// </summary>
         private Bindable<MultiplayerGame> SelectedGame { get; }
 
@@ -26,10 +31,12 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
         /// <summary>
         /// </summary>
         /// <param name="selectedGame"></param>
+        /// <param name="isMultiplayer"></param>
         /// <param name="size"></param>
-        public SelectedGamePanelContainer(Bindable<MultiplayerGame> selectedGame, ScalableVector2 size)
+        public SelectedGamePanelContainer(Bindable<MultiplayerGame> selectedGame, bool isMultiplayer, ScalableVector2 size)
         {
             SelectedGame = selectedGame;
+            IsMultiplayer = isMultiplayer;
 
             Alpha = 0;
             Size = size;
@@ -67,7 +74,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
         /// </summary>
         private void CreateSelectedGamePanelMatch()
         {
-            Match = new SelectedGamePanelMatch(SelectedGame, Size)
+            Match = new SelectedGamePanelMatch(SelectedGame, IsMultiplayer, Size)
             {
                 Parent = this,
                 Alignment = Alignment.TopCenter,

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelMatch.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelMatch.cs
@@ -9,6 +9,10 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
 {
     public class SelectedGamePanelMatch : Sprite, IMultiplayerGameComponent
     {
+        /// <summary>
+        /// </summary>
+        public bool IsMultiplayer { get; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -25,10 +29,12 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
         /// <summary>
         /// </summary>
         /// <param name="selectedGame"></param>
+        /// <param name="isMultiplayer"></param>
         /// <param name="size"></param>
-        public SelectedGamePanelMatch(Bindable<MultiplayerGame> selectedGame, ScalableVector2 size)
+        public SelectedGamePanelMatch(Bindable<MultiplayerGame> selectedGame, bool isMultiplayer, ScalableVector2 size)
         {
             SelectedGame = selectedGame;
+            IsMultiplayer = isMultiplayer;
             Size = size;
             Alpha = 0;
 
@@ -56,7 +62,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
         /// </summary>
         private void CreateTable()
         {
-            Table = new DrawableMultiplayerTable(SelectedGame, new ScalableVector2(Width,
+            Table = new DrawableMultiplayerTable(SelectedGame, IsMultiplayer, new ScalableVector2(Width,
                 Height - Banner.Height))
             {
                 Parent = this,

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTableItem.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTableItem.cs
@@ -1,6 +1,7 @@
 using System;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Containers;
+using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Helpers;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites.Text;
@@ -56,6 +57,32 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
             {
                 Name.Text = item.GetName();
                 Value.Text = item.GetValue();
+
+                var container = (DrawableMultiplayerTable) Container;
+
+                if (container.IsMultiplayer)
+                {
+                    if (item.Selector != null)
+                    {
+                        if (Item.Selector is Dropdown)
+                        {
+                            Item.Selector.Parent = Container.ContentContainer;
+                            Item.Selector.Alignment = Alignment.TopRight;
+                            Item.Selector.Y = Y + Height / 2f - Item.Selector.Height / 2f;
+                        }
+                        else
+                        {
+                            Item.Selector.Parent = this;
+                            Item.Selector.Alignment = Alignment.MidRight;
+                        }
+
+                        Item.Selector.X = -Name.X;
+                        Item.Selector.UsePreviousSpriteBatchOptions = true;
+                        Item.UpdateSelectorState();
+
+                        Value.Visible = false;
+                    }
+                }
             });
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/IMultiplayerTableItem.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/IMultiplayerTableItem.cs
@@ -1,5 +1,6 @@
 using Quaver.Server.Common.Objects.Multiplayer;
 using Wobble.Bindables;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
@@ -20,5 +21,15 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// </summary>
         /// <returns></returns>
         string GetValue();
+
+        /// <summary>
+        ///     The drawable used to select the item. This could be a checkbox/dropdown/etc.
+        /// </summary>
+        Drawable Selector { get; set; }
+
+        /// <summary>
+        ///     Updates the state of <see cref="Selector"/>
+        /// </summary>
+        void UpdateSelectorState();
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItem.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItem.cs
@@ -1,5 +1,6 @@
 using Quaver.Server.Common.Objects.Multiplayer;
 using Wobble.Bindables;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
@@ -12,8 +13,22 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 
         /// <summary>
         /// </summary>
+        public bool IsMultiplayer { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public virtual Drawable Selector { get; set; }
+
+        /// <summary>
+        /// </summary>
         /// <param name="game"></param>
-        public MultiplayerTableItem(Bindable<MultiplayerGame> game) => SelectedGame = game;
+        /// <param name="isMultiplayer"></param>
+        public MultiplayerTableItem(Bindable<MultiplayerGame> game, bool isMultiplayer)
+        {
+            IsMultiplayer = isMultiplayer;
+            SelectedGame = game;
+        }
 
         /// <inheritdoc />
         /// <summary>
@@ -31,6 +46,12 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// <summary>
         /// </summary>
         public virtual void UpdateState()
+        {
+        }
+
+        /// <summary>
+        /// </summary>
+        public void UpdateSelectorState()
         {
         }
     }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAllowedGameModes.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAllowedGameModes.cs
@@ -8,7 +8,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemAllowedGameModes : MultiplayerTableItem
     {
-        public MultiplayerTableItemAllowedGameModes(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemAllowedGameModes(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAutoHostRotation.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAutoHostRotation.cs
@@ -1,16 +1,54 @@
+using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics.Form;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public class MultiplayerTableItemAutoHostRotation : MultiplayerTableItem
+    public sealed class MultiplayerTableItemAutoHostRotation : MultiplayerTableItem
     {
-        public MultiplayerTableItemAutoHostRotation(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemAutoHostRotation(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
+            Selector = new MultiplayerAutoHostRotationCheckbox(game);
         }
 
         public override string GetName() => "Auto Host Rotation";
 
         public override string GetValue() => SelectedGame.Value.HostRotation ? "Yes" : "No";
+    }
+
+    public class MultiplayerAutoHostRotationCheckbox : QuaverCheckbox
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="game"></param>
+        public MultiplayerAutoHostRotationCheckbox(Bindable<MultiplayerGame> game)
+            : base(new Bindable<bool>(game?.Value?.HostRotation ?? false))
+        {
+            Game = game;
+            Depth = 1;
+
+            Clicked += (sender, args) =>
+            {
+                OnlineManager.Client.ChangeGameAutoHostRotation(BindedValue.Value);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            BindedValue.Value = Game?.Value?.HostRotation ?? false;
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemDifficultyRange.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemDifficultyRange.cs
@@ -6,7 +6,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemDifficultyRange : MultiplayerTableItem
     {
-        public MultiplayerTableItemDifficultyRange(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemDifficultyRange(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeMod.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeMod.cs
@@ -1,12 +1,18 @@
+using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics.Form;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public class MultiplayerTableItemFreeMod : MultiplayerTableItem
+    public sealed class MultiplayerTableItemFreeMod : MultiplayerTableItem
     {
-        public MultiplayerTableItemFreeMod(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemFreeMod(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
+            Selector = new MultiplayerFreeModCheckbox(game);
         }
 
         /// <inheritdoc />
@@ -21,5 +27,43 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// <returns></returns>
         public override string GetValue()
             => SelectedGame.Value.FreeModType.HasFlag(MultiplayerFreeModType.Regular) ? "Yes" : "No";
+    }
+
+    public class MultiplayerFreeModCheckbox : QuaverCheckbox
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="game"></param>
+        public MultiplayerFreeModCheckbox(Bindable<MultiplayerGame> game)
+            : base(new Bindable<bool>(game?.Value?.FreeModType.HasFlag(MultiplayerFreeModType.Regular) ?? false))
+        {
+            Game = game;
+            Depth = 1;
+
+            Clicked += (sender, args) =>
+            {
+                if (game?.Value == null)
+                    return;
+
+                if (game.Value.FreeModType.HasFlag(MultiplayerFreeModType.Regular))
+                    OnlineManager.Client?.ChangeGameFreeModType((MultiplayerFreeModType) (OnlineManager.CurrentGame.FreeModType - MultiplayerFreeModType.Regular));
+                else
+                    OnlineManager.Client?.ChangeGameFreeModType(OnlineManager.CurrentGame.FreeModType | MultiplayerFreeModType.Regular);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            BindedValue.Value = Game?.Value?.FreeModType.HasFlag(MultiplayerFreeModType.Regular) ?? false;
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeRate.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeRate.cs
@@ -1,12 +1,18 @@
+using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics.Form;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public class MultiplayerTableItemFreeRate : MultiplayerTableItem
+    public sealed class MultiplayerTableItemFreeRate : MultiplayerTableItem
     {
-        public MultiplayerTableItemFreeRate(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemFreeRate(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
+            Selector = new MultiplayerFreeRateCheckbox(game);
         }
 
         /// <inheritdoc />
@@ -21,5 +27,43 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// <returns></returns>
         public override string GetValue()
             => SelectedGame.Value.FreeModType.HasFlag(MultiplayerFreeModType.Rate) ? "Yes" : "No";
+    }
+
+    public class MultiplayerFreeRateCheckbox : QuaverCheckbox
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="game"></param>
+        public MultiplayerFreeRateCheckbox(Bindable<MultiplayerGame> game)
+            : base(new Bindable<bool>(game?.Value?.FreeModType.HasFlag(MultiplayerFreeModType.Rate) ?? false))
+        {
+            Game = game;
+            Depth = 1;
+
+            Clicked += (sender, args) =>
+            {
+                if (game?.Value == null)
+                    return;
+
+                if (game.Value.FreeModType.HasFlag(MultiplayerFreeModType.Rate))
+                    OnlineManager.Client?.ChangeGameFreeModType((MultiplayerFreeModType) (OnlineManager.CurrentGame.FreeModType - MultiplayerFreeModType.Rate));
+                else
+                    OnlineManager.Client?.ChangeGameFreeModType(OnlineManager.CurrentGame.FreeModType | MultiplayerFreeModType.Rate);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            BindedValue.Value = Game?.Value?.FreeModType.HasFlag(MultiplayerFreeModType.Rate) ?? false;
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemHealthType.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemHealthType.cs
@@ -1,29 +1,70 @@
 using System;
+using Microsoft.Xna.Framework;
 using Quaver.API.Enums;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics.Form;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public class MultiplayerTableItemHealthType : MultiplayerTableItem
+    public sealed class MultiplayerTableItemHealthType : MultiplayerTableItem
     {
-        public MultiplayerTableItemHealthType(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemHealthType(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
+            Selector = new MultiplayerHealthTypeCheckbox(game);
         }
 
-        public override string GetName() => "Health System";
+        public override string GetName() => "Lose A Life Upon Failing";
 
         public override string GetValue()
         {
             switch ((MultiplayerHealthType) SelectedGame.Value.HealthType)
             {
                 case MultiplayerHealthType.Manual_Regeneration:
-                    return "Manual Regeneration";
+                    return "No";
                 case MultiplayerHealthType.Lives:
-                    return "Lives";
+                    return "Yes";
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+        }
+    }
+
+    public class MultiplayerHealthTypeCheckbox : QuaverCheckbox
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="game"></param>
+        public MultiplayerHealthTypeCheckbox(Bindable<MultiplayerGame> game)
+            : base(new Bindable<bool>(game?.Value?.HealthType == (byte) MultiplayerHealthType.Lives))
+        {
+            Game = game;
+            Depth = 1;
+
+            Clicked += (sender, args) =>
+            {
+                if (BindedValue.Value)
+                    OnlineManager.Client?.ChangeGameHealthType(MultiplayerHealthType.Lives);
+                else
+                    OnlineManager.Client?.ChangeGameHealthType(MultiplayerHealthType.Manual_Regeneration);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            BindedValue.Value = Game?.Value?.HealthType == (byte) MultiplayerHealthType.Lives;
         }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemInProgress.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemInProgress.cs
@@ -5,7 +5,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemInProgress : MultiplayerTableItem
     {
-        public MultiplayerTableItemInProgress(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemInProgress(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLifeCount.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLifeCount.cs
@@ -5,7 +5,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemLifeCount : MultiplayerTableItem
     {
-        public MultiplayerTableItemLifeCount(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemLifeCount(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLongNotePercentageRange.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLongNotePercentageRange.cs
@@ -5,7 +5,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemLongNotePercentageRange : MultiplayerTableItem
     {
-        public MultiplayerTableItemLongNotePercentageRange(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemLongNotePercentageRange(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemPlayers.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemPlayers.cs
@@ -1,16 +1,68 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Form.Dropdowns;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public class MultiplayerTableItemPlayers : MultiplayerTableItem
+    public sealed class MultiplayerTableItemPlayers : MultiplayerTableItem
     {
-        public MultiplayerTableItemPlayers(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemPlayers(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
+            Selector = new MultiplayerMaxPlayersDropdown(game);
         }
 
-        public override string GetName() => "Players";
+        public override string GetName()
+        {
+            if (IsMultiplayer)
+                return "Max Players";
+
+            return "Players";
+        }
 
         public override string GetValue() => $"{SelectedGame.Value.PlayerIds.Count}/{SelectedGame.Value.MaxPlayers}";
+    }
+
+    public class MultiplayerMaxPlayersDropdown : Dropdown
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        public MultiplayerMaxPlayersDropdown(Bindable<MultiplayerGame> game) : base(GetOptions(),
+            new ScalableVector2(100, 36), 22, Colors.MainAccent, 0)
+        {
+            Game = game;
+            Depth = 1;
+
+            ItemSelected += (sender, args) => OnlineManager.Client?.ChangeGameMaxPlayers(int.Parse(args.Text));
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            SelectedIndex = (int) Game.Value.Ruleset;
+            SelectedText.Text = Game.Value.MaxPlayers.ToString();
+
+            base.Update(gameTime);
+        }
+
+        private static List<string> GetOptions()
+        {
+            var options = new List<string>();
+
+            for (var i = 1; i < 16; i++)
+                options.Add($"{i + 1}");
+
+            return options;
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemRuleset.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemRuleset.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Form.Dropdowns;
+using Quaver.Shared.Online;
+using Wobble.Bindables;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
+{
+    public sealed class MultiplayerTableItemRuleset : MultiplayerTableItem
+    {
+        public MultiplayerTableItemRuleset(Bindable<MultiplayerGame> game, bool isMultiplayer) : base(game, isMultiplayer)
+        {
+            Selector = new MultiplayerRulesetDropdown(game);
+        }
+
+        public override string GetName() => "Ruleset";
+
+        public override string GetValue()
+        {
+            switch (SelectedGame.Value.Ruleset)
+            {
+                case MultiplayerGameRuleset.Free_For_All:
+                    return "Free-For-All";
+                case MultiplayerGameRuleset.Team:
+                    return "Team";
+                case MultiplayerGameRuleset.Battle_Royale:
+                    return "Battle Royale";
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+
+    public class MultiplayerRulesetDropdown : Dropdown
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        public MultiplayerRulesetDropdown(Bindable<MultiplayerGame> game) : base(new List<string>()
+        {
+            "Free-For-All",
+            "Team",
+            "Battle Royale"
+        }, new ScalableVector2(170, 36), 22, Colors.MainAccent, 0)
+        {
+            Game = game;
+
+            ItemSelected += (sender, args) => OnlineManager.Client?.ChangeGameRuleset((MultiplayerGameRuleset) args.Index);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            SelectedIndex = (int) Game.Value.Ruleset;
+            SelectedText.Text = Options[SelectedIndex];
+
+            base.Update(gameTime);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemSongLength.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemSongLength.cs
@@ -6,7 +6,8 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
     public class MultiplayerTableItemSongLength : MultiplayerTableItem
     {
-        public MultiplayerTableItemSongLength(Bindable<MultiplayerGame> game) : base(game)
+        public MultiplayerTableItemSongLength(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
         {
         }
 


### PR DESCRIPTION
* Adds dropdowns/checkboxes to modify multiplayer game settings
* Handles online events for `MultiplayerPlayer` and `MultiplayerPlayerList` to update their states.
* Fix multiplayer teams not resetting when switching modes.