### PR TITLE
Add versioning system to other-game map sync

### DIFF
--- a/Quaver.Shared/Database/Maps/OtherGameMap.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMap.cs
@@ -1,4 +1,6 @@
-﻿namespace Quaver.Shared.Database.Maps
+﻿using SQLite;
+
+namespace Quaver.Shared.Database.Maps
 {
     public class OtherGameMap : Map
     {
@@ -6,5 +8,16 @@
         ///     The game that the map comes from
         /// </summary>
         public OtherGameMapDatabaseGame OriginalGame { get; set; }
+
+        /// <summary>
+        ///     Versioning system for syncing. Used to resync maps if things like parsing updates happen
+        /// </summary>
+        public int SyncVersion { get; set; }
+
+        [Ignore]
+        public static int OsuSyncVersion { get; set; } = 0;
+
+        [Ignore]
+        public static int EtternaSyncVersion { get; set; } = 1;
     }
 }

--- a/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
@@ -393,8 +393,14 @@ namespace Quaver.Shared.Database.Maps
                                 conn.Insert(map);
                                 break;
                             case MapGame.Osu:
+                                var osuMap = (OtherGameMap) map;
+                                osuMap.SyncVersion = OtherGameMap.OsuSyncVersion;
+                                conn.Insert(osuMap);
+                                break;
                             case MapGame.Etterna:
-                                conn.Insert((OtherGameMap) map);
+                                var etternaChart = (OtherGameMap) map;
+                                etternaChart.SyncVersion = OtherGameMap.EtternaSyncVersion;
+                                conn.Insert(etternaChart);
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException();
@@ -452,8 +458,14 @@ namespace Quaver.Shared.Database.Maps
                                 conn.Update(map);
                                 break;
                             case MapGame.Osu:
+                                var osuMap = (OtherGameMap) map;
+                                osuMap.SyncVersion = OtherGameMap.OsuSyncVersion;
+                                conn.Update(osuMap);
+                                break;
                             case MapGame.Etterna:
-                                conn.Update((OtherGameMap) map);
+                                var etternaChart = (OtherGameMap) map;
+                                etternaChart.SyncVersion = OtherGameMap.EtternaSyncVersion;
+                                conn.Update(etternaChart);
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException();

--- a/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
@@ -226,20 +226,25 @@ namespace Quaver.Shared.Database.Maps
 
             currentlyCached.ForEach(x =>
             {
-                if (x.DifficultyProcessorVersion != DifficultyProcessorKeys.Version && !MapsToCache[OtherGameCacheAction.Add].Contains(x))
-                    MapsToCache[OtherGameCacheAction.Update].Add(x);
+                var diffOutdated = x.DifficultyProcessorVersion != DifficultyProcessorKeys.Version;
+                var versionOutdated = false;
 
                 switch (x.OriginalGame)
                 {
                     case OtherGameMapDatabaseGame.Osu:
                         x.Game = MapGame.Osu;
+                        versionOutdated = OtherGameMap.OsuSyncVersion != x.SyncVersion;
                         break;
                     case OtherGameMapDatabaseGame.Etterna:
                         x.Game = MapGame.Etterna;
+                        versionOutdated = OtherGameMap.EtternaSyncVersion != x.SyncVersion;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+
+                if ((diffOutdated || versionOutdated) && !MapsToCache[OtherGameCacheAction.Add].Contains(x))
+                    MapsToCache[OtherGameCacheAction.Update].Add(x);
             });
 
             return currentlyCached;

--- a/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
@@ -121,7 +121,7 @@ namespace Quaver.Shared.Database.Maps
                 DeleteMaps(DatabaseManager.Connection);
 
                 if (SyncMapCount == 0)
-                    NotificationManager.Show(NotificationLevel.Success, "Successfully completed difficulty rating calculations!");
+                    NotificationManager.Show(NotificationLevel.Success, "Successfully completed syncing outdated maps!");
             })
             {
                 IsBackground = true,


### PR DESCRIPTION
Used to recalculate/update synced metadata when the .qua output changes - such as parsing or conversion updates