### PR TITLE
Wayland alpha fix and VSync

### DIFF
--- a/Quaver.Shared/Config/FpsLimitType.cs
+++ b/Quaver.Shared/Config/FpsLimitType.cs
@@ -12,6 +12,7 @@ namespace Quaver.Shared.Config
         Unlimited,
         Limited,
         Vsync,
+        WaylandVsync,
         Custom
     }
 }

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -494,20 +494,29 @@ namespace Quaver.Shared
                 case FpsLimitType.Unlimited:
                     Graphics.SynchronizeWithVerticalRetrace = false;
                     IsFixedTimeStep = false;
+                    WaylandVsync = false;
                     break;
                 case FpsLimitType.Limited:
                     Graphics.SynchronizeWithVerticalRetrace = false;
                     IsFixedTimeStep = true;
                     TargetElapsedTime = TimeSpan.FromSeconds(1d / 240d);
+                    WaylandVsync = false;
                     break;
                 case FpsLimitType.Vsync:
                     Graphics.SynchronizeWithVerticalRetrace = true;
                     IsFixedTimeStep = true;
+                    WaylandVsync = false;
+                    break;
+                case FpsLimitType.WaylandVsync:
+                    Graphics.SynchronizeWithVerticalRetrace = false;
+                    IsFixedTimeStep = false;
+                    WaylandVsync = true;
                     break;
                 case FpsLimitType.Custom:
                     Graphics.SynchronizeWithVerticalRetrace = false;
                     TargetElapsedTime = TimeSpan.FromSeconds(1d / ConfigManager.CustomFpsLimit.Value);
                     IsFixedTimeStep = true;
+                    WaylandVsync = false;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
@@ -554,6 +563,10 @@ namespace Quaver.Shared
                     break;
                 case FpsLimitType.Vsync:
                     NotificationManager.Show(NotificationLevel.Info, $"Vsync Enabled");
+                    break;
+                case FpsLimitType.WaylandVsync:
+                    NotificationManager.Show(NotificationLevel.Info,
+                        "Wayland VSync is enabled. Note: it only works on Linux under Wayland.");
                     break;
                 case FpsLimitType.Custom:
                     NotificationManager.Show(NotificationLevel.Info,

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -468,13 +468,9 @@ namespace Quaver.Shared
                 Parent = GlobalUserInterface,
                 Alignment = Alignment.BotRight,
                 Size = new ScalableVector2(70, 30),
-                TextFps =
-                {
-                    Tint = Color.White
-                },
                 X = -5,
                 Y = -36,
-                Alpha = 0
+                Visible = false
             };
 
             ShowFpsCounter(fpsCounter);
@@ -482,9 +478,9 @@ namespace Quaver.Shared
         }
 
         /// <summary>
-        ///     Shows the FPs counter based on the current config variable.
+        ///     Shows the FPS counter based on the current config variable.
         /// </summary>
-        private static void ShowFpsCounter(FpsCounter counter) => counter.TextFps.Alpha = ConfigManager.FpsCounter.Value ? 1 : 0;
+        private static void ShowFpsCounter(FpsCounter counter) => counter.Visible = ConfigManager.FpsCounter.Value;
 
         /// <summary>
         ///    Handles limiting/unlimiting FPS based on user config

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -366,6 +366,8 @@ namespace Quaver.Shared
             GlobalUserInterface.Draw(gameTime);
 
             Transitioner.Draw(gameTime);
+
+            ClearAlphaChannel(gameTime);
         }
 
         /// <summary>


### PR DESCRIPTION
Requires https://github.com/Quaver/MonoGame/pull/3 and https://github.com/Quaver/Wobble/pull/85. Fixes the alpha channel (I think the issue is on every platform, it's just that on Wayland it's actually visible) and adds the Wayland VSync option. #944 