### PR TITLE
Hit display for replays

### DIFF
--- a/Quaver.Shared/Graphics/Form/Checkboxes/Checkbox.cs
+++ b/Quaver.Shared/Graphics/Form/Checkboxes/Checkbox.cs
@@ -1,0 +1,87 @@
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Graphics.Form.Checkboxes
+{
+    public class Checkbox : Container
+    {
+        /// <summary>
+        /// </summary>
+        public ImageButton Button { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public SpriteTextPlus Name { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public Sprite Sprite { get; set; }
+
+        /// <summary>
+        ///     Creates a new checkbox.
+        /// </summary>
+        /// <param name="size"></param>
+        public Checkbox(ScalableVector2 size)
+        {
+            Size = size;
+
+            CreateButton();
+            CreateName();
+            CreateCheckbox();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Button.Alpha = Button.IsHovered ? 0.35f : 0;
+
+            base.Update(gameTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateButton()
+        {
+            Button = new CheckboxItemButton(UserInterface.BlankBox, this)
+            {
+                Parent = this,
+                Size = Size,
+                Alpha = 0,
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateName()
+        {
+            Name = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 21)
+            {
+                Parent = this,
+                Alignment = Alignment.MidLeft,
+                X = 14
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateCheckbox()
+        {
+            Sprite = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidRight,
+                X = -Name.X,
+                Size = new ScalableVector2(Height * 0.40f, Height * 0.40f),
+                Image = FontAwesome.Get(FontAwesomeIcon.fa_check_sign_in_a_rounded_black_square)
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Graphics/Form/Checkboxes/CheckboxContainer.cs
+++ b/Quaver.Shared/Graphics/Form/Checkboxes/CheckboxContainer.cs
@@ -80,7 +80,10 @@ namespace Quaver.Shared.Graphics.Form.Checkboxes
             foreach (var item in Pool)
             {
                 if (item is CheckboxContainerItem i)
-                    i.Button.Visible = false;
+                {
+                    i.Checkbox.Visible = false;
+                    i.Checkbox.Button.Visible = false;
+                }
             }
         }
 

--- a/Quaver.Shared/Graphics/Form/Checkboxes/CheckboxContainerItem.cs
+++ b/Quaver.Shared/Graphics/Form/Checkboxes/CheckboxContainerItem.cs
@@ -2,10 +2,6 @@ using Microsoft.Xna.Framework;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Containers;
 using Wobble.Graphics;
-using Wobble.Graphics.Sprites;
-using Wobble.Graphics.Sprites.Text;
-using Wobble.Graphics.UI.Buttons;
-using Wobble.Managers;
 
 namespace Quaver.Shared.Graphics.Form.Checkboxes
 {
@@ -17,16 +13,9 @@ namespace Quaver.Shared.Graphics.Form.Checkboxes
         public override int HEIGHT { get; } = 50;
 
         /// <summary>
+        ///     The checkbox itself.
         /// </summary>
-        public ImageButton Button { get; private set; }
-
-        /// <summary>
-        /// </summary>
-        private SpriteTextPlus Name { get; set; }
-
-        /// <summary>
-        /// </summary>
-        private Sprite Checkbox { get; set; }
+        public Checkbox Checkbox { get; set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -40,8 +29,6 @@ namespace Quaver.Shared.Graphics.Form.Checkboxes
             Size = new ScalableVector2(container.Width, HEIGHT);
             Alpha = 0;
 
-            CreateButton();
-            CreateName();
             CreateCheckbox();
 
             Item.IsSelected = Item.GetSelectedState();
@@ -53,7 +40,7 @@ namespace Quaver.Shared.Graphics.Form.Checkboxes
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            Button.Alpha = Button.IsHovered ? 0.35f : 0;
+            Checkbox.Update(gameTime);
 
             base.Update(gameTime);
         }
@@ -70,53 +57,25 @@ namespace Quaver.Shared.Graphics.Form.Checkboxes
 
             ScheduleUpdate(() =>
             {
-                Name.Text = item.GetName();
-                Checkbox.Image = FontAwesome.Get(Item.IsSelected ? FontAwesomeIcon.fa_check : FontAwesomeIcon.fa_check_box_empty);
+                Checkbox.Name.Text = item.GetName();
+                Checkbox.Sprite.Image = FontAwesome.Get(Item.IsSelected ? FontAwesomeIcon.fa_check : FontAwesomeIcon.fa_check_box_empty);
             });
-        }
-
-        /// <summary>
-        /// </summary>
-        private void CreateButton()
-        {
-            Button = new CheckboxItemButton(UserInterface.BlankBox, Container)
-            {
-                Parent = this,
-                Size = Size,
-                Alpha = 0,
-            };
-
-            Button.Clicked += (sender, args) =>
-            {
-                Item.IsSelected = !Item.IsSelected;
-                Item.OnToggle();
-                UpdateContent(Item, Index);
-            };
-        }
-
-        /// <summary>
-        /// </summary>
-        private void CreateName()
-        {
-            Name = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 21)
-            {
-                Parent = this,
-                Alignment = Alignment.MidLeft,
-                X = 14
-            };
         }
 
         /// <summary>
         /// </summary>
         private void CreateCheckbox()
         {
-            Checkbox = new Sprite()
+            Checkbox = new Checkbox(Size)
             {
                 Parent = this,
-                Alignment = Alignment.MidRight,
-                X = -Name.X,
-                Size = new ScalableVector2(Height * 0.40f, Height * 0.40f),
-                Image = FontAwesome.Get(FontAwesomeIcon.fa_check_sign_in_a_rounded_black_square)
+            };
+
+            Checkbox.Button.Clicked += (sender, args) =>
+            {
+                Item.IsSelected = !Item.IsSelected;
+                Item.OnToggle();
+                UpdateContent(Item, Index);
             };
         }
     }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -544,7 +544,8 @@ namespace Quaver.Shared.Screens.Gameplay
             HandlePlayRestart(dt);
 
             // Everything after this point is applicable to gameplay ONLY.
-            if (IsPaused || Failed)
+            // But we can change the scroll speed while paused in replay mode.
+            if ((IsPaused && !InReplayMode) || Failed)
                 return;
 
             if (!IsPlayComplete && !IsCalibratingOffset || IsMultiplayerGame || IsSongSelectPreview)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -328,7 +328,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
         private void ChangeScrollSpeed()
         {
             // Only allow scroll speed changes if the map hasn't started or if we're on a break
-            if (Ruleset.Screen.IsSongSelectPreview || Ruleset.Screen.Timing.Time >= 5000 && !Ruleset.Screen.EligibleToSkip && !(Ruleset.Screen is TournamentGameplayScreen))
+            if (Ruleset.Screen.IsSongSelectPreview || Ruleset.Screen.Timing.Time >= 5000 && !Ruleset.Screen.EligibleToSkip && !(Ruleset.Screen is TournamentGameplayScreen) && !Ruleset.Screen.InReplayMode)
                 return;
 
             // Decrease

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -5,17 +5,14 @@
  * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
 */
 
-using System;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring.Data;
 using Quaver.API.Maps.Structures;
-using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
-using Quaver.Shared.Graphics;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits;
@@ -90,17 +87,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <summary>
         ///     The actual HitObject sprite.
         /// </summary>
-        private Sprite HitObjectSprite { get; set; }
+        public Sprite HitObjectSprite { get; set; }
 
         /// <summary>
         ///     The hold body sprite for long notes.
         /// </summary>
-        private AnimatableSprite LongNoteBodySprite { get; set; }
+        public AnimatableSprite LongNoteBodySprite { get; set; }
 
         /// <summary>
         ///     The hold end sprite for long notes.
         /// </summary>
-        private Sprite LongNoteEndSprite { get; set; }
+        public Sprite LongNoteEndSprite { get; set; }
 
         /// <summary>
         ///     General Position for hitting. Calculated from Hit Body Height and Hit Position Offset
@@ -114,6 +111,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     difference takes those two half-heights into account.
         /// </summary>
         private float LongNoteSizeDifference { get; }
+
+        /// <summary>
+        ///     Base tint of the sprites.
+        ///
+        ///     Used for tint animation.
+        /// </summary>
+        public Color Tint { get; set; }
 
         /// <summary>
         ///     The hit representing the press of this object.
@@ -214,10 +218,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             HitPosition = info.IsLongNote ? playfield.HoldHitPositionY[info.Lane - 1] : playfield.HitPositionY[info.Lane - 1];
             Info = info;
 
+            Tint = Color.White;
+            var tint = Tint * (HitObjectManager.ShowHits ? HitObjectManagerKeys.SHOW_HITS_NOTE_ALPHA : 1);
+            tint.A = 255;
+
             // Update Hit Object State
             HitObjectSprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode);
             HitObjectSprite.Visible = true;
-            HitObjectSprite.Tint = Color.White;
+            HitObjectSprite.Tint = tint;
             InitialTrackPosition = manager.GetPositionFromTime(Info.StartTime);
             CurrentlyBeingHeld = false;
             StopLongNoteAnimation();
@@ -235,8 +243,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             }
             else
             {
-                LongNoteBodySprite.Tint = Color.White;
-                LongNoteEndSprite.Tint = Color.White;
+                LongNoteBodySprite.Tint = tint;
+                LongNoteEndSprite.Tint = tint;
                 LongNoteEndSprite.Visible = SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd;
                 LongNoteBodySprite.Visible = true;
                 InitialLongNoteTrackPosition = manager.GetPositionFromTime(Info.EndTime);
@@ -410,12 +418,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public void Kill()
         {
-            var deadNoteColor = SkinManager.Skin.Keys[Ruleset.Mode].DeadNoteColor;
-            HitObjectSprite.Tint = deadNoteColor;
+            Tint = SkinManager.Skin.Keys[Ruleset.Mode].DeadNoteColor;
+            var tint = Tint * (HitObjectManager.ShowHits ? HitObjectManagerKeys.SHOW_HITS_NOTE_ALPHA : 1);
+            tint.A = 255;
+            HitObjectSprite.Tint = tint;
             if (Info.IsLongNote)
             {
-                LongNoteBodySprite.Tint = deadNoteColor;
-                LongNoteEndSprite.Tint = deadNoteColor;
+                LongNoteBodySprite.Tint = tint;
+                LongNoteEndSprite.Tint = tint;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -87,17 +87,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <summary>
         ///     The actual HitObject sprite.
         /// </summary>
-        public Sprite HitObjectSprite { get; set; }
+        public Sprite HitObjectSprite { get; private set; }
 
         /// <summary>
         ///     The hold body sprite for long notes.
         /// </summary>
-        public AnimatableSprite LongNoteBodySprite { get; set; }
+        public AnimatableSprite LongNoteBodySprite { get; private set; }
 
         /// <summary>
         ///     The hold end sprite for long notes.
         /// </summary>
-        public Sprite LongNoteEndSprite { get; set; }
+        public Sprite LongNoteEndSprite { get; private set; }
 
         /// <summary>
         ///     General Position for hitting. Calculated from Hit Body Height and Hit Position Offset
@@ -117,17 +117,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///
         ///     Used for tint animation.
         /// </summary>
-        public Color Tint { get; set; }
+        public Color Tint { get; private set; }
 
         /// <summary>
         ///     The hit representing the press of this object.
         /// </summary>
-        private Hit PressHit { get; set; }
+        private DrawableReplayHit PressHit { get; set; }
 
         /// <summary>
         ///     The hit representing the release of this object.
         /// </summary>
-        private Hit ReleaseHit { get; set; }
+        private DrawableReplayHit ReleaseHit { get; set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -142,7 +142,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             var lane = info.Lane - 1;
             var playfield = (GameplayPlayfieldKeys)ruleset.Playfield;
+
             LongNoteSizeDifference = playfield.LongNoteSizeAdjustment[lane];
+
             InitializeSprites(ruleset, lane, playfield.ScrollDirections[lane]);
             InitializeObject(manager, info);
         }
@@ -203,8 +205,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             HitObjectSprite.Parent = playfield.Stage.HitObjectContainer;
 
             // Hits go above the hit object.
-            PressHit = new Hit(Ruleset, HitObjectManager, lane);
-            ReleaseHit = new Hit(Ruleset, HitObjectManager, lane);
+            PressHit = new DrawableReplayHit(Ruleset, HitObjectManager, lane);
+            ReleaseHit = new DrawableReplayHit(Ruleset, HitObjectManager, lane);
         }
 
         /// <summary>
@@ -273,10 +275,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 return;
 
             var hitStats = HitObjectManager.HitStats[Info];
+
             foreach (var hitStat in hitStats)
             {
-                if (hitStat.KeyPressType == KeyPressType.Release
-                    || (hitStat.KeyPressType == KeyPressType.None && hitStat.Judgement == Judgement.Okay))
+                if (hitStat.KeyPressType == KeyPressType.Release ||
+                    hitStat.KeyPressType == KeyPressType.None && hitStat.Judgement == Judgement.Okay)
                 {
                     ReleaseHit.InitializeWithHitStat(hitStat);
                     ReleaseHit.Visible = true;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using MoreLinq;
 using Quaver.API.Enums;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Processors.Scoring.Data;
@@ -23,6 +24,8 @@ using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
 using Quaver.Shared.Screens.Selection;
 using Wobble;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 {
@@ -142,6 +145,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public Dictionary<HitObjectInfo, List<HitStat>> HitStats { get; private set; }
 
+        /// <summary>
+        ///     Note alpha when showing hits.
+        /// </summary>
+        public const float SHOW_HITS_NOTE_ALPHA = 0.3f;
+
         private bool _showHits = false;
         /// <summary>
         ///     Whether hits are currently shown.
@@ -155,6 +163,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     return;
 
                 _showHits = value;
+
+                foreach (GameplayHitObjectKeys hitObject in ActiveNoteLanes.Concat(DeadNoteLanes).Concat(HeldLongNoteLanes).Flatten())
+                {
+                    var tint = hitObject.Tint * (_showHits ? 1 : SHOW_HITS_NOTE_ALPHA);
+                    var newTint = hitObject.Tint * (_showHits ? SHOW_HITS_NOTE_ALPHA : 1);
+
+                    hitObject.HitObjectSprite.Tint = tint;
+                    hitObject.HitObjectSprite.ClearAnimations();
+                    hitObject.HitObjectSprite.FadeToColor(newTint, Easing.OutQuad, 250);
+                    hitObject.LongNoteBodySprite.Tint = tint;
+                    hitObject.LongNoteBodySprite.ClearAnimations();
+                    hitObject.LongNoteBodySprite.FadeToColor(newTint, Easing.OutQuad, 250);
+                    hitObject.LongNoteEndSprite.Tint = tint;
+                    hitObject.LongNoteEndSprite.ClearAnimations();
+                    hitObject.LongNoteEndSprite.FadeToColor(newTint, Easing.OutQuad, 250);
+                }
 
                 ((GameplayPlayfieldKeys) Ruleset.Playfield).Stage.HitContainer.Children.ForEach(x =>
                 {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -64,7 +64,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <summary>
         ///     Reference to the ruleset this HitObject manager is for.
         /// </summary>
-        public GameplayRulesetKeys Ruleset { get; private set; }
+        public GameplayRulesetKeys Ruleset { get; }
 
         /// <summary>
         ///     Hit Object info used for object pool and gameplay
@@ -150,10 +150,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public const float SHOW_HITS_NOTE_ALPHA = 0.3f;
 
-        private bool _showHits = false;
         /// <summary>
         ///     Whether hits are currently shown.
         /// </summary>
+        private bool _showHits = false;
         public bool ShowHits
         {
             get => _showHits;
@@ -180,20 +180,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     hitObject.LongNoteEndSprite.FadeToColor(newTint, Easing.OutQuad, 250);
                 }
 
-                ((GameplayPlayfieldKeys) Ruleset.Playfield).Stage.HitContainer.Children.ForEach(x =>
+                var playfield = (GameplayPlayfieldKeys) Ruleset.Playfield;
+
+                playfield.Stage.HitContainer.Children.ForEach(x =>
                 {
-                    if (x is Sprite sprite)
+                    if (!(x is Sprite sprite))
+                        return;
+
+                    if (_showHits)
                     {
-                        if (_showHits)
-                        {
-                            sprite.Alpha = 0;
-                            sprite.FadeTo(1, Easing.OutQuad, 250);
-                        }
-                        else
-                        {
-                            sprite.Alpha = 1;
-                            sprite.FadeTo(0, Easing.OutQuad, 250);
-                        }
+                        sprite.Alpha = 0;
+                        sprite.FadeTo(1, Easing.OutQuad, 250);
+                    }
+                    else
+                    {
+                        sprite.Alpha = 1;
+                        sprite.FadeTo(0, Easing.OutQuad, 250);
                     }
                 });
             }
@@ -316,10 +318,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 return;
 
             var inputManager = ((KeysInputManager) Ruleset.InputManager).ReplayInputManager;
+
             if (inputManager == null)
                 return;
 
             HitStats = new Dictionary<HitObjectInfo, List<HitStat>>();
+
             foreach (var hitStat in inputManager.VirtualPlayer.ScoreProcessor.Stats)
             {
                 if (!HitStats.ContainsKey(hitStat.HitObject))

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -53,6 +53,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         public Container TimingLineContainer { get; private set; }
 
         /// <summary>
+        ///     The container that holds all hits.
+        /// </summary>
+        public Container HitContainer { get; private set; }
+
+        /// <summary>
         ///     The left side of the stage.
         /// </summary>
         public Sprite StageLeft { get; private set; }
@@ -168,6 +173,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             {
                 CreateTimingLineContainer();
                 CreateHitObjectContainer();
+                CreateHitContainer();
                 CreateReceptorsAndLighting();
                 CreateHitPositionOverlay();
             }
@@ -177,6 +183,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 CreateHitPositionOverlay();
                 CreateTimingLineContainer();
                 CreateHitObjectContainer();
+                CreateHitContainer();
             }
 
             CreateDistantOverlay();
@@ -386,6 +393,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         ///     Creates the TimingLineContainer
         /// </summary>
         private void CreateTimingLineContainer() => TimingLineContainer = new Container
+        {
+            Size = new ScalableVector2(Playfield.Width, 0, 0, 1),
+            Alignment = Alignment.TopCenter,
+            Parent = Playfield.ForegroundContainer
+        };
+
+        /// <summary>
+        ///     Creates the HitContainer
+        /// </summary>
+        private void CreateHitContainer() => HitContainer = new Container
         {
             Size = new ScalableVector2(Playfield.Width, 0, 0, 1),
             Alignment = Alignment.TopCenter,

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/DrawableReplayHit.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/DrawableReplayHit.cs
@@ -77,13 +77,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
         /// <summary>
         ///     Computes the hit position and the perfect hit position.
         /// </summary>
-        /// <param name="hitStat"></param>
         private void ComputePositions()
         {
+            if (HitStat == null)
+                return;
+            
             var hitStat = HitStat.Value;
             var info = hitStat.HitObject;
-            if (hitStat.KeyPressType == KeyPressType.Release
-                || (hitStat.KeyPressType == KeyPressType.None && hitStat.Judgement == Judgement.Okay))
+            
+            if (hitStat.KeyPressType == KeyPressType.Release || 
+                hitStat.KeyPressType == KeyPressType.None && hitStat.Judgement == Judgement.Okay)
             {
                 PerfectPosition = Manager.GetPositionFromTime(info.EndTime);
 
@@ -112,10 +115,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
             JudgeColors = SkinManager.Skin.Keys[ruleset.Mode].JudgeColors;
 
             var playfield = (GameplayPlayfieldKeys) ruleset.Playfield;
+            
             ScrollDirection = playfield.ScrollDirections[lane];
             LineHitPosition = playfield.TimingLinePositionY[lane];
 
             var laneX = playfield.Stage.Receptors[lane].X;
+            
             LineToPerfect = new Sprite
             {
                 Alignment = Alignment.TopLeft,
@@ -125,6 +130,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
                 Visible = false,
                 Parent = playfield.Stage.HitContainer,
             };
+            
             Indicator = new Sprite
             {
                 Alignment = Alignment.TopLeft,
@@ -195,12 +201,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
 
             var indicatorPosition = GetIndicatorPosition(offset);
             var perfectPosition = GetPerfectPosition(offset);
+            
             Indicator.Y = indicatorPosition;
             LineToPerfect.Height = Math.Abs(perfectPosition - indicatorPosition);
-            if (indicatorPosition < perfectPosition)
-                LineToPerfect.Y = indicatorPosition;
-            else
-                LineToPerfect.Y = perfectPosition;
+            
+            LineToPerfect.Y = indicatorPosition < perfectPosition ? indicatorPosition : perfectPosition;
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/DrawableReplayHit.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/DrawableReplayHit.cs
@@ -18,7 +18,7 @@ using Wobble.Graphics.Sprites;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
 {
-    public class Hit
+    public class DrawableReplayHit
     {
         /// <summary>
         ///     The hit stat for this hit.
@@ -106,7 +106,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
         /// <summary>
         ///     Creates a Hit and its sprites.
         /// </summary>
-        public Hit(GameplayRulesetKeys ruleset, HitObjectManagerKeys manager, int lane)
+        public DrawableReplayHit(GameplayRulesetKeys ruleset, HitObjectManagerKeys manager, int lane)
         {
             Manager = manager;
             JudgeColors = SkinManager.Skin.Keys[ruleset.Mode].JudgeColors;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/Hit.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Hits/Hit.cs
@@ -1,0 +1,206 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
+*/
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.API.Enums;
+using Quaver.API.Maps.Processors.Scoring.Data;
+using Quaver.Shared.Config;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
+using Quaver.Shared.Skinning;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Hits
+{
+    public class Hit
+    {
+        /// <summary>
+        ///     The hit stat for this hit.
+        /// </summary>
+        private HitStat? HitStat { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private HitObjectManagerKeys Manager { get; }
+
+        /// <summary>
+        /// </summary>
+        private IDictionary<Judgement, Color> JudgeColors { get; }
+
+        /// <summary>
+        /// </summary>
+        private ScrollDirection ScrollDirection { get; }
+
+        /// <summary>
+        ///     Position for hitting without taking hit object height into account.
+        ///     Use this to compute positions of line indicators (height = 1), such as the press and release position.
+        /// </summary>
+        private float LineHitPosition { get; }
+
+        /// <summary>
+        ///     The indicator line itself.
+        /// </summary>
+        private Sprite Indicator { get; }
+
+        /// <summary>
+        ///     Vertical line from the indicator to the perfect position.
+        /// </summary>
+        private Sprite LineToPerfect { get; }
+
+        /// <summary>
+        ///     The actual hit position.
+        /// </summary>
+        private long Position { get; set; }
+
+        /// <summary>
+        ///     Perfect position for this hit.
+        /// </summary>
+        private long PerfectPosition { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public bool Visible
+        {
+            set
+            {
+                Indicator.Visible = value;
+                LineToPerfect.Visible = value;
+            }
+        }
+
+        /// <summary>
+        ///     Computes the hit position and the perfect hit position.
+        /// </summary>
+        /// <param name="hitStat"></param>
+        private void ComputePositions()
+        {
+            var hitStat = HitStat.Value;
+            var info = hitStat.HitObject;
+            if (hitStat.KeyPressType == KeyPressType.Release
+                || (hitStat.KeyPressType == KeyPressType.None && hitStat.Judgement == Judgement.Okay))
+            {
+                PerfectPosition = Manager.GetPositionFromTime(info.EndTime);
+
+                if (hitStat.KeyPressType == KeyPressType.None)
+                    Position = PerfectPosition;
+                else
+                    Position = Manager.GetPositionFromTime(info.EndTime - hitStat.HitDifference);
+            }
+            else
+            {
+                PerfectPosition = Manager.GetPositionFromTime(info.StartTime);
+
+                if (hitStat.KeyPressType == KeyPressType.None)
+                    Position = PerfectPosition;
+                else
+                    Position = Manager.GetPositionFromTime(info.StartTime - hitStat.HitDifference);
+            }
+        }
+
+        /// <summary>
+        ///     Creates a Hit and its sprites.
+        /// </summary>
+        public Hit(GameplayRulesetKeys ruleset, HitObjectManagerKeys manager, int lane)
+        {
+            Manager = manager;
+            JudgeColors = SkinManager.Skin.Keys[ruleset.Mode].JudgeColors;
+
+            var playfield = (GameplayPlayfieldKeys) ruleset.Playfield;
+            ScrollDirection = playfield.ScrollDirections[lane];
+            LineHitPosition = playfield.TimingLinePositionY[lane];
+
+            var laneX = playfield.Stage.Receptors[lane].X;
+            LineToPerfect = new Sprite
+            {
+                Alignment = Alignment.TopLeft,
+                Position = new ScalableVector2(laneX + 0.5f * playfield.LaneSize, 0),
+                Size = new ScalableVector2(2, 0),
+                Alpha = Manager.ShowHits ? 1 : 0,
+                Visible = false,
+                Parent = playfield.Stage.HitContainer,
+            };
+            Indicator = new Sprite
+            {
+                Alignment = Alignment.TopLeft,
+                Position = new ScalableVector2(laneX + 0.125f * playfield.LaneSize, 0),
+                Size = new ScalableVector2(playfield.LaneSize * 0.75f, 2),
+                Alpha = Manager.ShowHits ? 1 : 0,
+                Visible = false,
+                Parent = playfield.Stage.HitContainer,
+            };
+        }
+
+        /// <summary>
+        ///     Destroys the sprites.
+        /// </summary>
+        public void Destroy()
+        {
+            Indicator.Destroy();
+            LineToPerfect.Destroy();
+        }
+
+        /// <summary>
+        ///     Initializes the object with a new hit stat.
+        /// </summary>
+        /// <param name="hitStat"></param>
+        public void InitializeWithHitStat(HitStat hitStat)
+        {
+            HitStat = hitStat;
+
+            ComputePositions();
+
+            var tint = JudgeColors[hitStat.Judgement];
+            LineToPerfect.Tint = tint;
+            Indicator.Tint = tint;
+        }
+
+        /// <summary>
+        ///     Calculates the screen position offset from the initial track position and current track offset.
+        /// </summary>
+        /// <param name="initial"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+        private float GetPosition(long initial, long offset) =>
+            (initial - offset) *
+            (ScrollDirection.Equals(ScrollDirection.Down)
+                ? -HitObjectManagerKeys.ScrollSpeed
+                : HitObjectManagerKeys.ScrollSpeed) / HitObjectManagerKeys.TrackRounding;
+
+        /// <summary>
+        ///     Calculates the position of the indicator with a position offset.
+        /// </summary>
+        /// <returns></returns>
+        private float GetIndicatorPosition(long offset) => LineHitPosition + GetPosition(Position, offset);
+
+        /// <summary>
+        ///     Calculates the position of the perfect hit with a position offset.
+        /// </summary>
+        /// <returns></returns>
+        private float GetPerfectPosition(long offset) => LineHitPosition + GetPosition(PerfectPosition, offset);
+
+        /// <summary>
+        ///     Updates the sprite positions.
+        /// </summary>
+        /// <param name="offset"></param>
+        public void UpdateSpritePositions(long offset)
+        {
+            if (HitStat == null)
+                return;
+
+            var indicatorPosition = GetIndicatorPosition(offset);
+            var perfectPosition = GetPerfectPosition(offset);
+            Indicator.Y = indicatorPosition;
+            LineToPerfect.Height = Math.Abs(perfectPosition - indicatorPosition);
+            if (indicatorPosition < perfectPosition)
+                LineToPerfect.Y = indicatorPosition;
+            else
+                LineToPerfect.Y = perfectPosition;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -91,7 +91,15 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
 
         /// <summary>
         /// </summary>
+        private const int PANEL_PADDING = 14;
+
+        /// <summary>
+        /// </summary>
         private ReplayControllerSpeed SpeedSlider { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private ReplayControllerShowHits ShowHits { get; set; }
 
         /// <summary>
         /// </summary>
@@ -114,6 +122,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
             //CreateToggleSvButton();
             CreateHidePrompt();
             CreateSpeedSlider();
+            CreateShowHitsButton();
         }
 
         /// <inheritdoc />
@@ -364,10 +373,23 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
             SpeedSlider = new ReplayControllerSpeed(Screen, new ScalableVector2(264, 38))
             {
                 Parent = this,
-                Y = -14
+                Y = -PANEL_PADDING
             };
 
             SpeedSlider.Y -= SpeedSlider.Height;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateShowHitsButton()
+        {
+            ShowHits = new ReplayControllerShowHits(Screen, new ScalableVector2(264, 38))
+            {
+                Parent = this,
+                Y = SpeedSlider.Y - PANEL_PADDING,
+            };
+
+            ShowHits.Y -= ShowHits.Height;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayControllerShowHits.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayControllerShowHits.cs
@@ -1,0 +1,45 @@
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Form.Checkboxes;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Gameplay.UI.Replays
+{
+    public class ReplayControllerShowHits : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        private HitObjectManagerKeys Manager { get; }
+
+        /// <summary>
+        /// </summary>
+        private Checkbox Checkbox { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        /// <param name="size"></param>
+        public ReplayControllerShowHits(GameplayScreen screen, ScalableVector2 size)
+        {
+            Manager = (HitObjectManagerKeys) screen.Ruleset.HitObjectManager;
+
+            Image = UserInterface.ReplayControllerSpeedPanel;
+            Size = size;
+
+            Checkbox = new Checkbox(Size)
+            {
+                Parent = this,
+                Alignment = Alignment.MidLeft,
+                Name = {Text = "Show Hits"},
+                Sprite = {Image = FontAwesome.Get(FontAwesomeIcon.fa_check_box_empty)},
+            };
+
+            Checkbox.Button.Clicked += (sender, args) =>
+            {
+                Manager.ShowHits = !Manager.ShowHits;
+                Checkbox.Sprite.Image = FontAwesome.Get(Manager.ShowHits ? FontAwesomeIcon.fa_check : FontAwesomeIcon.fa_check_box_empty);
+            };
+        }
+    }
+}


### PR DESCRIPTION
cc #453

The hit positions are based on the timing line positions, which means that they look perfect on bars, but on (at least the default) arrows and circles they are aligned to the bottom of the hit objects, whereas you could argue that the expected would be to the center. This should really be solved by changing the timing line base and not by hardcoding something into the hit display (see #1546 for my idea on how to do that).