### PR TITLE
Implement Multiplayer Map Selection, Importing, & Banner Map Statistics

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -107,7 +107,7 @@ namespace Quaver.Shared.Database.Maps
                     if (OnlineManager.CurrentGame != null)
                     {
                         var select = game.CurrentScreen as SelectionScreen;
-                        screen.Exit(() => new ImportingScreen(select?.MultiplayerScreen, true));
+                        screen.Exit(() => new ImportingScreen(null, true));
                         return;
                     }
 

--- a/Quaver.Shared/Graphics/Overlays/Hub/SongRequests/Scrolling/SongRequestRightClickOptions.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/SongRequests/Scrolling/SongRequestRightClickOptions.cs
@@ -144,7 +144,7 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.SongRequests.Scrolling
                             if (game.CurrentScreen.Type == QuaverScreenType.Select)
                             {
                                 var selectScreen = (SelectionScreen) game.CurrentScreen;
-                                game.CurrentScreen.Exit(() => new ImportingScreen(selectScreen.MultiplayerScreen, true));
+                                game.CurrentScreen.Exit(() => new ImportingScreen(null, true));
 
                                 var dialog = DialogManager.Dialogs.Find(x => x is OnlineHubDialog) as OnlineHubDialog;
                                 dialog?.Close();

--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -259,6 +259,7 @@ namespace Quaver.Shared.Online
             Client.OnGamePlayerHasMap += OnGamePlayerHasMap;
             Client.OnGameHostSelectingMap += OnGameHostSelectingMap;
             Client.OnGameSetReferee += OnGameSetReferee;
+            Client.OnGameMapChanged += OnGameMapChanged;
             Client.OnJoinedListeningParty += OnJoinedListeningParty;
             Client.OnLeftListeningParty += OnLeftListeningParty;
             Client.OnListeningPartyStateUpdate += OnListeningPartyStateUpdate;
@@ -707,7 +708,7 @@ namespace Quaver.Shared.Online
             game.CurrentScreen.Exit(() =>
             {
                 Logger.Important($"Successfully joined game: {CurrentGame.Id} | {CurrentGame.Name} | {CurrentGame.HasPassword}", LogType.Network);
-                return new MultiplayerScreen(CurrentGame);
+                return new MultiplayerGameScreen();
             });
         }
 
@@ -1180,6 +1181,26 @@ namespace Quaver.Shared.Online
                 return;
 
             CurrentGame.HostSelectingMap = e.IsSelecting;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void OnGameMapChanged(object sender, GameMapChangedEventArgs e)
+        {
+            // Make sure to clear all the players that don't have the map, as this information is
+            // now outdated.
+            CurrentGame.PlayersWithoutMap.Clear();
+
+            CurrentGame.MapMd5 = e.MapMd5;
+            CurrentGame.AlternativeMd5 = e.AlternativeMd5;
+            CurrentGame.MapId = e.MapId;
+            CurrentGame.MapsetId = e.MapsetId;
+            CurrentGame.Map = e.Map;
+            CurrentGame.DifficultyRating = e.DifficultyRating;
+            CurrentGame.AllDifficultyRatings = e.AllDifficultyRatings;
+            CurrentGame.GameMode = e.GameMode;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Importing/ImportingScreen.cs
+++ b/Quaver.Shared/Screens/Importing/ImportingScreen.cs
@@ -14,6 +14,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Settings;
 using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Multi;
 using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Music;
 using Quaver.Shared.Screens.Select;
@@ -103,19 +104,16 @@ namespace Quaver.Shared.Screens.Importing
         {
             Logger.Important($"Map import has completed", LogType.Runtime);
 
-            if (OnlineManager.CurrentGame != null && MultiplayerScreen != null)
+            if (OnlineManager.CurrentGame != null)
             {
                 MapManager.Selected.Value = PreviouslySelectedMap;
-
-                var view = (MultiplayerScreenView) MultiplayerScreen.View;
-                view.Map.UpdateContent();
 
                 Exit(() =>
                 {
                     if (ComingFromSelect)
-                        return new SelectionScreen(MultiplayerScreen);
+                        return new SelectionScreen();
 
-                    return MultiplayerScreen;
+                    return new MultiplayerGameScreen();
                 });
             }
             else if (OnlineManager.ListeningParty != null)
@@ -138,7 +136,7 @@ namespace Quaver.Shared.Screens.Importing
             }
             else
             {
-                Exit(() => new SelectionScreen(MultiplayerScreen));
+                Exit(() => new SelectionScreen());
             }
         }
     }

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -1,11 +1,19 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using Quaver.API.Enums;
+using Quaver.Server.Client.Handlers;
 using Quaver.Server.Common.Enums;
 using Quaver.Server.Common.Objects;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Audio;
