### PR TITLE
Use DesiredPoolStartingIndex in more places

### DIFF
--- a/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
@@ -145,7 +145,7 @@ namespace Quaver.Shared.Graphics.Containers
         /// </summary>
         /// <param name="middleObjectIndex"></param>
         /// <returns></returns>
-        private int DesiredPoolStartingIndex(int middleObjectIndex)
+        protected int DesiredPoolStartingIndex(int middleObjectIndex)
         {
             if (middleObjectIndex < PoolSize / 2)
                 return 0;

--- a/Quaver.Shared/Screens/Selection/UI/Maps/MapScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/MapScrollContainer.cs
@@ -143,7 +143,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
             SetSelectedIndex();
 
             // Reset the starting index so we can be aware of the mapsets that are needed
-            PoolStartingIndex = GetPoolStartingIndex();
+            PoolStartingIndex = DesiredPoolStartingIndex(SelectedIndex.Value);
 
             // Recreate the object pool
             CreatePool();

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -162,7 +162,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 SetSelectedIndex();
 
                 // Reset the starting index so we can be aware of the mapsets that are needed
-                PoolStartingIndex = GetPoolStartingIndex();
+                PoolStartingIndex = DesiredPoolStartingIndex(SelectedIndex.Value);
 
                 // Recreate the object pool
                 CreatePool();

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/SongSelectContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/SongSelectContainer.cs
@@ -74,7 +74,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             // ReSharper disable once VirtualMemberCallInConstructor
             SetSelectedIndex();
 
-            PoolStartingIndex = GetPoolStartingIndex();
+            PoolStartingIndex = DesiredPoolStartingIndex(SelectedIndex.Value);
             SnapToSelected();
             CreatePool();
             PositionAndContainPoolObjects();
@@ -128,26 +128,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             Scrollbar.Parent = ScrollbarBackground;
             Scrollbar.Alignment = Alignment.BotCenter;
             Scrollbar.Tint = Color.White;
-        }
-
-        /// <summary>
-        ///    Retrieves the starting index for the object pool
-        /// </summary>
-        /// <returns></returns>
-        protected int GetPoolStartingIndex()
-        {
-            const int ITEMS_DISPLAYED_BEFORE_POOL_SHIFT = 5;
-
-            var val = SelectedIndex.Value - ITEMS_DISPLAYED_BEFORE_POOL_SHIFT;
-
-            if (SelectedIndex.Value <= 0)
-                return 0;
-
-            if (SelectedIndex.Value <= AvailableItems.Count - ITEMS_DISPLAYED_BEFORE_POOL_SHIFT)
-                return val < 0 ? 0 : val;
-
-            var proposed = AvailableItems.Count - PoolSize;
-            return proposed < 0 ? 0 : proposed;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
@@ -147,7 +147,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 SetSelectedIndex();
 
                 // Reset the starting index so we can be aware of the mapsets that are needed
-                PoolStartingIndex = GetPoolStartingIndex();
+                PoolStartingIndex = DesiredPoolStartingIndex(SelectedIndex.Value);
 
                 // Recreate the object pool
                 CreatePool();


### PR DESCRIPTION
This fixes the poolable scroll container sometimes not pooling enough
objects leading to the displayed objects not refreshing. Particularly
this happened when a map selection screen was opened with the 6th map
from the bottom selected: due to an outdated constant used in removed
code, the pool (of size 12) would initialize only 11 objects.

In general, in all such computations DesiredPoolStartingIndex should be
used as it always does the correct computation.