### PR TITLE
Implement .05x rates for higher than 1.0x

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -229,15 +229,25 @@ namespace Quaver.Shared.Database.Maps
         public double Difficulty09X { get; set; }
         public double Difficulty095X { get; set; }
         public double Difficulty10X { get; set; }
+        public double Difficulty105X { get; set; }
         public double Difficulty11X { get; set; }
+        public double Difficulty115X { get; set; }
         public double Difficulty12X { get; set; }
+        public double Difficulty125X { get; set; }
         public double Difficulty13X { get; set; }
+        public double Difficulty135X { get; set; }
         public double Difficulty14X { get; set; }
+        public double Difficulty145X { get; set; }
         public double Difficulty15X { get; set; }
+        public double Difficulty155X { get; set; }
         public double Difficulty16X { get; set; }
+        public double Difficulty165X { get; set; }
         public double Difficulty17X { get; set; }
+        public double Difficulty175X { get; set; }
         public double Difficulty18X { get; set; }
+        public double Difficulty185X { get; set; }
         public double Difficulty19X { get; set; }
+        public double Difficulty195X { get; set; }
         public double Difficulty20X { get; set; }
  #endregion
 
@@ -417,15 +427,25 @@ namespace Quaver.Shared.Database.Maps
             Difficulty09X = qua.SolveDifficulty(ModIdentifier.Speed09X).OverallDifficulty;
             Difficulty095X = qua.SolveDifficulty(ModIdentifier.Speed095X).OverallDifficulty;
             Difficulty10X = qua.SolveDifficulty().OverallDifficulty;
+            Difficulty105X = qua.SolveDifficulty(ModIdentifier.Speed105X).OverallDifficulty;
             Difficulty11X = qua.SolveDifficulty(ModIdentifier.Speed11X).OverallDifficulty;
+            Difficulty115X = qua.SolveDifficulty(ModIdentifier.Speed115X).OverallDifficulty;
             Difficulty12X = qua.SolveDifficulty(ModIdentifier.Speed12X).OverallDifficulty;
+            Difficulty125X = qua.SolveDifficulty(ModIdentifier.Speed125X).OverallDifficulty;
             Difficulty13X = qua.SolveDifficulty(ModIdentifier.Speed13X).OverallDifficulty;
+            Difficulty135X = qua.SolveDifficulty(ModIdentifier.Speed135X).OverallDifficulty;
             Difficulty14X = qua.SolveDifficulty(ModIdentifier.Speed14X).OverallDifficulty;
+            Difficulty145X = qua.SolveDifficulty(ModIdentifier.Speed145X).OverallDifficulty;
             Difficulty15X = qua.SolveDifficulty(ModIdentifier.Speed15X).OverallDifficulty;
+            Difficulty155X = qua.SolveDifficulty(ModIdentifier.Speed155X).OverallDifficulty;
             Difficulty16X = qua.SolveDifficulty(ModIdentifier.Speed16X).OverallDifficulty;
+            Difficulty165X = qua.SolveDifficulty(ModIdentifier.Speed165X).OverallDifficulty;
             Difficulty17X = qua.SolveDifficulty(ModIdentifier.Speed17X).OverallDifficulty;
+            Difficulty175X = qua.SolveDifficulty(ModIdentifier.Speed175X).OverallDifficulty;
             Difficulty18X = qua.SolveDifficulty(ModIdentifier.Speed18X).OverallDifficulty;
+            Difficulty185X = qua.SolveDifficulty(ModIdentifier.Speed185X).OverallDifficulty;
             Difficulty19X = qua.SolveDifficulty(ModIdentifier.Speed19X).OverallDifficulty;
+            Difficulty195X = qua.SolveDifficulty(ModIdentifier.Speed195X).OverallDifficulty;
             Difficulty20X = qua.SolveDifficulty(ModIdentifier.Speed20X).OverallDifficulty;
         }
 
@@ -455,24 +475,44 @@ namespace Quaver.Shared.Database.Maps
                 return Difficulty09X;
             if (mods.HasFlag(ModIdentifier.Speed095X))
                 return Difficulty095X;
+            if (mods.HasFlag(ModIdentifier.Speed105X))
+                return Difficulty105X;
             if (mods.HasFlag(ModIdentifier.Speed11X))
                 return Difficulty11X;