+using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Selection.UI;
 using Wobble.Bindables;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Input;
 
 namespace Quaver.Shared.Screens.Multi
 {
@@ -22,12 +30,45 @@ namespace Quaver.Shared.Screens.Multi
         public Bindable<MultiplayerGame> Game { get; private set; }
 
         /// <summary>
+        ///     The currently active panel on the left side of the screen
+        /// </summary>
+        public Bindable<SelectContainerPanel> ActiveLeftPanel { get; private set; }
+
+        /// <summary>
+        ///     If true, when the screen exits, it will not exit the user out of the game
+        /// </summary>
+        public bool DontLeaveGameUponScreenSwitch { get; set; }
+
+        /// <summary>
         /// </summary>
         public MultiplayerGameScreen()
         {
             CreateGameBindable();
-            ScreenExiting += (sender, args) => OnlineManager.LeaveGame();
+            InitializeActiveLeftPanelBindable();
+
+            ScreenExiting += (sender, args) =>
+            {
+                if (DontLeaveGameUponScreenSwitch)
+                    return;
+
+                OnlineManager.LeaveGame();
+            };
+
+            SelectMultiplayerMap();
+
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameMapChanged += OnMapChanged;
+
             View = new MultiplayerGameScreenView(this);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            HandleInput();
+            base.Update(gameTime);
         }
 
         /// <inheritdoc />
@@ -36,6 +77,10 @@ namespace Quaver.Shared.Screens.Multi
         public override void Destroy()
         {
             Game?.Dispose();
+
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameMapChanged -= OnMapChanged;
+
             base.Destroy();
         }
 
@@ -48,11 +93,73 @@ namespace Quaver.Shared.Screens.Multi
             Game = new Bindable<MultiplayerGame>(game) {Value = game};
         }
 
+        /// <summary>
+        ///     Initializes the bindable which keeps track of which panel on the left side of the screen is active
+        /// </summary>
+        private void InitializeActiveLeftPanelBindable()
+        {
+            ActiveLeftPanel = new Bindable<SelectContainerPanel>(SelectContainerPanel.MatchSettings)
+            {
+                Value = SelectContainerPanel.MatchSettings
+            };
+        }
+
+        /// <summary>
+        ///     Finds and selects the multiplayer map
+        /// </summary>
+        private void SelectMultiplayerMap()
+        {
+            var map = MapManager.FindMapFromMd5(Game.Value.MapMd5);
+
+            if (map == null)
+                map = MapManager.FindMapFromMd5(Game.Value.AlternativeMd5);
+
+            if (map == null)
+            {
+                if (AudioEngine.Track.IsPlaying)
+                    AudioEngine.Track.Pause();
+
+                MapManager.Selected.Value = null;
+                OnlineManager.Client?.DontHaveMultiplayerGameMap();
+                return;
+            }
+
+            MapManager.Selected.Value = map;
+            OnlineManager.Client?.HasMultiplayerGameMap();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnMapChanged(object sender, GameMapChangedEventArgs e) => SelectMultiplayerMap();
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
         /// <returns></returns>
         public override UserClientStatus GetClientStatus() => new UserClientStatus(ClientStatus.Multiplayer, -1, "-1", 1, "", 0);
+
+        /// <summary>
+        /// </summary>
+        private void HandleInput()
+        {
+            if (DialogManager.Dialogs.Count != 0)
+                return;
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.F2))
+                HandleKeyPressF2();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleKeyPressF2()
+        {
+            if (ActiveLeftPanel.Value != SelectContainerPanel.Leaderboard)
+                ActiveLeftPanel.Value = SelectContainerPanel.Leaderboard;
+            else
+                ActiveLeftPanel.Value = SelectContainerPanel.MatchSettings;
+        }
 
         /// <summary>
         /// </summary>
@@ -65,7 +172,7 @@ namespace Quaver.Shared.Screens.Multi
                 GameId = 999,
                 Name = "Example Game",
                 Type = MultiplayerGameType.Friendly,
-                Ruleset = MultiplayerGameRuleset.Team,
+                Ruleset = MultiplayerGameRuleset.Battle_Royale,
                 GameMode = (byte) GameMode.Keys4,
                 PlayerIds = new List<int>(),
                 MaxPlayers = 16,
@@ -75,10 +182,10 @@ namespace Quaver.Shared.Screens.Multi
                 MapsetId = -1,
                 Map = "Artist - Title [Example]",
                 JudgementCount = 1000,
-                HostId = 7,
+                HostId = 1,
                 PlayersReady = new List<int>() { 3, 6, 13, 7 },
