### PR TITLE
Add new editor screen setup + visual test

### DIFF
--- a/Quaver.Shared/Graphics/PausePlayButton.cs
+++ b/Quaver.Shared/Graphics/PausePlayButton.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Screens.Menu.UI.Jukebox;
+using Wobble.Audio.Tracks;
 
 namespace Quaver.Shared.Graphics
 {
@@ -15,20 +16,27 @@ namespace Quaver.Shared.Graphics
 
         private Texture2D PlayButton { get; }
 
-        public PausePlayButton(Texture2D pauseButton = null, Texture2D playButton = null) : base(pauseButton ?? FontAwesome.Get(FontAwesomeIcon.fa_pause_symbol))
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        public PausePlayButton(Texture2D pauseButton = null, Texture2D playButton = null, IAudioTrack track = null)
+            : base(pauseButton ?? FontAwesome.Get(FontAwesomeIcon.fa_pause_symbol))
         {
+            Track = track ?? AudioEngine.Track;
+
             PauseButton = pauseButton ?? FontAwesome.Get(FontAwesomeIcon.fa_pause_symbol);
             PlayButton = playButton ?? FontAwesome.Get(FontAwesomeIcon.fa_play_button);
 
             Clicked += (sender, args) =>
             {
-                if (AudioEngine.Track == null)
+                if (Track == null || Track.IsDisposed)
                     return;
 
-                if (AudioEngine.Track.IsPlaying)
-                    AudioEngine.Track.Pause();
-                else if (AudioEngine.Track.IsPaused)
-                    AudioEngine.Track.Play();
+                if (Track.IsPlaying)
+                    Track.Pause();
+                else
+                    Track.Play();
             };
         }
 
@@ -38,16 +46,16 @@ namespace Quaver.Shared.Graphics
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            if (AudioEngine.Track != null)
+            if (Track != null)
             {
-                if (AudioEngine.Track.IsPlaying)
+                if (Track.IsPlaying)
                 {
                     var pause = PauseButton;
 
                     if (Image != pause)
                         Image = pause;
                 }
-                else if (AudioEngine.Track.IsStopped || AudioEngine.Track.IsPaused)
+                else if (Track.IsStopped || Track.IsPaused)
                 {
                     var play = PlayButton;
 

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -42,6 +42,7 @@ using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Alpha;
 using Quaver.Shared.Screens.Downloading;
+using Quaver.Shared.Screens.Edit;
 using Quaver.Shared.Screens.Main;
 using Quaver.Shared.Screens.Menu;
 using Quaver.Shared.Screens.Menu.UI.Navigation.User;
@@ -64,6 +65,7 @@ using Quaver.Shared.Screens.Tests.DrawableMapsets;
 using Quaver.Shared.Screens.Tests.DrawableMapsetsMultiple;
 using Quaver.Shared.Screens.Tests.DrawablePlaylists;
 using Quaver.Shared.Screens.Tests.Dropdowns;
+using Quaver.Shared.Screens.Tests.Editor;
 using Quaver.Shared.Screens.Tests.FilterPanel;
 using Quaver.Shared.Screens.Tests.Jukebox;
 using Quaver.Shared.Screens.Tests.Leaderboards;
@@ -188,6 +190,7 @@ namespace Quaver.Shared
         /// </summary>
         private Dictionary<string, Type> VisualTests { get; } = new Dictionary<string, Type>()
         {
+            {"Editor", typeof(TestEditorScreen)},
             {"LuaImGui", typeof(TestLuaScriptingScreen)},
             {"LocalProfileContainer", typeof(TestUserProfileContainerScreen)},
             {"DifficultyGraph", typeof(TestDifficultyGraphScreen)},

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1,0 +1,350 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Maps;
+using Quaver.Server.Common.Enums;
+using Quaver.Server.Common.Objects;
+using Quaver.Shared.Audio;
+using Quaver.Shared.Config;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
+using Quaver.Shared.Skinning;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Edit
+{
+    public sealed class EditScreen : QuaverScreen
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override QuaverScreenType Type { get; } = QuaverScreenType.Editor;
+
+        /// <summary>
+        ///     A copy of the original and unedited map
+        /// </summary>
+        public Qua OriginalMap { get; }
+
+        /// <summary>
+        ///     The map that is being worked on by the user
+        /// </summary>
+        public Qua WorkingMap { get; }
+
+        /// <summary>
+        ///     The uneditable map that is currently being viewed. Usually used for
+        ///     viewing multiple difficulties at a time.
+        /// </summary>
+        public Bindable<Qua> UneditableMap { get; }
+
+        /// <summary>
+        ///     The AudioTrack to be used during this edit session
+        /// </summary>
+        public IAudioTrack Track { get; private set; }
+
+        /// <summary>
+        ///     The cvrrently active skin
+        /// </summary>
+        public Bindable<SkinStore> Skin { get; private set; }
+
+        /// <summary>
+        ///     The index of the hitobjects in which hitsounds are being played
+        /// </summary>
+        private int HitsoundObjectIndex { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public BindableInt BeatSnap { get; } = new BindableInt(4, 1, 16);
+
+        /// <summary>
+        ///     All of the available beat snaps to use in the editor.
+        /// </summary>
+        public List<int> AvailableBeatSnaps { get; } = new List<int> {1, 2, 3, 4, 6, 8, 12, 16};
+
+        /// <summary>
+        /// </summary>
+        private int BeatSnapIndex => AvailableBeatSnaps.FindIndex(x => x == BeatSnap.Value);
+
+        /// <summary>
+        /// </summary>
+        public BindableInt PlayfieldScrollSpeed { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public Bindable<bool> AnchorHitObjectsAtMidpoint { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public EditScreen(Qua map, IAudioTrack track = null)
+        {
+            OriginalMap = map;
+            WorkingMap = ObjectHelper.DeepClone(OriginalMap);
+
+            SetAudioTrack(track);
+            LoadSkin();
+            InitializePlayfieldScrollSpeed();
+            InitializeHitObjectMidpointAnchoring();
+            SetHitSoundObjectIndex();
+            UneditableMap = new Bindable<Qua>(null);
+
+            View = new EditScreenView(this);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            if (!Exiting)
+            {
+                HandleInput();
+                PlayHitsounds();
+            }
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            Track.Seeked -= OnTrackSeeked;
+            Track?.Dispose();
+            Skin?.Value?.Dispose();
+            Skin?.Dispose();
+            UneditableMap?.Dispose();
+            BeatSnap?.Dispose();
+
+            if (PlayfieldScrollSpeed != ConfigManager.EditorScrollSpeedKeys)
+                PlayfieldScrollSpeed.Dispose();
+
+            if (AnchorHitObjectsAtMidpoint != ConfigManager.EditorHitObjectsMidpointAnchored)
+                AnchorHitObjectsAtMidpoint.Dispose();
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="track"></param>
+        private void SetAudioTrack(IAudioTrack track)
+        {
+            if (track == null)
+            {
+                AudioEngine.LoadCurrentTrack();
+                Track = AudioEngine.Track;
+            }
+            else
+                Track = track;
+
+            Track.Seeked += OnTrackSeeked;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void LoadSkin()
+        {
+            Skin = new Bindable<SkinStore>(SkinManager.Skin) { Value = SkinManager.Skin };
+
+            if (Skin.Value != null)
+                return;
+
+            Skin.Value = new SkinStore();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void InitializePlayfieldScrollSpeed()
+            => PlayfieldScrollSpeed = ConfigManager.EditorScrollSpeedKeys ?? new BindableInt(20, 1, 40);
+
+        /// <summary>
+        /// </summary>
+        private void InitializeHitObjectMidpointAnchoring()
+        {
+            AnchorHitObjectsAtMidpoint = ConfigManager.EditorHitObjectsMidpointAnchored ?? new Bindable<bool>(true)
+            {
+                Value = true
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleInput()
+        {
+            if (DialogManager.Dialogs.Count != 0)
+                return;
+
+            HandleKeyPressSpace();
+            HandleKeyPressPageUp();
+            HandleKeyPressPageDown();
+
+            // To not conflict with the volume controller
+            if (KeyboardManager.CurrentState.IsKeyUp(Keys.LeftAlt) && KeyboardManager.CurrentState.IsKeyUp(Keys.RightAlt) &&
+                KeyboardManager.CurrentState.IsKeyUp(Keys.LeftControl) && KeyboardManager.CurrentState.IsKeyUp(Keys.Right))
+            {
+                HandleSeekingBackwards();
+                HandleSeekingForwards();
+            }
+
+            HandleBeatSnapChanges();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleKeyPressSpace()
+        {
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.Space))
+                return;
+
+            if (Track == null || Track.IsDisposed)
+                return;
+
+            if (Track.IsPlaying)
+                Track.Pause();
+            else
+            {
+                var wasStopped = Track.IsStopped;
+
+                Track.Play();
+
+                if (wasStopped)
+                    SetHitSoundObjectIndex();
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleSeekingBackwards()
+        {
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.Left)
+                && MouseManager.CurrentState.ScrollWheelValue <= MouseManager.PreviousState.ScrollWheelValue)
+                return;
+
+            if (Track == null || Track.IsDisposed)
+                return;
+
+            var time = AudioEngine.GetNearestSnapTimeFromTime(WorkingMap, Direction.Backward, BeatSnap.Value, Track.Time);
+
+            if (time < 0)
+                return;
+
+            Track.Seek(time);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleSeekingForwards()
+        {
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.Right)
+                && MouseManager.CurrentState.ScrollWheelValue >= MouseManager.PreviousState.ScrollWheelValue)
+                return;
+
+            if (Track == null || Track.IsDisposed)
+                return;
+
+            var time = AudioEngine.GetNearestSnapTimeFromTime(WorkingMap, Direction.Forward, BeatSnap.Value, Track.Time);
+
+            if (time > Track.Length)
+                return;
+
+            Track.Seek(time);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleBeatSnapChanges()
+        {
+            if (KeyboardManager.CurrentState.IsKeyUp(Keys.LeftControl) && KeyboardManager.CurrentState.IsKeyUp(Keys.Right))
+                return;
+
+            if (MouseManager.CurrentState.ScrollWheelValue > MouseManager.PreviousState.ScrollWheelValue || KeyboardManager.IsUniqueKeyPress(Keys.Up))
+                ChangeBeatSnap(Direction.Forward);
+
+            if (MouseManager.CurrentState.ScrollWheelValue < MouseManager.PreviousState.ScrollWheelValue || KeyboardManager.IsUniqueKeyPress(Keys.Down))
+                ChangeBeatSnap(Direction.Backward);
+        }
+
+        /// <summary>
+        ///     Sets the hitsounds object index, so we know which object to play sounds for.
+        ///     This is generally used when seeking through the map.
+        /// </summary>
+        private void SetHitSoundObjectIndex()
+        {
+            HitsoundObjectIndex = WorkingMap.HitObjects.FindLastIndex(x => x.StartTime <= Track.Time);
+            HitsoundObjectIndex++;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void PlayHitsounds()
+        {
+            for (var i = HitsoundObjectIndex; i < WorkingMap.HitObjects.Count; i++)
+            {
+                var obj = WorkingMap.HitObjects[i];
+
+                if (Track.Time >= obj.StartTime)
+                {
+                    HitObjectManager.PlayObjectHitSounds(obj, Skin.Value);
+                    HitsoundObjectIndex = i + 1;
+                }
+                else
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="direction"></param>
+        public void ChangeBeatSnap(Direction direction)
+        {
+            var index = BeatSnapIndex;
+
+            switch (direction)
+            {
+                case Direction.Forward:
+                    BeatSnap.Value = index + 1 < AvailableBeatSnaps.Count ? AvailableBeatSnaps[index + 1] : AvailableBeatSnaps.First();
+                    break;
+                case Direction.Backward:
+                    BeatSnap.Value = index - 1 >= 0 ? AvailableBeatSnaps[index - 1] : AvailableBeatSnaps.Last();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleKeyPressPageUp()
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.PageUp))
+                PlayfieldScrollSpeed.Value++;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleKeyPressPageDown()
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.PageDown))
+                PlayfieldScrollSpeed.Value--;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnTrackSeeked(object sender, TrackSeekedEventArgs e) => SetHitSoundObjectIndex();
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public override UserClientStatus GetClientStatus() => null;
+    }
+}

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -1,0 +1,144 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Maps;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Edit.UI.Footer;
+using Quaver.Shared.Screens.Edit.UI.Playfield;
+using Wobble;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.UI;
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Edit
+{
+    public class EditScreenView : ScreenView
+    {
+        /// <summary>
+        /// </summary>
+        private EditScreen EditScreen => (EditScreen) Screen;
+
+        /// <summary>
+        /// </summary>
+        private BackgroundImage Background { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private EditorPlayfield Playfield { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private EditorPlayfield UnEditablePlayfield { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private EditorFooter Footer { get; set; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public EditScreenView(Screen screen) : base(screen)
+        {
+            CreateBackground();
+            CreatePlayfield();
+            CreateFooter();
+
+            EditScreen.UneditableMap.ValueChanged += OnUneditableMapChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime) => Container?.Update(gameTime);
+
+        /// <inheritdoc />
+        ///  <summary>
+        ///  </summary>
+        ///  <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            GameBase.Game.GraphicsDevice.Clear(ColorHelper.HexToColor("#2F2F2F"));
+            Container?.Draw(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            Container?.Destroy();
+
+            // ReSharper disable twice DelegateSubtraction
+            EditScreen.UneditableMap.ValueChanged -= OnUneditableMapChanged;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateBackground()
+        {
+            Background = new BackgroundImage(UserInterface.Triangles, 0, false)
+            {
+                Parent = Container
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreatePlayfield() => Playfield = new EditorPlayfield(EditScreen.WorkingMap, EditScreen.Skin,
+            EditScreen.Track, EditScreen.BeatSnap, EditScreen.PlayfieldScrollSpeed, EditScreen.AnchorHitObjectsAtMidpoint) { Parent = Container};
+
+        /// <summary>
+        ///
+        /// </summary>
+        private void CreateFooter() => Footer = new EditorFooter(EditScreen.Track)
+        {
+            Parent = Container,
+            Alignment = Alignment.BotLeft
+        };
+
+        /// <summary>
+        /// </summary>
+        private void CreateOtherDifficultyPlayfield()
+        {
+            UnEditablePlayfield = new EditorPlayfield(EditScreen.UneditableMap.Value, EditScreen.Skin, EditScreen.Track,
+                EditScreen.BeatSnap, EditScreen.PlayfieldScrollSpeed, EditScreen.AnchorHitObjectsAtMidpoint, true)
+            {
+                Parent = Container,
+            };
+
+            // Reset the parent of the footer, so it draws over this playfield.
+            Footer.Parent = Container;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void PositionPlayfields()
+        {
+            if (UnEditablePlayfield == null)
+                return;
+
+            const int spacing = 60;
+
+            Playfield.X = -Playfield.Width / 2 - spacing;
+            UnEditablePlayfield.X = Playfield.Width / 2 + spacing;
+
+            Playfield.ResetObjectPositions();
+            UnEditablePlayfield.ResetObjectPositions();
+        }
+
+        /// <summary>
+        ///     Called when the user wants to view an uneditable map
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnUneditableMapChanged(object sender, BindableValueChangedEventArgs<Qua> e)
+        {
+            UnEditablePlayfield?.Destroy();
+
+            CreateOtherDifficultyPlayfield();
+            PositionPlayfields();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Footer/EditorFooter.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Footer/EditorFooter.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Menu.Border;
+using Quaver.Shared.Screens.Edit.UI.Footer.Time;
+using TagLib.Matroska;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Edit.UI.Footer
+{
+    public class EditorFooter : MenuBorder
+    {
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        /// <summary>
+        /// </summary>
+        private EditorFooterSeekBar SeekBar { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private EditorFooterTime CurrentTime { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private EditorFooterTime TimeLeft { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private PausePlayButton PausePlayButton { get; set; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="track"></param>
+        public EditorFooter(IAudioTrack track) : base(MenuBorderType.Footer, new List<Drawable>()
+        {
+            new IconTextButtonExit()
+        }, new List<Drawable>()
+        {
+            new IconTextButtonTestPlay()
+        })
+        {
+            Track = track;
+
+            AnimatedLine.Visible = false;
+            ForegroundLine.Visible = false;
+
+            CreateSeekBar();
+            CreateTimeTexts();
+            CreatePausePlayButton();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateSeekBar()
+        {
+            SeekBar = new EditorFooterSeekBar(new BindableInt(0, 0, (int) Track.Length), new Vector2(Width, 6), Track)
+            {
+                Parent = this,
+            };
+
+            SeekBar.Y -= SeekBar.Height;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateTimeTexts()
+        {
+            const int posX = 18;
+
+            CurrentTime = new EditorFooterTime(EditorFooterTimeType.Current, FontManager.GetWobbleFont(Fonts.LatoBlack), Track)
+            {
+                Parent = this,
+                X = posX,
+            };
+
+            TimeLeft = new EditorFooterTime(EditorFooterTimeType.Left, FontManager.GetWobbleFont(Fonts.LatoBlack), Track)
+            {
+                Parent = this,
+                Alignment = Alignment.TopRight,
+                X = -posX,
+            };
+
+            CurrentTime.Y -= CurrentTime.Height + 26;
+            TimeLeft.Y = CurrentTime.Y;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreatePausePlayButton()
+        {
+            PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton, Track)
+            {
+                Parent = this,
+                Alignment = Alignment.MidCenter,
+                Size = new ScalableVector2(40, 40)
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Footer/EditorFooterSeekBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Footer/EditorFooterSeekBar.cs
@@ -1,0 +1,82 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Assets;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.UI.Form;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Edit.UI.Footer
+{
+    public class EditorFooterSeekBar : Slider
+    {
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="binded"></param>
+        /// <param name="size"></param>
+        /// <param name="track"></param>
+        public EditorFooterSeekBar(BindableInt binded, Vector2 size, IAudioTrack track) : base(binded, size, UserInterface.VolumeSliderProgressBall)
+        {
+            Track = track;
+            ActiveColor.Image = UserInterface.VolumeSliderActive;
+            Image = UserInterface.VolumeSliderInactive;
+
+            ProgressBall.Size = new ScalableVector2(24, 24);
+
+            BindedValue.ValueChanged += (sender, args) =>
+            {
+                if (!IsHeld)
+                    return;
+
+                if (Math.Abs(Track.Time - args.Value) < 200)
+                    return;
+
+                Track.Seek(args.Value);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            BindedValue.Value = (int) Track.Time;
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            BindedValue.Dispose();
+            base.Destroy();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        ///     Gets the click area of the slider.
+        /// </summary>
+        /// <returns></returns>
+        protected override bool IsMouseInClickArea()
+        {
+            // The RectY increase of the click area.
+            const int offset = 34;
+
+            DrawRectangle clickArea;
+
+            clickArea = new DrawRectangle(ScreenRectangle.X, ScreenRectangle.Y - offset / 2f, ScreenRectangle.Width,
+                ScreenRectangle.Height + offset);
+
+            return GraphicsHelper.RectangleContains(clickArea, MouseManager.CurrentState.Position);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Footer/IconTextButtonExit.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Footer/IconTextButtonExit.cs
@@ -1,0 +1,16 @@
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Menu.Border.Components;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Edit.UI.Footer
+{
+    public class IconTextButtonExit : IconTextButton
+    {
+        public IconTextButtonExit() : base(FontAwesome.Get(FontAwesomeIcon.fa_chevron_pointing_to_the_left),
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Exit", (sender, args) =>
+            {
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Footer/IconTextButtonTestPlay.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Footer/IconTextButtonTestPlay.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Menu.Border.Components;
+using Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs.Create;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Edit.UI.Footer
+{
+    public class IconTextButtonTestPlay : IconTextButton
+    {
+        public IconTextButtonTestPlay() : base(FontAwesome.Get(FontAwesomeIcon.fa_play_button),
+            FontManager.GetWobbleFont(Fonts.LatoBlack),"Test Play", (sender, args) =>
+            {
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Footer/Time/EditorFooterTime.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Footer/Time/EditorFooterTime.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.Xna.Framework;
+using Wobble.Audio.Tracks;
+using Wobble.Graphics.Sprites.Text;
+
+namespace Quaver.Shared.Screens.Edit.UI.Footer.Time
+{
+    public class EditorFooterTime : SpriteTextPlus
+    {
+        /// <summary>
+        /// </summary>
+        private EditorFooterTimeType Type { get; }
+
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="font"></param>
+        /// <param name="track"></param>
+        public EditorFooterTime(EditorFooterTimeType type, WobbleFontStore font, IAudioTrack track) : base(font, "00:00.000", 26)
+        {
+            Type = type;
+            Track = track;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            // TODO: Optimize this, so it's not creating a new rendertarget each frame
+            switch (Type)
+            {
+                case EditorFooterTimeType.Current:
+                    // @"mm\:ss\.fff")
+                    Text = TimeSpan.FromMilliseconds(Track.Time).ToString(@"mm\:ss");
+                    break;
+                case EditorFooterTimeType.Left:
+                    Text = "-" + TimeSpan.FromMilliseconds(Track.Length - Track.Time).ToString(@"mm\:ss");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            base.Update(gameTime);
+        }
+    }
+
+    public enum EditorFooterTimeType
+    {
+        Current,
+        Left
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
@@ -1,0 +1,112 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
+using Quaver.Shared.Skinning;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield
+{
+    public class EditorHitObject : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        protected Qua Map { get; }
+
+        /// <summary>
+        /// </summary>
+        protected EditorPlayfield Playfield { get; }
+
+        /// <summary>
+        /// </summary>
+        protected HitObjectInfo Info { get; }
+
+        /// <summary>
+        /// </summary>
+        protected Bindable<SkinStore> Skin { get; }
+
+        /// <summary>
+        /// </summary>
+        protected IAudioTrack Track { get; }
+
+        /// <summary>
+        /// </summary>
+        protected Bindable<bool> AnchorHitObjectsAtMidpoint { get; }
+
+        /// <summary>
+        /// </summary>
+        protected SkinKeys SkinMode => Skin.Value.Keys[Map.Mode];
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="playfield"></param>
+        /// <param name="info"></param>
+        /// <param name="skin"></param>
+        /// <param name="track"></param>
+        /// <param name="anchorHitObjectsAtMidpoint"></param>
+        public EditorHitObject(Qua map, EditorPlayfield playfield, HitObjectInfo info, Bindable<SkinStore> skin, IAudioTrack track,
+            Bindable<bool> anchorHitObjectsAtMidpoint)
+        {
+            Map = map;
+            Playfield = playfield;
+            Info = info;
+            Skin = skin;
+            Track = track;
+            AnchorHitObjectsAtMidpoint = anchorHitObjectsAtMidpoint;
+
+            Image = GetHitObjectTexture();
+
+            SetPosition();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        ///     When drawing the object, we only want to just draw it to SpriteBatch.
+        ///     We don't want to handle anything else since its all manual in this purpose
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime) => DrawToSpriteBatch();
+
+        /// <summary>
+        ///     Sets the size of the object
+        /// </summary>
+        public virtual void SetSize()
+        {
+            Width = Playfield.ColumnSize - Playfield.BorderLeft.Width * 2;
+            Height = (Playfield.ColumnSize - Playfield.BorderLeft.Width * 2) * Image.Height / Image.Width;
+        }
+
+        /// <summary>
+        ///     Sets the position of the object
+        /// </summary>
+        public void SetPosition()
+        {
+            X = Playfield.ScreenRectangle.X + Playfield.ColumnSize * (Info.Lane - 1) + Playfield.BorderLeft.Width;
+            Y = Playfield.HitPositionY - Info.StartTime * Playfield.TrackSpeed - Height;
+
+            if (AnchorHitObjectsAtMidpoint.Value)
+                Y += Height / 2f;
+        }
+
+        /// <summary>
+        ///    Returns the texture for the hitobject
+        /// </summary>
+        private Texture2D GetHitObjectTexture()
+        {
+            var index = SkinMode.ColorObjectsBySnapDistance ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            return SkinMode.NoteHoldHitObjects[Info.Lane - 1][index];
+        }
+
+        /// <summary>
+        ///     Checks if the object is visible and on the screen
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool IsOnScreen() => Info.StartTime * Playfield.TrackSpeed >= Playfield.TrackPositionY - Playfield.Height &&
+                                                 Info.StartTime * Playfield.TrackSpeed <= Playfield.TrackPositionY + Playfield.Height;
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectLong.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectLong.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Skinning;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield
+{
+    public class EditorHitObjectLong : EditorHitObject
+    {
+        /// <summary>
+        ///     The long note's body sprite
+        /// </summary>
+        public Sprite Body { get; private set; }
+
+        /// <summary>
+        ///     The long note's tail.
+        /// </summary>
+        public Sprite Tail { get; private set; }
+
+        /// <summary>
+        ///     The texture for the long note's body
+        /// </summary>
+        public Texture2D TextureBody { get; }
+
+        /// <summary>
+        ///     The texture for the long note's end.
+        /// </summary>
+        public Texture2D TextureTail { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="playfield"></param>
+        /// <param name="info"></param>
+        /// <param name="skin"></param>
+        /// <param name="track"></param>
+        /// <param name="anchorHitObjectsAtMidpoint"></param>
+        public EditorHitObjectLong(Qua map, EditorPlayfield playfield, HitObjectInfo info, Bindable<SkinStore> skin, IAudioTrack track,
+            Bindable<bool> anchorHitObjectsAtMidpoint) : base(map, playfield, info, skin, track, anchorHitObjectsAtMidpoint)
+        {
+            TextureBody = GetBodyTexture();
+            TextureTail = GetTailTexture();
+
+            CreateLongNoteSprite();
+            ResizeLongNote();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+        }
+
+        public override void Draw(GameTime gameTime) => DrawToSpriteBatch();
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            base.Destroy();
+            Body?.Destroy();
+            Tail?.Destroy();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void DrawToSpriteBatch()
+        {
+            // Draw the body first, then the note. That'll make it so we can get that effect
+            // where if the player is using an arrow skin, part of the body will be under the note.
+            Body.DrawToSpriteBatch();
+            Tail.DrawToSpriteBatch();
+            base.DrawToSpriteBatch();
+        }
+
+        /// <summary>
+        ///     Handles the creation of the long note sprite.
+        /// </summary>
+        private void CreateLongNoteSprite()
+        {
+            // Make sure the
+            base.SetSize();
+
+            Body = new Sprite
+            {
+                Parent = this,
+                Image = TextureBody,
+                Size = new ScalableVector2(Width, GetLongNoteHeight()),
+            };
+
+            Body.Y = -Body.Height + Height / 2f;
+
+            Tail = new Sprite
+            {
+                Parent = this,
+                Image = TextureTail,
+                Size = new ScalableVector2(Width, GetTailHeight()),
+                Y = -Body.Height,
+            };
+        }
+
+        /// <summary>
+        ///     Resizes the long note to the correct height.
+        ///     Usually used for when the zoom/playback rate has changed.
+        /// </summary>
+        public void ResizeLongNote()
+        {
+            Body.Height = GetLongNoteHeight();
+            Body.Y = -Body.Height + Height / 2f;
+            Tail.Y = -Body.Height;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private float GetLongNoteHeight()
+        {
+            var height = Math.Abs(Playfield.HitPositionY - Info.EndTime * Playfield.TrackSpeed -
+                                  (float) Playfield.ColumnSize * TextureTail.Height / TextureTail.Width / 2 - Height / 2f - Y);
+
+            if (AnchorHitObjectsAtMidpoint.Value)
+                height -= Height / 2f;
+
+            return height;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void SetSize()
+        {
+            base.SetSize();
+
+            Tail.Height = GetTailHeight();
+            ResizeLongNote();
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private float GetTailHeight() => (float) Playfield.ColumnSize * TextureTail.Height / TextureTail.Width;
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private Texture2D GetBodyTexture() => SkinMode.NoteHoldBodies[Info.Lane - 1].First();
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private Texture2D GetTailTexture() => SkinMode.NoteHoldEnds[Info.Lane - 1];
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public override bool IsOnScreen() => base.IsOnScreen() || Track.Time >= Info.StartTime 
+                                                  && Track.Time <= Info.EndTime + 1000;
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Enums;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Edit.UI.Playfield.Timeline;
+using Quaver.Shared.Skinning;
+using Wobble;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Window;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield
+{
+    public class EditorPlayfield : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        private Qua Map { get; }
+
+        /// <summary>
+        /// </summary>
+        private Bindable<SkinStore> Skin { get; }
+
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        /// <summary>
+        /// </summary>
+        private BindableInt BeatSnap { get; }
+
+        /// <summary>
+        /// </summary>
+        private BindableInt ScrollSpeed { get; }
+
+        /// <summary>
+        /// </summary>
+        private Bindable<bool> AnchorHitObjectsAtMidpoint { get; }
+
+        /// <summary>
+        ///     If true, this playfield is unable to be edited/interacted with. This is purely for viewing
+        /// </summary>
+        public bool IsUneditable { get; }
+
+        /// <summary>
+        ///     The size of each column in the playfield
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public int ColumnSize
+        {
+            get
+            {
+                switch (Map.Mode)
+                {
+                    case GameMode.Keys4:
+                        return 80;
+                    case GameMode.Keys7:
+                        return 70;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        public int HitPositionY { get; } = 860;
+
+        /// <summary>
+        ///     The speed at which the container scrolls at.
+        /// </summary>
+        public float TrackSpeed => ScrollSpeed.Value / (20 * Track.Rate);
+
+        /// <summary>
+        ///     The current y positon of the playfield track
+        /// </summary>
+        public float TrackPositionY => (float) Track.Time * TrackSpeed;
+
+        /// <summary>
+        /// </summary>
+        public Sprite BorderLeft { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        private Sprite BorderRight { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private List<Sprite> DividerLines { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private Sprite HitPositionLine { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private ImageButton Button { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private List<EditorHitObject> HitObjects { get; set; }
+
+        /// <summary>
+        ///     The objects that are currently visible and ready to be drawn to the screen
+        /// </summary>
+        private List<EditorHitObject> HitObjectPool { get; set; }
+
+        /// <summary>
+        ///     The index of the last object that was added to the pool
+        /// </summary>
+        private int LastPooledHitObjectIndex { get; set; } = -1;
+
+        /// <summary>
+        /// </summary>
+        private EditorPlayfieldTimeline Timeline { get; set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="skin"></param>
+        /// <param name="track"></param>
+        /// <param name="beatSnap"></param>
+        /// <param name="scrollSpeed"></param>
+        /// <param name="isUneditable"></param>
+        public EditorPlayfield(Qua map, Bindable<SkinStore> skin, IAudioTrack track, BindableInt beatSnap, BindableInt scrollSpeed,
+            Bindable<bool> anchorHitObjectsAtMidpoint, bool isUneditable = false)
+        {
+            Map = map;
+            Skin = skin;
+            Track = track;
+            BeatSnap = beatSnap;
+            IsUneditable = isUneditable;
+            ScrollSpeed = scrollSpeed;
+            AnchorHitObjectsAtMidpoint = anchorHitObjectsAtMidpoint;
+
+            Alignment = Alignment.TopCenter;
+            Tint = ColorHelper.HexToColor("#181818");
+            Size = new ScalableVector2(ColumnSize * Map.GetKeyCount(), WindowManager.Height);
+
+            CreateBorders();
+            CreateDividerLines();
+            CreateHitPositionLine();
+            CreateTimeline();
+            CreateHitObjects();
+            CreateButton();
+
+            InitializeHitObjectPool();
+            Track.Seeked += OnTrackSeeked;
+            ScrollSpeed.ValueChanged += OnScrollSpeedChanged;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            Button.Alignment = Alignment;
+            Button.Position = new ScalableVector2(X + BorderLeft.Width / 2f, Y);
+            UpdateHitObjectPool();
+            Timeline.Update(gameTime);
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime)
+        {
+            base.Draw(gameTime);
+
+            try
+            {
+                GameBase.Game.SpriteBatch.End();
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            var transformMatrix = Matrix.CreateTranslation(0, TrackPositionY, 0) * WindowManager.Scale;
+
+            GameBase.Game.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied, null, null, null, null, transformMatrix);
+            Timeline.Draw(gameTime);
+            DrawHitObjects(gameTime);
+            GameBase.Game.SpriteBatch.End();
+
+            // Draw the button on top of the hitobjects because it serves as a dimming
+            Button.Draw(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            HitObjects.ForEach(x => x.Destroy());
+            Track.Seeked -= OnTrackSeeked;
+
+            // ReSharper disable once DelegateSubtraction
+            ScrollSpeed.ValueChanged -= OnScrollSpeedChanged;
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateBorders()
+        {
+            var color = ColorHelper.HexToColor("#808080");
+            const int width = 2;
+
+            BorderLeft = new Sprite
+            {
+                Parent = this,
+                Size = new ScalableVector2(width, Height),
+                Tint = color
+            };
+
+            BorderRight = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.TopRight,
+                Size = new ScalableVector2(width, Height),
+                Tint = color
+            };
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateDividerLines()
+        {
+            DividerLines = new List<Sprite>();
+
+            for (var i = 0; i < Map.GetKeyCount() - 1; i++)
+            {
+                DividerLines.Add(new Sprite
+                {
+                    Parent = this,
+                    Alignment = Alignment.TopLeft,
+                    Size = new ScalableVector2(2, Height),
+                    X = ColumnSize * (i + 1),
+                    Alpha = 0.35f
+                });
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateHitPositionLine() => HitPositionLine = new Sprite
+        {
+            Parent = this,
+            Alignment = Alignment.TopCenter,
+            Y = HitPositionY,
+            Size = new ScalableVector2(Width - BorderLeft.Width * 2, 6),
+            Tint = Colors.MainBlue
+        };
+
+        /// <summary>
+        /// </summary>
+        private void CreateTimeline() => Timeline = new EditorPlayfieldTimeline(Map, this, Track, BeatSnap, ScrollSpeed);
+
+        /// <summary>
+        /// </summary>
+        private void CreateHitObjects()
+        {
+            HitObjects = new List<EditorHitObject>();
+            Map.HitObjects.ForEach(CreateHitObject);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="info"></param>
+        private void CreateHitObject(HitObjectInfo info)
+        {
+            var ho = info.IsLongNote ? new EditorHitObjectLong(Map, this, info, Skin, Track, AnchorHitObjectsAtMidpoint)
+                                      : new EditorHitObject(Map, this, info, Skin, Track, AnchorHitObjectsAtMidpoint);
+
+            ho.SetSize();
+            ho.SetPosition();
+
+            if (ho is EditorHitObjectLong longNote)
+                longNote.ResizeLongNote();
+
+            HitObjects.Add(ho);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateButton()
+        {
+            Button = new ImageButton(UserInterface.BlankBox)
+            {
+                Size = new ScalableVector2(Width - BorderLeft.Width * 4, Height),
+                Tint = Color.Black,
+                Alpha = 0
+            };
+
+            if (IsUneditable)
+                Button.Alpha = 0.45f;
+        }
+
+        /// <summary>
+        ///     Does any initializing of the pool from the current time
+        /// </summary>
+        private void InitializeHitObjectPool()
+        {
+            HitObjectPool = new List<EditorHitObject>();
+            LastPooledHitObjectIndex = -1;
+
+            for (var i = 0; i < HitObjects.Count; i++)
+            {
+                var hitObject = HitObjects[i];
+
+                if (!hitObject.IsOnScreen())
+                    continue;
+
+                HitObjectPool.Add(hitObject);
+                LastPooledHitObjectIndex = i;
+            }
+        }
+
+        /// <summary>
+        ///     Updates the object pool to get rid of old/out of view objects
+        /// </summary>
+        private void UpdateHitObjectPool()
+        {
+            // Check the objects that are in the pool currently to see if they're still in view.
+            // if they're not, remove them.
+            for (var i = HitObjectPool.Count - 1; i >= 0; i--)
+            {
+                var hitObject = HitObjectPool[i];
+
+                if (!hitObject.IsOnScreen())
+                    HitObjectPool.Remove(hitObject);
+            }
+
+            // Add any objects that are now on-screen
+            for (var i = LastPooledHitObjectIndex + 1; i < HitObjects.Count; i++)
+            {
+                var hitObject = HitObjects[i];
+
+                if (!hitObject.IsOnScreen())
+                    break;
+
+                HitObjectPool.Add(hitObject);
+                LastPooledHitObjectIndex = i;
+            }
+        }
+
+        /// <summary>
+        ///     Draws all of the currently available hitobjects.
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawHitObjects(GameTime gameTime)
+        {
+            for (var i = 0; i < HitObjectPool.Count; i++)
+            {
+                HitObjectPool[i].SetPosition();
+                HitObjectPool[i].Draw(gameTime);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        public void ResetObjectPositions() => HitObjects.ForEach(x => x.SetPosition());
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnTrackSeeked(object sender, TrackSeekedEventArgs e) => InitializeHitObjectPool();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnScrollSpeedChanged(object sender, BindableValueChangedEventArgs<int> e)
+        {
+            ScheduleUpdate(() =>
+            {
+                foreach (var ho in HitObjects)
+                {
+                    ho.SetPosition();
+
+                    if (ho is EditorHitObjectLong ln)
+                        ln.ResizeLongNote();
+                }
+
+                InitializeHitObjectPool();
+            });
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -1,0 +1,413 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Quaver.API.Maps;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Scheduling;
+using Wobble.Audio.Tracks;
+using Wobble.Bindables;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
+{
+    public class EditorPlayfieldTimeline : Container
+    {
+        /// <summary>
+        /// </summary>
+        private Qua Map { get; }
+
+        /// <summary>
+        /// </summary>
+        private EditorPlayfield Playfield { get; }
+
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        /// <summary>
+        /// </summary>
+        private BindableInt BeatSnap { get; }
+
+        /// <summary>
+        /// </summary>
+        private BindableInt ScrollSpeed { get; }
+
+        /// <summary>
+        /// </summary>
+        public List<EditorPlayfieldTimelineTick> Lines { get; private set; }
+
+        /// <summary>
+        ///     Contains cached timeline tick lines for each beat snap.
+        /// </summary>
+        private Dictionary<int, List<EditorPlayfieldTimelineTick>> CachedLines { get; } = new Dictionary<int, List<EditorPlayfieldTimelineTick>>();
+
+        /// <summary>
+        ///     The lines that are visible and ready to be drawn to the screen
+        /// </summary>
+        private List<EditorPlayfieldTimelineTick> LinePool { get; set; }
+
+        /// <summary>
+        ///     The index of the last object that was added to the pool
+        /// </summary>
+        private int LastPooledLineIndex { get; set; } = -1;
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="playfield"></param>
+        /// <param name="track"></param>
+        /// <param name="beatSnap"></param>
+        /// <param name="scrollSpeed"></param>
+        public EditorPlayfieldTimeline(Qua map, EditorPlayfield playfield, IAudioTrack track, BindableInt beatSnap, BindableInt scrollSpeed)
+        {
+            Map = map;
+            Playfield = playfield;
+            Track = track;
+            BeatSnap = beatSnap;
+            ScrollSpeed = scrollSpeed;
+
+            InitializeLines();
+
+            BeatSnap.ValueChanged += OnBeatSnapChanged;
+            ScrollSpeed.ValueChanged += OnScrollSpeedChanged;
+            Track.Seeked += OnTrackSeeked;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime) => UpdateLinePool();
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime) => DrawLines(gameTime);
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Destroy()
+        {
+            foreach (var item in CachedLines)
+                item.Value.ForEach(x => x.Destroy());
+
+            // ReSharper disable twice DelegateSubtraction
+            BeatSnap.ValueChanged -= OnBeatSnapChanged;
+            ScrollSpeed.ValueChanged -= OnScrollSpeedChanged;
+            Track.Seeked -= OnTrackSeeked;
+
+            base.Destroy();
+        }
+
+        /// <summary>
+        /// </summary>
+        public void InitializeLines(bool forceRefresh = false)
+        {
+            if (CachedLines.ContainsKey(BeatSnap.Value) && !forceRefresh)
+            {
+                Lines = CachedLines[BeatSnap.Value];
+                InitializeLinePool();
+                return;
+            }
+
+            var lines = new List<EditorPlayfieldTimelineTick>();
+
+            // Keeps track of the total amount of measures in the song.
+            var measureCount = 0;
+
+            foreach (var tp in Map.TimingPoints)
+            {
+                var pointLength = Map.GetTimingPointLength(tp);
+                var startTime = tp.StartTime;
+                var numBeatsOffsetted = 0;
+
+                // First point, so we need to make sure that the lines begin from the beginning of the track minus some.
+                if (Equals(tp, Map.TimingPoints.First()) && startTime > 0)
+                {
+                    while (true)
+                    {
+                        if (numBeatsOffsetted / BeatSnap.Value % 4 == 0
+                            && numBeatsOffsetted % BeatSnap.Value == 0 && startTime <= -2000)
+                            break;
+
+                        numBeatsOffsetted++;
+
+                        // Move the start time back a beat.
+                        startTime -= tp.MillisecondsPerBeat;
+
+                        // Since we're moving back a beat, we still want the point to end at the same position,
+                        // so we need to compensate for this.
+                        pointLength += tp.MillisecondsPerBeat;
+                    }
+                }
+
+                // Last point, so the lines have to extend to the end of the song + more,
+                if (Equals(tp, Map.TimingPoints[Map.TimingPoints.Count - 1]))
+                    pointLength = Track.Length + tp.MillisecondsPerBeat * numBeatsOffsetted + 2000;
+
+                // Create all lines.
+                for (var i = 0; i < pointLength / tp.MillisecondsPerBeat * BeatSnap.Value; i++)
+                {
+                    var time = startTime + tp.MillisecondsPerBeat / BeatSnap.Value * i;
+
+                    var measureBeat = i / BeatSnap.Value % 4 == 0 && i % BeatSnap.Value == 0;
+
+                    if (measureBeat && time >= tp.StartTime)
+                        measureCount++;
+
+                    var height = measureBeat ? 5 : 2;
+
+                    lines.Add(new EditorPlayfieldTimelineTick(Playfield, tp, BeatSnap, time, i, measureCount)
+                    {
+                        Image = UserInterface.BlankBox,
+                        Size = new ScalableVector2(Playfield.Width - 4, 0),
+                        X = Playfield.AbsolutePosition.X + 2,
+                        Y = Playfield.HitPositionY - time * Playfield.TrackSpeed - height,
+                        Tint = GetLineColor(i % BeatSnap.Value, i),
+                        Height = height
+                    });
+                }
+            }
+
+            CachedLines[BeatSnap.Value] = lines;
+            Lines = lines;
+            InitializeLinePool();
+        }
+
+        /// <summary>
+        ///     Does any initializing of the pool from the current time
+        /// </summary>
+        private void InitializeLinePool()
+        {
+            LinePool = new List<EditorPlayfieldTimelineTick>();
+            LastPooledLineIndex = -1;
+
+            for (var i = 0; i < Lines.Count; i++)
+            {
+                var line = Lines[i];
+
+                if (!line.IsOnScreen())
+                    continue;
+
+                LinePool.Add(line);
+                LastPooledLineIndex = i;
+            }
+        }
+
+        /// <summary>
+        ///     Updates the object pool to get rid of old/out of view objects
+        /// </summary>
+        private void UpdateLinePool()
+        {
+            // Check the objects that are in the pool currently to see if they're still in view.
+            // if they're not, remove them.
+            for (var i = LinePool.Count - 1; i >= 0; i--)
+            {
+                var line = LinePool[i];
+
+                if (!line.IsOnScreen())
+                    LinePool.Remove(line);
+            }
+
+            // Add any objects that are now on-screen
+            for (var i = LastPooledLineIndex + 1; i < Lines.Count; i++)
+            {
+                var line = Lines[i];
+
+                if (!line.IsOnScreen())
+                    break;
+
+                LinePool.Add(line);
+                LastPooledLineIndex = i;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        private void DrawLines(GameTime gameTime)
+        {
+            for (var i = 0; i < LinePool.Count; i++)
+            {
+                var line = LinePool[i];
+                line.SetPosition();
+
+                if (line.IsOnScreen())
+                    line.Draw(gameTime);
+            }
+        }
+
+        /// <summary>
+        ///     Gets an individual lioe color for the snap line.
+        /// </summary>
+        /// <param name="val"></param>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private Color GetLineColor(int val, int i)
+        {
+            var snapColor = Playfield.IsUneditable ? EditorBeatSnapColor.Default : EditorBeatSnapColor.Legacy;
+
+            switch (snapColor)
+            {
+                case EditorBeatSnapColor.Default:
+                    return GetDefaultLineColor(val, i);
+                case EditorBeatSnapColor.Legacy:
+                    return GetLegacyLineColor(val, i);
+                case EditorBeatSnapColor.White:
+                    return Color.White;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+       /// <summary>
+        /// </summary>
+        /// <param name="val"></param>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private Color GetDefaultLineColor(int val, int i)
+        {
+            switch (BeatSnap.Value)
+            {
+                // 1/1th
+                case 1:
+                    return Color.White;
+                // 1/2nd
+                case 2:
+                    switch (val)
+                    {
+                        case 0:
+                            return Color.White;
+                        default:
+                            return ColorHelper.HexToColor("#4e94b7");
+                    }
+                // 1/4th
+                case 4:
+                    switch (val)
+                    {
+                        case 0:
+                        case 4:
+                            return Color.White;
+                        case 1:
+                        case 3:
+                            return ColorHelper.HexToColor("#af4fb8");
+                        default:
+                            return ColorHelper.HexToColor("#4e94b7");
+                    }
+                // 1/3rd, 1/6th, 1/12th,
+                case 3:
+                case 6:
+                case 12:
+                    if (val % 3 == 0)
+                        return Color.White;
+                    else if (val == 0)
+                        return Color.White;
+                    else
+                        return ColorHelper.HexToColor("#4e94b7");
+                // 1/8th, 1//16th
+                case 8:
+                case 16:
+                    if (val == 0)
+                        return Color.White;
+                    else if (( i - 1 ) % 2 == 0)
+                        return ColorHelper.HexToColor("#af4fb8");
+                    else if (i % 4 == 0)
+                        return ColorHelper.HexToColor("#4e94b7");
+                    else
+                        return Colors.MainAccent;
+                default:
+                    return Color.White;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="val"></param>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private Color GetLegacyLineColor(int val, int i)
+        {
+            switch (BeatSnap.Value)
+            {
+                // 1/1th
+                case 1:
+                    return Color.White;
+                // 1/2nd
+                case 2:
+                    switch (val)
+                    {
+                        case 0:
+                            return Color.White;
+                        default:
+                            return Color.Red;
+                    }
+                // 1/4th
+                case 4:
+                    switch (val)
+                    {
+                        case 0:
+                        case 4:
+                            return Color.White;
+                        case 1:
+                        case 3:
+                            return ColorHelper.HexToColor("#0085ff");
+                        default:
+                            return Color.Red;
+                    }
+                // 1/3rd, 1/6th, 1/12th,
+                case 3:
+                case 6:
+                case 12:
+                    if (val % 3 == 0)
+                        return Color.Red;
+                    else if (val == 0)
+                        return Color.White;
+                    else
+                        return Color.Purple;
+                // 1/8th, 1//16th
+                case 8:
+                case 16:
+                    if (val == 0)
+                        return Color.White;
+                    else if (( i - 1 ) % 2 == 0)
+                        return Color.Gold;
+                    else if (i % 4 == 0)
+                        return Color.Red;
+                    else
+                        return ColorHelper.HexToColor("#0085ff");
+                default:
+                    return Color.White;
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnBeatSnapChanged(object sender, BindableValueChangedEventArgs<int> e) => InitializeLines();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnTrackSeeked(object sender, TrackSeekedEventArgs e) => InitializeLinePool();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnScrollSpeedChanged(object sender, BindableValueChangedEventArgs<int> e)
+        {
+            foreach (var line in Lines)
+                line.SetPosition();
+
+            InitializeLinePool();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
@@ -1,0 +1,83 @@
+using Microsoft.Xna.Framework;
+using Quaver.API.Maps.Structures;
+using Wobble.Bindables;
+using Wobble.Graphics.Sprites;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
+{
+    public class EditorPlayfieldTimelineTick : Sprite
+    {
+        /// <summary>
+        /// </summary>
+        private EditorPlayfield Playfield { get; }
+
+        /// <summary>
+        ///     The timing point this snap line belongs to.
+        /// </summary>
+        public TimingPointInfo TimingPoint { get; }
+
+        /// <summary>
+        ///     The time in the song the line is located.
+        /// </summary>
+        public float Time { get; }
+
+        /// <summary>
+        ///     The index of the timing point this snap line is.
+        /// </summary>
+        public int Index { get; }
+
+        /// <summary>
+        ///     Determines if this line is for a measure.
+        /// </summary>
+        public bool IsMeasureLine => Index / BeatSnap.Value % 4 == 0
+                                      && Index % BeatSnap.Value == 0 && Time >= TimingPoint.StartTime;
+
+        /// <summary>
+        /// </summary>
+        private BindableInt BeatSnap { get; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="playfield"></param>
+        /// <param name="tp"></param>
+        /// <param name="beatSnap"></param>
+        /// <param name="time"></param>
+        /// <param name="index"></param>
+        /// <param name="measureCount"></param>
+        public EditorPlayfieldTimelineTick(EditorPlayfield playfield, TimingPointInfo tp, BindableInt beatSnap, float time, int index, int measureCount)
+        {
+            Playfield = playfield;
+            TimingPoint = tp;
+            Index = index;
+            Time = time;
+            BeatSnap = beatSnap;
+
+            if (!IsMeasureLine)
+                return;
+
+            Y = -2;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Draw(GameTime gameTime) => DrawToSpriteBatch();
+
+        /// <summary>
+        ///     Checks if the timing line is on-screen.
+        /// </summary>
+        /// <returns></returns>
+        public bool IsOnScreen() => Time * Playfield.TrackSpeed >= Playfield.TrackPositionY - Playfield.Height &&
+                                         Time * Playfield.TrackSpeed <= Playfield.TrackPositionY + Playfield.Height;
+
+        /// <summary>
+        /// </summary>
+        public void SetPosition()
+        {
+            X = Playfield.AbsolutePosition.X + 2;
+            Y = Playfield.HitPositionY - Time * Playfield.TrackSpeed - Height;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/HitObjects/HitObjectManager.cs
@@ -73,8 +73,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects
         /// <summary>
         ///     Plays the correct hitsounds based on the note index of the HitObjectPool.
         /// </summary>
-        public static void PlayObjectHitSounds(HitObjectInfo hitObject)
+        public static void PlayObjectHitSounds(HitObjectInfo hitObject, SkinStore skin = null)
         {
+            // Default to fallback skin if one wasn't provided
+            if (skin == null)
+                skin = SkinManager.Skin;
+
             var game = GameBase.Game as QuaverGame;
 
             // Disable hitsounds for left panel screens if the map preview isnt active
@@ -86,19 +90,19 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects
 
             // Normal
             if (hitObject.HitSound == 0 || (HitSounds.Normal & hitObject.HitSound) != 0)
-                SkinManager.Skin.SoundHit.CreateChannel().Play();
+                skin?.SoundHit?.CreateChannel().Play();
 
             // Clap
             if ((HitSounds.Clap & hitObject.HitSound) != 0)
-                SkinManager.Skin.SoundHitClap.CreateChannel().Play();
+                skin?.SoundHitClap?.CreateChannel().Play();
 
             // Whistle
             if ((HitSounds.Whistle & hitObject.HitSound) != 0)
-                SkinManager.Skin.SoundHitWhistle.CreateChannel().Play();
+                skin?.SoundHitWhistle?.CreateChannel().Play();
 
             // Finish
             if ((HitSounds.Finish & hitObject.HitSound) != 0)
-                SkinManager.Skin.SoundHitFinish.CreateChannel().Play();
+                skin?.SoundHitFinish?.CreateChannel().Play();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Tests/Editor/TestEditorScreen.cs
+++ b/Quaver.Shared/Screens/Tests/Editor/TestEditorScreen.cs
@@ -1,0 +1,11 @@
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Tests.Editor
+{
+    public sealed class TestEditorScreen : Screen
+    {
+        public override ScreenView View { get; protected set; }
+
+        public TestEditorScreen() => View = new TestEditorScreenView(this);
+    }
+}

--- a/Quaver.Shared/Screens/Tests/Editor/TestEditorScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/Editor/TestEditorScreenView.cs
@@ -1,0 +1,50 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.API.Maps;
+using Quaver.Shared.Screens.Edit;
+using Wobble;
+using Wobble.Audio.Tracks;
+using Wobble.Input;
+using Wobble.Screens;
+
+namespace Quaver.Shared.Screens.Tests.Editor
+{
+    public class TestEditorScreenView : ScreenView
+    {
+        private EditScreen Edit { get; }
+
+        /// <summary>
+        /// </summary>
+        private IAudioTrack Track { get; }
+
+        private string Dir = $"Quaver.Resources/Maps/PrincessOfWinter";
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="screen"></param>
+        public TestEditorScreenView(Screen screen) : base(screen)
+        {
+            var qua = Qua.Parse(GameBase.Game.Resources.Get($"{Dir}/2043.qua"), false);
+            Track = new AudioTrack(GameBase.Game.Resources.Get($"{Dir}/audio.mp3"), false, false);
+
+            Edit = new EditScreen(qua, Track);
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (KeyboardManager.IsUniqueKeyPress(Keys.D1))
+                Edit.UneditableMap.Value = Qua.Parse(GameBase.Game.Resources.Get($"{Dir}/2044.qua"), false);
+
+            Edit.Update(gameTime);
+        }
+
+        public override void Draw(GameTime gameTime) => Edit.Draw(gameTime);
+
+        public override void Destroy()
+        {
+            Edit.Destroy();
+            Track.Dispose();
+        }
+    }
+}

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -37,6 +37,10 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         private GameMode Mode { get; }
 
+        /// <summary>
+        /// </summary>
+        private static string DefaultSkin => DefaultSkins.Arrow.ToString();
+
 #region SKIN.INI VALUES
 
         [FixedScale]
@@ -385,7 +389,7 @@ namespace Quaver.Shared.Skinning
 
             if (loadFromResources)
             {
-                using (var stream = new StreamReader(GameBase.Game.Resources.GetStream($"Quaver.Resources/Textures/Skins/{ConfigManager.DefaultSkin.Value}/skin.ini")))
+                using (var stream = new StreamReader(GameBase.Game.Resources.GetStream($"Quaver.Resources/Textures/Skins/{DefaultSkin}/skin.ini")))
                     config = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadData(stream);
             }
             else
@@ -513,7 +517,7 @@ namespace Quaver.Shared.Skinning
             }
             else
             {
-                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.DefaultSkin.Value.ToString()}/{Mode.ToString()}/{folder.ToString()}" +
+                resource = $"Quaver.Resources/Textures/Skins/{DefaultSkin}/{Mode.ToString()}/{folder.ToString()}" +
                                $"/{GetResourcePath(element)}.png";
             }
 
@@ -540,7 +544,7 @@ namespace Quaver.Shared.Skinning
             }
             else
             {
-                resource = $"Quaver.Resources/Textures/Skins/{ConfigManager.DefaultSkin.Value.ToString()}/{Mode.ToString()}/{folder.ToString()}" +
+                resource = $"Quaver.Resources/Textures/Skins/{DefaultSkin}/{Mode.ToString()}/{folder.ToString()}" +
                            $"/{GetResourcePath(element)}";
             }
 

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -8,10 +8,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using IniFileParser;
 using IniFileParser.Model;
 using Microsoft.Xna.Framework.Graphics;
+using MoreLinq.Extensions;
 using Quaver.API.Enums;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
@@ -31,6 +33,9 @@ namespace Quaver.Shared.Skinning
         {
             get
             {
+                if (ConfigManager.UseSteamWorkshopSkin == null)
+                    return "";
+
                 if (!ConfigManager.UseSteamWorkshopSkin.Value)
                     return $"{ConfigManager.SkinDirectory.Value}/{ConfigManager.Skin.Value}";
 
@@ -649,6 +654,58 @@ namespace Quaver.Shared.Skinning
 
             for (var i = 0; i < 100 && File.Exists($"{sfxFolder}/{soundComboAlert}-{i + 1}.wav"); i++)
                 SoundComboAlerts.Add(LoadSoundEffect($"{sfxFolder}/{soundComboAlert}-{i + 1}", soundComboAlert + "-" + i + 1, "Menu"));
+        }
+
+        /// <summary>
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var p in GetType().GetProperties())
+            {
+                if (p.PropertyType == typeof(Texture2D))
+                {
+                    var tex = (Texture2D) p.GetValue(this);
+
+                    if (!tex.IsDisposed)
+                        tex.Dispose();
+                }
+                else if (p.PropertyType == typeof(AudioSample))
+                {
+                    var sample = (AudioSample) p.GetValue(this);
+
+                    if (!sample.IsDisposed)
+                        sample.Dispose();
+                }
+                else if (p.PropertyType == typeof(Texture2D[]))
+                {
+                    var textureList = (Texture2D[]) p.GetValue(this);
+                    textureList.ForEach(x => x.Dispose());
+                }
+                else if (p.PropertyType == typeof(List<Texture2D>))
+                {
+                    var textureList = (List<Texture2D>) p.GetValue(this);
+                    textureList.ForEach(x => x.Dispose());
+                }
+                else if (p.PropertyType == typeof(List<AudioSample>))
+                {
+                    var textureList = (List<AudioSample>) p.GetValue(this);
+                    textureList.ForEach(x => x.Dispose());
+                }
+            }
+
+            foreach (var mode in Keys.Values)
+            {
+                foreach (var p in mode.GetType().GetProperties())
+                {
+                    if (p.PropertyType != typeof(Texture2D))
+                        continue;
+
+                    var tex = (Texture2D) p.GetValue(mode);
+
+                    if (!tex.IsDisposed)
+                        tex.Dispose();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Sets up the new editor screen along with a visual testing screen
- Implements the playfield display with basic functions to zoom and change beat snap.
- Implements basic audio controls (pause/play, seek).