+            if (mods.HasFlag(ModIdentifier.Speed115X))
+                return Difficulty115X;
             if (mods.HasFlag(ModIdentifier.Speed12X))
                 return Difficulty12X;
+            if (mods.HasFlag(ModIdentifier.Speed125X))
+                return Difficulty125X;
             if (mods.HasFlag(ModIdentifier.Speed13X))
                 return Difficulty13X;
+            if (mods.HasFlag(ModIdentifier.Speed135X))
+                return Difficulty135X;
             if (mods.HasFlag(ModIdentifier.Speed14X))
                 return Difficulty14X;
+            if (mods.HasFlag(ModIdentifier.Speed145X))
+                return Difficulty145X;
             if (mods.HasFlag(ModIdentifier.Speed15X))
                 return Difficulty15X;
+            if (mods.HasFlag(ModIdentifier.Speed155X))
+                return Difficulty155X;
             if (mods.HasFlag(ModIdentifier.Speed16X))
                 return Difficulty16X;
+            if (mods.HasFlag(ModIdentifier.Speed165X))
+                return Difficulty165X;
             if (mods.HasFlag(ModIdentifier.Speed17X))
                 return Difficulty17X;
+            if (mods.HasFlag(ModIdentifier.Speed175X))
+                return Difficulty175X;
             if (mods.HasFlag(ModIdentifier.Speed18X))
                 return Difficulty18X;
+            if (mods.HasFlag(ModIdentifier.Speed185X))
+                return Difficulty185X;
             if (mods.HasFlag(ModIdentifier.Speed19X))
                 return Difficulty19X;
+            if (mods.HasFlag(ModIdentifier.Speed195X))
+                return Difficulty195X;
             if (mods.HasFlag(ModIdentifier.Speed20X))
                 return Difficulty20X;
 

--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -250,6 +250,23 @@ namespace Quaver.Shared.Database.Maps
             var mapsets = MapsetHelper.ConvertMapsToMapsets(maps);
             MapManager.Mapsets = MapsetHelper.OrderMapsByDifficulty(MapsetHelper.OrderMapsetsByArtist(mapsets));
             MapManager.RecentlyPlayed = new List<Map>();