-                RedTeamPlayers = new List<int> { 0, 1, 2, 3, 4, 5, 6, },
-                BlueTeamPlayers = new List<int> { 7, 8, 9, 10, 11, 12, 13, 14 },
+                RedTeamPlayers = new List<int> { 0, 1, 2, 3, 4, 5, 6 },
+                BlueTeamPlayers = new List<int> { 7, 8, 9, 10, 11, 12, 13, 14},
                 PlayersWithoutMap = new List<int>()
                 {
                     8, 9, 7, 2
@@ -109,7 +216,9 @@ namespace Quaver.Shared.Screens.Multi
                         Wins = 47
                     }
                 },
-                RefereeUserId = 15
+                RefereeUserId = 11,
+                HostRotation = true,
+                FreeModType = MultiplayerFreeModType.Regular,
             };
         }
     }

--- a/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayer.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayer.cs
@@ -164,20 +164,20 @@ namespace Quaver.Shared.Screens.Multi.UI.Players
             if (User.HasUserInfo)
             {
                 Username.Text = User.OnlineUser.Username;
-
-                if (User.Stats.ContainsKey((GameMode) Game.Value.GameMode))
-                    Username.Text += $"";
-
                 Flag.Image = Flags.Get(User.OnlineUser.CountryFlag ?? "XX");
             }
             else
             {
                 // Request the user's information from the server
                 OnlineManager.Client?.RequestUserInfo(new List<int>{ User.OnlineUser.Id });
+                OnlineManager.Client?.RequestUserStats(new List<int>{ User.OnlineUser.Id });
 
                 Username.Text = "Loading...";
                 Flag.Image = Flags.Get("XX");
             }
+
+            if (User.Stats.ContainsKey((GameMode) Game.Value.GameMode))
+                Username.Text += $" (#{User.Stats[(GameMode) Game.Value.GameMode].Rank})";
 
             // Update host crown visibility
             HostCrown.Visible = Game.Value.HostId == User.OnlineUser.Id;

--- a/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayerList.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayerList.cs
@@ -145,6 +145,16 @@ namespace Quaver.Shared.Screens.Multi.UI.Players
             {
                 if (OnlineManager.OnlineUsers.ContainsKey(player))
                     AddPlayer(OnlineManager.OnlineUsers[player]);
+                else
+                {
+                    AddPlayer(new User(new OnlineUser()
+                    {
+                        Id = player,
+                        SteamId = player,
+                        Username = $"User_{player}",
+                        CountryFlag = "US"
+                    }));
+                }
             }
         }
 

--- a/Quaver.Shared/Screens/Multiplayer/UI/MenuFooterMultiplayer.cs
+++ b/Quaver.Shared/Screens/Multiplayer/UI/MenuFooterMultiplayer.cs
@@ -148,7 +148,7 @@ namespace Quaver.Shared.Screens.Multiplayer.UI
 
                 var game = (QuaverGame) GameBase.Game;
                 var screen = game.CurrentScreen as MultiplayerScreen;
