### PR TITLE
Handle alt enter input to toggle fullscreen

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -532,6 +532,7 @@ namespace Quaver.Shared
             HandleKeyPressF7();
             HandleKeyPressCtrlO();
             HandleKeyPressCtrlS();
+            HandleKeyPressAltEnter();
         }
 
         /// <summary>
@@ -624,6 +625,21 @@ namespace Quaver.Shared
                     SkinManager.TimeSkinReloadRequested = GameBase.Game.TimeRunning;
                     break;
             }
+        }
+
+        /// <summary>
+        ///    Handles when the user holds either Alt (ALT) button and presses Enter
+        /// </summary>
+        private void HandleKeyPressAltEnter()
+        {
+            // Check for modifier keys
+            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt)))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.Enter))
+                return;
+
+            Graphics.ToggleFullScreen();
         }
 
         /// <summary>

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -633,13 +633,13 @@ namespace Quaver.Shared
         private void HandleKeyPressAltEnter()
         {
             // Check for modifier keys
-            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt)))
+            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt) && !KeyboardManager.CurrentState.IsKeyDown(Keys.RightAlt))
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Enter))
                 return;
 
-            Graphics.ToggleFullScreen();
+            ConfigManager.WindowFullScreen.Value = !ConfigManager.WindowFullScreen.Value;
         }
 
         /// <summary>


### PR DESCRIPTION
Issue [Quaver/Quaver#865](https://github.com/Quaver/Quaver/issues/865)

## Summary
- Add global input handler when holding either Alt (ALT) and presses enter to toggle fullscreen / windowed