+
+            // Schedule maps that don't have difficulty ratings to recalculate.
+            // If forcing a full recalculation due to diff calc updates, then the difficulty processor version should just be bumped
+            // instead of adding things here.
+            foreach (var mapset in MapManager.Mapsets)
+            {
+                foreach (var map in mapset.Maps)
+                {
+                    // The difficulty calculator only calculates for maps with >= 2 hitobjects
+                    if (map.RegularNoteCount + map.LongNoteCount >= 2)
+                    {
+                        // ReSharper disable once CompareOfFloatsByEqualityOperator
+                        if (map.Difficulty105X == 0f)
+                            OtherGameMapDatabaseCache.MapsToCache[OtherGameCacheAction.Update].Add(map);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Modifiers/IGameplayModifier.cs
+++ b/Quaver.Shared/Modifiers/IGameplayModifier.cs
@@ -35,7 +35,7 @@ namespace Quaver.Shared.Modifiers
         /// <summary>
         ///     Is the gameplayModifier ranked?
         /// </summary>
-        bool Ranked { get; set; }
+        bool Ranked();
 
         /// <summary>
         ///     Is the modifier allowed in multiplayer?

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -73,15 +73,25 @@ namespace Quaver.Shared.Modifiers
                 case ModIdentifier.Speed085X:
                 case ModIdentifier.Speed09X:
                 case ModIdentifier.Speed095X:
+                case ModIdentifier.Speed105X:
                 case ModIdentifier.Speed11X:
+                case ModIdentifier.Speed115X:
                 case ModIdentifier.Speed12X:
+                case ModIdentifier.Speed125X:
                 case ModIdentifier.Speed13X:
+                case ModIdentifier.Speed135X:
                 case ModIdentifier.Speed14X:
+                case ModIdentifier.Speed145X:
                 case ModIdentifier.Speed15X:
+                case ModIdentifier.Speed155X:
                 case ModIdentifier.Speed16X:
+                case ModIdentifier.Speed165X:
                 case ModIdentifier.Speed17X:
+                case ModIdentifier.Speed175X:
                 case ModIdentifier.Speed18X:
+                case ModIdentifier.Speed185X:
                 case ModIdentifier.Speed19X:
+                case ModIdentifier.Speed195X:
                 case ModIdentifier.Speed20X:
                     gameplayModifier = new ModSpeed(modIdentifier);
                     break;

--- a/Quaver.Shared/Modifiers/Mods/ModAutoplay.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModAutoplay.cs
@@ -21,7 +21,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Take a break, and watch something magical.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = false;
 

--- a/Quaver.Shared/Modifiers/Mods/ModChill.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModChill.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Make it easier on yourself.";
 
-        public bool Ranked { get; set; } = true;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModCoop.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModCoop.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Grab a friend, and play together. You do have friends... right?";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = false;
 

--- a/Quaver.Shared/Modifiers/Mods/ModFullLN.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModFullLN.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "So I heard you like long notes.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModInverse.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModInverse.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Converts regular notes into long notes and long notes into gaps.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModJudgementWindows.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModJudgementWindows.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Fully customize the timing windows.";
 
-        public bool Ranked { get; set; } = true;
+        public bool Ranked() => true;
 
         public bool AllowedInMultiplayer { get; set; }
 

--- a/Quaver.Shared/Modifiers/Mods/ModMirror.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModMirror.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Flips the map horizontally.";
 
-        public bool Ranked { get; set; } = true;
+        public bool Ranked() => true;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModNoFail.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModNoFail.cs
@@ -21,9 +21,10 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Failure is not an option.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
+
         public bool OnlyMultiplayerHostCanCanChange { get; set; }
 
         public ModIdentifier[] IncompatibleMods { get; set; } =

--- a/Quaver.Shared/Modifiers/Mods/ModNoLongNotes.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModNoLongNotes.cs
@@ -21,7 +21,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "I have a variety of taste preferences, but noodles aren't included.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModNoSliderVelocities.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModNoSliderVelocities.cs
@@ -21,7 +21,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Hate scroll speed changes? Say no more.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModPaused.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModPaused.cs
@@ -20,7 +20,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Player paused in gameplay";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Modifiers/Mods/ModRandomize.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModRandomize.cs
@@ -32,7 +32,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Swap up the lanes.";
 
-        public bool Ranked { get; set; } = false;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = false;
 

--- a/Quaver.Shared/Modifiers/Mods/ModSpeed.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModSpeed.cs
@@ -29,7 +29,12 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "Change the audio playback rate of the song.";
 
-        public bool Ranked { get; set; } = true;
+        /// <summary>
+        ///     Speeds that are 0.05x above 1.0x are defined after 0.95x.
+        ///     Temporarily leave this unranked.
+        /// </summary>
+        /// <returns></returns>
+        public bool Ranked() => ModIdentifier <= ModIdentifier.Speed095X;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 
@@ -47,15 +52,25 @@ namespace Quaver.Shared.Modifiers.Mods
             ModIdentifier.Speed085X,
             ModIdentifier.Speed09X,
             ModIdentifier.Speed095X,
+            ModIdentifier.Speed105X,
             ModIdentifier.Speed11X,
+            ModIdentifier.Speed115X,
             ModIdentifier.Speed12X,
+            ModIdentifier.Speed125X,
             ModIdentifier.Speed13X,
+            ModIdentifier.Speed135X,
             ModIdentifier.Speed14X,
+            ModIdentifier.Speed145X,
             ModIdentifier.Speed15X,
+            ModIdentifier.Speed155X,
             ModIdentifier.Speed16X,
+            ModIdentifier.Speed165X,
             ModIdentifier.Speed17X,
+            ModIdentifier.Speed175X,
             ModIdentifier.Speed18X,
+            ModIdentifier.Speed185X,
             ModIdentifier.Speed19X,
+            ModIdentifier.Speed195X,
             ModIdentifier.Speed20X,
         };
 

--- a/Quaver.Shared/Modifiers/Mods/ModStrict.cs
+++ b/Quaver.Shared/Modifiers/Mods/ModStrict.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Modifiers.Mods
 
         public string Description { get; set; } = "You'll need to be super accurate.";
 
-        public bool Ranked { get; set; } = true;
+        public bool Ranked() => false;
 
         public bool AllowedInMultiplayer { get; set; } = true;
 

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -46,6 +46,8 @@ namespace Quaver.Shared.Screens.Main
 #if  !VISUAL_TESTS
             SetDiscordRichPresence();
 #endif
+            ModManager.RemoveSpeedMods();
+
             View = new MainMenuScreenView(this);
         }
 

--- a/Quaver.Shared/Screens/Result/ResultScreen.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreen.cs
@@ -380,6 +380,13 @@ namespace Quaver.Shared.Screens.Result
             if (OnlineManager.Status.Value == ConnectionStatus.Disconnected)
                 return;
 
+            // Don't submit scores that have unranked modifiers
+            if (ModManager.CurrentModifiersList.Any(x => !x.Ranked()))
+            {
+                Logger.Important($"Skipping score submission due to having unranked modifiers activated", LogType.Runtime);
+                return;
+            }
+
             if (Gameplay.IsMultiplayerGame)
             {
                 if (!Gameplay.IsPlayComplete)

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifier.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifier.cs
@@ -108,7 +108,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers
         /// <param name="dialog"></param>
         /// <param name="modifier"></param>
         public DrawableModifier(ModifiersDialog dialog, IGameplayModifier modifier)
-            : this(dialog, modifier.Name, modifier.Description, modifier.Ranked)
+            : this(dialog, modifier.Name, modifier.Description, modifier.Ranked())
         {
         }
 

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifierModList.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifierModList.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers
         private string DefaultDescription { get; }
 
         public DrawableModifierModList(ModifiersDialog dialog, IGameplayModifier[] modifiers, string name, string defaultDescription)
-            : base(dialog, name, defaultDescription, modifiers.All(x => x.Ranked))
+            : base(dialog, name, defaultDescription, modifiers.All(x => x.Ranked()))
         {
             Modifiers = modifiers;
             DefaultDescription = defaultDescription;

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -361,13 +361,16 @@ namespace Quaver.Shared.Screens.Selection
                 !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
                 return;
 
+            var shiftHeld = KeyboardManager.CurrentState.IsKeyUp(Keys.LeftShift) ||
+                            KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift);
+
             // Increase rate.
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemPlus) || KeyboardManager.IsUniqueKeyPress(Keys.Add))
-                ModManager.AddSpeedMods(GetNextRate(true));
+                ModManager.AddSpeedMods(GetNextRate(true, !shiftHeld));
 
             // Decrease Rate
             if (KeyboardManager.IsUniqueKeyPress(Keys.OemMinus) || KeyboardManager.IsUniqueKeyPress(Keys.Subtract))