-                screen?.Exit(() => new SelectionScreen(screen), 0);
+                screen?.Exit(() => new SelectionScreen(), 0);
             })
             {
                 DestroyIfParentIsNull = false

--- a/Quaver.Shared/Screens/Multiplayer/UI/MultiplayerMap.cs
+++ b/Quaver.Shared/Screens/Multiplayer/UI/MultiplayerMap.cs
@@ -430,7 +430,7 @@ namespace Quaver.Shared.Screens.Multiplayer.UI
             {
                 var game = (QuaverGame) GameBase.Game;
                 var screen = game.CurrentScreen as MultiplayerScreen;
-                screen?.Exit(() => new SelectionScreen(screen), 0, QuaverScreenChangeType.AddToStack);
+                screen?.Exit(() => new SelectionScreen(), 0, QuaverScreenChangeType.AddToStack);
                 return;
             }
 

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelMatch.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/SelectedGamePanelMatch.cs
@@ -50,7 +50,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected
         /// </summary>
         private void CreateBanner()
         {
-            Banner = new SelectedGamePanelMatchBanner(SelectedGame, new ScalableVector2(Width, 136))
+            Banner = new SelectedGamePanelMatchBanner(SelectedGame, new ScalableVector2(Width, 136), IsMultiplayer)
             {
                 Parent = this,
                 X = 1,

--- a/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
+++ b/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
@@ -28,15 +28,30 @@ namespace Quaver.Shared.Screens.Selection.Components
 
         /// <summary>
         /// </summary>
-        public SelectJukebox(QuaverScreen screen = null)
+        private bool PlayFromBeginning { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public SelectJukebox(QuaverScreen screen = null, bool playFromBeginning = false)
         {
             Screen = screen;
+            PlayFromBeginning = playFromBeginning;
             Size = new ScalableVector2(0, 0);
 
             LoadTrackTask = new TaskHandler<int, int>((i, token) =>
             {
                 LogLoadingTrack();
-                AudioEngine.PlaySelectedTrackAtPreview();
+
+                if (PlayFromBeginning)
+                {
+                    AudioEngine.LoadCurrentTrack();
+                    AudioEngine.Track.Play();
+                }
+                else
+                {
+                    AudioEngine.PlaySelectedTrackAtPreview();
+                }
+
                 AudioTrackStoppedInLastFrame = false;
                 return 0;
             });

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -26,6 +26,7 @@ using Quaver.Shared.Screens.Importing;
 using Quaver.Shared.Screens.Loading;
 using Quaver.Shared.Screens.Main;
 using Quaver.Shared.Screens.Menu;
+using Quaver.Shared.Screens.Multi;
 using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
 using Quaver.Shared.Screens.Selection.UI;
@@ -52,7 +53,7 @@ namespace Quaver.Shared.Screens.Selection
         /// <summary>
         ///     If the user is in multiplayer, this is the current screen
         /// </summary>
-        public MultiplayerScreen MultiplayerScreen { get; }
+        public bool IsMultiplayer { get; }
 
         /// <summary>
         ///     Stores the currently available mapsets to play in the screen
@@ -90,19 +91,19 @@ namespace Quaver.Shared.Screens.Selection
 
         /// <summary>
         /// </summary>
-        public SelectionScreen(MultiplayerScreen multiplayerScreen = null)
+        public SelectionScreen()
         {
-            MultiplayerScreen = multiplayerScreen;
+            IsMultiplayer = OnlineManager.CurrentGame != null;
 
             // Go to the import screen if we've imported a map not on the select screen
             if (MapsetImporter.Queue.Count > 0 || QuaverSettingsDatabaseCache.OutdatedMaps.Count != 0
                                                || MapDatabaseCache.MapsToUpdate.Count != 0)
             {
-                Exit(() => new ImportingScreen(MultiplayerScreen, true));
+                Exit(() => new ImportingScreen(null, true));
                 return;
             }
 
-            if (MultiplayerScreen != null)
+            if (IsMultiplayer)
                 OnlineManager.Client?.SetGameCurrentlySelectingMap(true);
             else
                 SetRichPresence();
@@ -551,11 +552,10 @@ namespace Quaver.Shared.Screens.Selection
         {
             Exit(() =>
             {
-                if (MultiplayerScreen != null)
+                if (IsMultiplayer)
                 {
-                    MultiplayerScreen.Exiting = false;
                     OnlineManager.Client?.SetGameCurrentlySelectingMap(false);
-                    return MultiplayerScreen;
+                    return new MultiplayerGameScreen();
                 }
 
                 return new MainMenuScreen();
@@ -615,11 +615,7 @@ namespace Quaver.Shared.Screens.Selection
 
                 OnlineManager.Client.SetGameCurrentlySelectingMap(false);
 
-                Exit(() =>
-                {
-                    MultiplayerScreen.Exiting = false;
-                    return MultiplayerScreen;
-                });
+                Exit(() => new MultiplayerGameScreen());
             });
         }
 
@@ -833,7 +829,7 @@ namespace Quaver.Shared.Screens.Selection
         /// <param name="e"></param>
         /// <exception cref="NotImplementedException"></exception>
         private void OnAutoLoadOsuBeatmapsChanged(object sender, BindableValueChangedEventArgs<bool> e)
-            => Exit(() => new ImportingScreen(MultiplayerScreen, true));
+            => Exit(() => new ImportingScreen(null, true));
 
         /// <inheritdoc />
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/TextKeyValue.cs
@@ -13,12 +13,12 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
         /// <summary>
         ///     Displays the key of the metadata
         /// </summary>
-        protected SpriteTextPlus Key { get; private set; }
+        public SpriteTextPlus Key { get; private set; }
 
         /// <summary>
         ///     Displays the value of the metadata
         /// </summary>
-        protected SpriteTextPlus Value { get; private set; }
+        public SpriteTextPlus Value { get; private set; }
 
         /// <summary>
         ///     The size of the font

--- a/Quaver.Shared/Screens/Selection/UI/SelectContainerPanel.cs
+++ b/Quaver.Shared/Screens/Selection/UI/SelectContainerPanel.cs
@@ -3,6 +3,7 @@ namespace Quaver.Shared.Screens.Selection.UI
     public enum SelectContainerPanel
     {
         Leaderboard,
-        Modifiers
+        Modifiers,
+        MatchSettings
     }
 }


### PR DESCRIPTION
* Decouples the old multiplayer screen from the import and selection screens
* Adds map statistics (BPM, Length, LN%, & NPS) to the match settings banner
* Adds click event handlers to the match settings banner which allow the user to select the map, download, or view the map's online page
* Adds the song select leaderboard to the multiplayer screen

Closes #867 
Fixes #1282  