### PR TITLE
Various Multiplayer Fixes

### DIFF
--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/DrawableOnlineUserRightClickOptions.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/DrawableOnlineUserRightClickOptions.cs
@@ -83,7 +83,10 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Scrolling
                             ? MultiplayerTeam.Blue
                             : MultiplayerTeam.Red;
 
-                        OnlineManager.Client.ChangeOtherPlayerTeam(user.OnlineUser.Id, team);
+                        if (user == OnlineManager.Self)
+                            OnlineManager.Client?.ChangeGameTeam(team);
+                        else
+                            OnlineManager.Client.ChangeOtherPlayerTeam(user.OnlineUser.Id, team);
                         break;
                     case GiveHost:
                         OnlineManager.Client?.TransferMultiplayerGameHost(user.OnlineUser.Id);
@@ -105,7 +108,12 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Scrolling
 
             // Don't add actions meant for other users
             if (OnlineManager.Self?.OnlineUser?.Id == user.OnlineUser.Id)
+            {
+                if (OnlineManager.CurrentGame != null && OnlineManager.CurrentGame.Ruleset == MultiplayerGameRuleset.Team)
+                    options.Add(SwitchTeams, ColorHelper.HexToColor("#F2994A"));
+
                 return options;
+            }
 
             // Friends List
             if (OnlineManager.FriendsList != null && OnlineManager.FriendsList.Contains(user.OnlineUser.Id))

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -248,7 +248,18 @@ namespace Quaver.Shared.Screens.Multi
                 HandleKeyPressF2();
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.Escape))
-                Exit(() => new MultiplayerLobbyScreen());
+            {
+                if (ActiveLeftPanel.Value != SelectContainerPanel.MatchSettings)
+                    ActiveLeftPanel.Value = SelectContainerPanel.MatchSettings;
+                else
+                {
+                    Exit(() => new MultiplayerLobbyScreen());
+                    return;
+                }
+            }
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.Tab) && ActiveLeftPanel.Value == SelectContainerPanel.Leaderboard)
+                SelectionScreen.HandleKeyPressTab();
 
             HandleKeyPressControlInput();
         }

--- a/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayerList.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayerList.cs
@@ -17,6 +17,7 @@ using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
+using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
 
 namespace Quaver.Shared.Screens.Multi.UI.Players
@@ -79,7 +80,8 @@ namespace Quaver.Shared.Screens.Multi.UI.Players
         {
             InputEnabled = GraphicsHelper.RectangleContains(ScreenRectangle, MouseManager.CurrentState.Position)
                            && !KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt)
-                           && !KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt);
+                           && !KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt)
+                           && DialogManager.Dialogs.Count == 0;
 
             base.Update(gameTime);
         }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTable.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTable.cs
