### PR TITLE
Make arrow skins easier to create

### DIFF
--- a/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonDownloadMaps.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonDownloadMaps.cs
@@ -12,7 +12,7 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components.Buttons
     public class IconTextButtonDownloadMaps : IconTextButton
     {
         public IconTextButtonDownloadMaps() : base(FontAwesome.Get(FontAwesomeIcon.fa_download_to_storage_drive),
-            FontManager.GetWobbleFont(Fonts.LatoBlack),"Download Maps", (sender, args) =>
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Maps", (sender, args) =>
             {
                 if (!OnlineManager.Connected)
                 {

--- a/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonMusicPlayer.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/Buttons/IconTextButtonMusicPlayer.cs
@@ -13,7 +13,7 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components.Buttons
     public class IconTextButtonMusicPlayer : IconTextButton
     {
         public IconTextButtonMusicPlayer() : base(FontAwesome.Get(FontAwesomeIcon.fa_music_note_black_symbol),
-            FontManager.GetWobbleFont(Fonts.LatoBlack),"Music Player", (sender, args) =>
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Jukebox", (sender, args) =>
             {
                 var game = (QuaverGame) GameBase.Game;
                 game.CurrentScreen.Exit(() => new MusicPlayerScreen());

--- a/Quaver.Shared/Graphics/Menu/Border/Components/DrawableSessionTime.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/DrawableSessionTime.cs
@@ -31,7 +31,7 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components
         /// <inheritdoc />
         /// <summary>
         /// </summary>
-        public int CustomPaddingX { get; } = 25;
+        public int CustomPaddingX { get; } = 34;
 
         /// <summary>
         ///     The time that the game has been running for

--- a/Quaver.Shared/Graphics/Menu/Border/Components/Users/DrawableLoggedInUser.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/Components/Users/DrawableLoggedInUser.cs
@@ -42,7 +42,7 @@ namespace Quaver.Shared.Graphics.Menu.Border.Components.Users
         /// <inheritdoc />
         /// <summary>
         /// </summary>
-        public int CustomPaddingX { get; } = 20;
+        public int CustomPaddingX { get; } = 30;
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
@@ -10,8 +10,11 @@ using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
+using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
+using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 
@@ -69,6 +72,11 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling.HitObjects
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
+            if (!ConfigManager.EditorViewLayers.Value && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].UseAndRotateHitObjectSheet)
+                Rotation = GameplayHitObjectKeys.GetObjectRotation(MapManager.Selected.Value.Mode, Info.Lane - 1);
+            else
+                Rotation = 0;
+
             DrawToSpriteBatch();
 
             if (SelectionSprite.Visible)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -153,6 +153,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 SpriteEffect = flipNoteBody ? SpriteEffects.FlipVertically : SpriteEffects.None
             };
 
+            // Handle rotating the objects automatically
+            if (SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].UseAndRotateHitObjectSheet)
+                HitObjectSprite.Rotation = GetObjectRotation(MapManager.Selected.Value.Mode, lane);
+
             // Create Hold Body
             var bodies = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldBodies[lane];
             LongNoteBodySprite = new AnimatableSprite(bodies)
@@ -387,5 +391,54 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     It will only be initiated when the player releases the note.
         /// </summary>
         public void StopLongNoteAnimation() => LongNoteBodySprite.StopLoop();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="mode"></param>
+        /// <param name="lane"></param>
+        /// <returns></returns>
+        public static float GetObjectRotation(GameMode mode, int lane)
+        {
+            switch (mode)
+            {
+                case GameMode.Keys4:
+                    switch (lane)
+                    {
+                        case 0:
+                            return  90;
+                        case 1:
+                            // Already downwards
+                            break;
+                        case 2:
+                            return 180;
+                        case 3:
+                            return 270;
+                    }
+                    break;
+                case GameMode.Keys7:
+                    switch (lane)
+                    {
+                        case 0:
+                            return 90;
+                        case 1:
+                            return 135;
+                        case 2:
+                            return 180;
+                        case 3:
+                            // Already downwards
+                            break;
+                        case 4:
+                            return 180;
+                        case 5:
+                            return 225;
+                        case 6:
+                            return 270;
+                    }
+
+                    break;
+            }
+
+            return 0;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
@@ -9,7 +9,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Borders.Footer
     {
         public IconTextButtonMapPreview(Bindable<SelectContainerPanel> activeLeftPanel)
             : base(FontAwesome.Get(FontAwesomeIcon.fa_eye_open), FontManager.GetWobbleFont(Fonts.LatoBlack),
-                "Preview Map", (sender, args) =>
+                "View Map", (sender, args) =>
                 {
                     if (activeLeftPanel == null)
                         return;

--- a/Quaver.Shared/Screens/Selection/UI/Borders/Footer/SelectMenuFooter.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Borders/Footer/SelectMenuFooter.cs
@@ -16,14 +16,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Borders.Footer
             new IconTextButtonOptions(),
             new IconTextButtonModifiers(screen.ActiveLeftPanel),
             new IconTextButtonMapPreview(screen.ActiveLeftPanel),
-            new IconTextButtonCreatePlaylist()
         }, new List<Drawable>
         {
             new IconTextButtonPlay(screen),
             new IconTextButtonEdit(screen),
-            new IconTextButtonExport(screen),
             new IconTextButtonRandom(screen),
-            new IconTextButtonOnlineListing()
+            new IconTextButtonCreatePlaylist()
         })
         {
         }

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/FilterPanelMapsAvailable.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/FilterPanelMapsAvailable.cs
@@ -67,7 +67,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
         /// </summary>
         private void CreateTextCount()
         {
-            TextCount = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0", 22)
+            TextCount = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0", 21)
             {
                 Parent = this,
                 Tint = Colors.MainAccent
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
         /// </summary>
         private void CreateTextMapsFound()
         {
-            TextMapsFound = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "Maps Found", 22)
+            TextMapsFound = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "Maps Found", 21)
             {
                 Parent = this,
                 X = TextCount.Width + TextSpacing

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/Search/FilterPanelSearchBox.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/Search/FilterPanelSearchBox.cs
@@ -56,7 +56,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.Search
         /// <param name="placeHolderText"></param>
         public FilterPanelSearchBox(Bindable<string> currentSearchQuery, Bindable<List<Mapset>> availableMapsets,
             Bindable<bool> isPlayTesting, string placeHolderText)
-            : base(new ScalableVector2(370, 40), FontManager.GetWobbleFont(Fonts.LatoBlack),22, PreviousSearchTerm, placeHolderText)
+            : base(new ScalableVector2(280, 40), FontManager.GetWobbleFont(Fonts.LatoBlack),22, PreviousSearchTerm, placeHolderText)
         {
             CurrentSearchQuery = currentSearchQuery;
             AvailableMapsets = availableMapsets;
@@ -95,7 +95,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.Search
             {
                 Parent = this,
                 Alignment = Alignment.MidRight,
-                Size = new ScalableVector2(20, 20),
+                Size = new ScalableVector2(16, 16),
                 X = -10,
                 Image = FontAwesome.Get(FontAwesomeIcon.fa_magnifying_glass)
             };

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/SelectFilterPanel.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/SelectFilterPanel.cs
@@ -240,7 +240,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel
                 item.Alignment = Alignment.MidRight;
 
                 const int padding = 25;
-                var spacing = 25;
+                var spacing = 30;
 
                 if (i == 0)
                     item.X = -padding;

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -221,6 +221,8 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float HealthBarPosOffsetY { get; private set; }
 
+        internal bool UseAndRotateHitObjectSheet { get; private set; }
+
         #endregion
 
 #region TEXTURES
@@ -461,6 +463,7 @@ namespace Quaver.Shared.Skinning
             BattleRoyaleEliminatedPosY = ConfigHelper.ReadInt32((int) BattleRoyaleEliminatedPosY, ini["BattleRoyaleEliminatedPosY"]);
             HealthBarPosOffsetX = ConfigHelper.ReadInt32((int) HealthBarPosOffsetX, ini["HealthBarPosOffsetX"]);
             HealthBarPosOffsetY = ConfigHelper.ReadInt32((int) HealthBarPosOffsetY, ini["HealthBarPosOffsetY"]);
+            UseAndRotateHitObjectSheet = ConfigHelper.ReadBool(UseAndRotateHitObjectSheet, ini["UseAndRotateHitObjectSheet"]);
         }
 
         /// <summary>
@@ -615,8 +618,18 @@ namespace Quaver.Shared.Skinning
                     ColumnColors[i] = ConfigHelper.ReadColor(ColumnColors[i], Store.Config[ModeHelper.ToShortHand(Mode).ToUpper()][$"ColumnColor{i + 1}"]);
 
                 // HitObjects
-                LoadHitObjects(NoteHitObjects, $"note-hitobject-{i + 1}", i);
-                LoadHitObjects(NoteHoldHitObjects, $"note-holdhitobject-{i + 1}", i);
+                if (!UseAndRotateHitObjectSheet)
+                {
+                    LoadHitObjects(NoteHitObjects, $"note-hitobject-{i + 1}", i);
+                    LoadHitObjects(NoteHoldHitObjects, $"note-holdhitobject-{i + 1}", i);
+                }
+                else
+                {
+                    var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, 8, 1);
+
+                    NoteHitObjects.Add(objects);
+                    NoteHoldHitObjects.Add(objects);
+                }
 
                 // LNS
                 NoteHoldBodies.Add(LoadSpritesheet(SkinKeysFolder.HitObjects, $"note-holdbody-{i + 1}", false, 0, 0));


### PR DESCRIPTION
Adds a `UseRotateHitObjectSheet` property to skin.ini config which will look for a spritesheet at path: `/HitObjects/note-hitobject-sheet@8x1.png`. 

Doing so will automatically reuse the textures for each lane and rotate the objects - making arrow skin creation easier/more consistent with other games

[Eaxmple Skin](https://drive.google.com/file/d/1APiN3002LH-IIsaGGvFpCFhDjyK0ZoNW/view?usp=sharing)

Closes #335