-                ModManager.AddSpeedMods(GetNextRate(false));
+                ModManager.AddSpeedMods(GetNextRate(false, !shiftHeld));
 
             // Change from pitched to non-pitched
             if (KeyboardManager.IsUniqueKeyPress(Keys.D0))
@@ -431,14 +434,15 @@ namespace Quaver.Shared.Screens.Selection
         ///     depending on the argument.
         /// </summary>
         /// <param name="faster">If true, returns the higher rate, otherwise the lower rate.</param>
+        /// <param name="forceHalfRate"></param>
         /// <returns></returns>
-        public static float GetNextRate(bool faster)
+        public static float GetNextRate(bool faster, bool forceHalfRate = false)
         {
             var current = ModHelper.GetRateFromMods(ModManager.Mods);
             var adjustment = 0.1f;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (current < 1.0f || (current == 1.0f && !faster))
+            if (current < 1.0f || OnlineManager.CurrentGame == null && forceHalfRate)
                 adjustment = 0.05f;
 
             var next = current + adjustment * (faster ? 1f : -1f);

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
@@ -26,6 +26,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (mods == ModIdentifier.None)
                     mods = 0;
 
+                // .05x rates not supported for ranked play yet
+                if (mods >= ModIdentifier.Speed105X)
+                    return new FetchedScoreStore(new List<Score>());
+
                 var onlineScores = OnlineManager.Client?.RetrieveOnlineScores(map.MapId, map.Md5Checksum, ModIdentifier.None,
                     false, mods);
 


### PR DESCRIPTION
**Note: Needs new mod icons**  

* Adds .05x rate support for speeds higher than 1.0x.
* Currently unavailable for ranked plays and use in multiplayer to preserve compatibility and fairness with players on the older clients.
* Schedules a recalculation for all maps with outdated or non-existing difficulty ratings.