@@ -94,18 +94,29 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// </summary>
         private static List<MultiplayerTableItem> GetAvailableItems(Bindable<MultiplayerGame> game, bool isMultiplayer)
         {
-            var items = new List<MultiplayerTableItem>()
+            var items = new List<MultiplayerTableItem>();
+
+            if (!isMultiplayer)
+                items.Add(new MultiplayerTableItemInProgress(game, false));
+
+            items.AddRange(new List<MultiplayerTableItem>()
             {
-                new MultiplayerTableItemInProgress(game, isMultiplayer),
                 new MultiplayerTableItemFreeMod(game, isMultiplayer),
                 new MultiplayerTableItemFreeRate(game, isMultiplayer),
                 new MultiplayerTableItemAutoHostRotation(game, isMultiplayer),
                 new MultiplayerTableItemHealthType(game, isMultiplayer),
+            });
+
+            if (isMultiplayer)
+                items.Add(new MultiplayerTableItemInProgress(game, false));
+
+            items.AddRange(new List<MultiplayerTableItem>()
+            {
                 new MultiplayerTableItemLifeCount(game, isMultiplayer),
                 new MultiplayerTableItemSongLength(game, isMultiplayer),
                 new MultiplayerTableItemDifficultyRange(game, isMultiplayer),
                 new MultiplayerTableItemLongNotePercentageRange(game, isMultiplayer)
-            };
+            });
 
             items.Insert(0, new MultiplayerTableItemPlayers(game, isMultiplayer));
             items.Insert(0, new MultiplayerTableItemRuleset(game, isMultiplayer));

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItem.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItem.cs
@@ -1,10 +1,11 @@
+using System;
 using Quaver.Server.Common.Objects.Multiplayer;
 using Wobble.Bindables;
 using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
 {
-    public abstract class MultiplayerTableItem : IMultiplayerTableItem, IMultiplayerGameComponent
+    public abstract class MultiplayerTableItem : IMultiplayerTableItem, IMultiplayerGameComponent, IDisposable
     {
         /// <inheritdoc />
         /// <summary>
@@ -19,6 +20,15 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// <summary>
         /// </summary>
         public virtual Drawable Selector { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public virtual Action ClickAction { get; protected set; }
+
+        /// <summary>
+        ///     If true, the item will update its content in <see cref="DrawableMultiplayerTableItem"/>
+        /// </summary>
+        public bool NeedsStateUpdate { get; set; }
 
         /// <summary>
         /// </summary>
@@ -53,6 +63,14 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// </summary>
         public void UpdateSelectorState()
         {
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public virtual void Dispose()
+        {
+            Selector?.Dispose();
         }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAutoHostRotation.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemAutoHostRotation.cs
@@ -12,7 +12,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemAutoHostRotation(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
-            Selector = new MultiplayerAutoHostRotationCheckbox(game);
+            var checkbox = new MultiplayerAutoHostRotationCheckbox(game);
+            Selector = checkbox;
+
+            if (OnlineManager.CurrentGame != null)
+                ClickAction = () => checkbox?.FireButtonClickEvent();
         }
 
         public override string GetName() => "Auto Host Rotation";

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemDifficultyRange.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemDifficultyRange.cs
@@ -1,5 +1,7 @@
+using Quaver.Server.Client.Handlers;
 using Quaver.Server.Common.Objects.Multiplayer;
 using Quaver.Shared.Helpers;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
@@ -9,14 +11,34 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemDifficultyRange(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnDifficultyRangeChanged += OnDifficultyRangeChanged;
         }
 
         public override string GetName() => "Difficulty Range";
 
         public override string GetValue()
         {
+            // ReSharper disable twice CompareOfFloatsByEqualityOperator
+            if (SelectedGame.Value.MinimumDifficultyRating == 0 && SelectedGame.Value.MaximumDifficultyRating == 9999)
+                return "Any";
+
             return $"{StringHelper.RatingToString(SelectedGame.Value.MinimumDifficultyRating)} " +
                    $"- {StringHelper.RatingToString(SelectedGame.Value.MaximumDifficultyRating)}";
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnDifficultyRangeChanged(object sender, DifficultyRangeChangedEventArgs e) => NeedsStateUpdate = true;
+
+        public override void Dispose()
+        {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnDifficultyRangeChanged -= OnDifficultyRangeChanged;
+
+            base.Dispose();
         }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeMod.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeMod.cs
@@ -12,7 +12,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemFreeMod(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
-            Selector = new MultiplayerFreeModCheckbox(game);
+            var checkbox  = new MultiplayerFreeModCheckbox(game);
+            Selector = checkbox;
+
+            if (OnlineManager.CurrentGame != null)
+                ClickAction = () => checkbox?.FireButtonClickEvent();
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeRate.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemFreeRate.cs
@@ -12,7 +12,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemFreeRate(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
-            Selector = new MultiplayerFreeRateCheckbox(game);
+            var checkbox = new MultiplayerFreeRateCheckbox(game);
+            Selector = checkbox;
+
+            if (OnlineManager.CurrentGame != null)
+                ClickAction = () => checkbox?.FireButtonClickEvent();
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemHealthType.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemHealthType.cs
@@ -14,7 +14,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemHealthType(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
-            Selector = new MultiplayerHealthTypeCheckbox(game);
+            var checkbox = new MultiplayerHealthTypeCheckbox(game);
+            Selector = checkbox;
+
+            if (OnlineManager.CurrentGame != null)
+                ClickAction = () => checkbox?.FireButtonClickEvent();
         }
 
         public override string GetName() => "Lose A Life Upon Failing";

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemInProgress.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemInProgress.cs
@@ -10,10 +10,41 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemInProgress(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
+            if (OnlineManager.Client != null)
+            {
+                OnlineManager.Client.OnGameStarted += OnGameStarted;
+                OnlineManager.Client.OnGameEnded += OnGameEnded;
+            }
         }
-
+        
         public override string GetName() => "In Progress";
 
         public override string GetValue() => SelectedGame.Value.InProgress ? "Yes" : "No";
+        
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnGameStarted(object sender, GameStartedEventArgs e) => NeedsStateUpdate = true;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnGameEnded(object sender, GameEndedEventArgs e) => NeedsStateUpdate = true;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Dispose()
+        {
+            if (OnlineManager.Client != null)
+            {
+                OnlineManager.Client.OnGameStarted -= OnGameStarted;
+                OnlineManager.Client.OnGameEnded -= OnGameEnded;
+            }
+            
+            base.Dispose();
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLifeCount.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLifeCount.cs
@@ -1,4 +1,6 @@
+using Quaver.Server.Client.Handlers;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
@@ -8,10 +10,22 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemLifeCount(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameLivesChanged += OnLifeCountChanged;
         }
 
         public override string GetName() => "Life Count";
 
         public override string GetValue() => SelectedGame.Value.Lives.ToString();
+
+        private void OnLifeCountChanged(object sender, LivesChangedEventArgs e) => NeedsStateUpdate = true;
+
+        public override void Dispose()
+        {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameLivesChanged -= OnLifeCountChanged;
+
+            base.Dispose();
+        }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLongNotePercentageRange.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemLongNotePercentageRange.cs
@@ -1,4 +1,6 @@
+using Quaver.Server.Client.Handlers;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
@@ -8,13 +10,29 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemLongNotePercentageRange(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameLongNotePercentageChanged += OnLongNotePercentageRangeChanged;
         }
 
         public override string GetName() => "Long Note % Range";
 
         public override string GetValue()
         {
+            if (SelectedGame.Value.MinimumLongNotePercentage == 0 && SelectedGame.Value.MaximumLongNotePercentage == 100)
+                return "Any";
+
             return $"{SelectedGame.Value.MinimumLongNotePercentage}-{SelectedGame.Value.MaximumLongNotePercentage}%";
+        }
+
+        private void OnLongNotePercentageRangeChanged(object sender, LongNotePercentageChangedEventArgs e) =>
+            NeedsStateUpdate = true;
+
+        public override void Dispose()
+        {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnGameLongNotePercentageChanged -= OnLongNotePercentageRangeChanged;
+
+            base.Dispose();
         }
     }
 }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemSongLength.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemSongLength.cs
@@ -1,5 +1,7 @@
 using System;
+using Quaver.Server.Client.Handlers;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Quaver.Shared.Online;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
@@ -9,15 +11,30 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         public MultiplayerTableItemSongLength(Bindable<MultiplayerGame> game, bool isMultiplayer)
             : base(game, isMultiplayer)
         {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnMaxSongLengthChanged += OnSongLengthChanged;
         }
 
         public override string GetName() => "Maximum Song Length";
 
         public override string GetValue()
         {
+            if (SelectedGame.Value.MaximumSongLength == 999999999)
+                return "Any";
+
             var t = TimeSpan.FromSeconds(SelectedGame.Value.MaximumSongLength);
 
             return $"{t.Minutes}:{t.Seconds:00}";
+        }
+
+        private void OnSongLengthChanged(object sender, MaxSongLengthChangedEventArgs e) => NeedsStateUpdate = true;
+
+        public override void Dispose()
+        {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnMaxSongLengthChanged += OnSongLengthChanged;
+
+            base.Dispose();
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -339,7 +339,7 @@ namespace Quaver.Shared.Screens.Selection
         /// <summary>
         ///     Handles when the user presses the tab key
         /// </summary>
-        private void HandleKeyPressTab()
+        public static void HandleKeyPressTab()
         {
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Tab))
                 return;

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
@@ -4,6 +4,7 @@ using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Online;
 using Quaver.Shared.Screens.Menu.UI.Jukebox;
 using Wobble;
 using Wobble.Assets;
@@ -113,7 +114,16 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
                 Tint = ColorHelper.HexToColor("#181818")
             };
 
-            ResetModifiersButton = new IconButton(UserInterface.EditPlayButton, (sender, args) => ModManager.RemoveAllMods())
+            ResetModifiersButton = new IconButton(UserInterface.EditPlayButton, (sender, args) =>
+            {
+                if (OnlineManager.CurrentGame != null &&
+                    (OnlineManager.CurrentGame.HostId != OnlineManager.Self?.OnlineUser?.Id && OnlineManager.CurrentGame.FreeModType == 0))
+                {
+                    return;
+                }
+
+                ModManager.RemoveAllMods();
+            })
             {
                 Parent = ButtonBackground,
                 Alignment = Alignment.MidLeft,


### PR DESCRIPTION
* Fixes multiplayer settings row not being clickable - Fixes #1358 
* Fixes the multiplayer player list being scrollable while dialogs are open
* Adds tab input to change leaderboard sections while the leaderboard is on-screen
* Fixes the player leaving the game when pressing escape while the match settings panel isn't active
* Fixes the reset modifiers button being clickable while the player doesn't have permission to modify them.