### PR TITLE
Implement new failure animation

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -87,7 +87,7 @@ namespace Quaver.Shared.Screens.Gameplay
         public void Update(GameTime gameTime)
         {
             // Don't bother updating if the game is paused or the user failed.
-            if (Screen.IsPaused || Screen.Failed)
+            if (Screen.IsPaused)
                 return;
 
             if (Screen.IsMultiplayerGame && !Screen.IsMultiplayerGameStarted)

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -333,7 +333,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
         /// <summary>
         /// </summary>
-        private const int FAILURE_FADE_TIME = 1500;
+        private const int FAILURE_FADE_TIME = 1700;
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -332,6 +332,18 @@ namespace Quaver.Shared.Screens.Gameplay
         public bool IsDisposed { get; private set; }
 
         /// <summary>
+        /// </summary>
+        private const int FAILURE_FADE_TIME = 1500;
+
+        /// <summary>
+        /// </summary>
+        private const int QUIT_FADE_TIME = 800;
+
+        /// <summary>
+        /// </summary>
+        public int FailFadeTime => HasQuit ? QUIT_FADE_TIME : FAILURE_FADE_TIME;
+
+        /// <summary>
         ///     Ctor -
         /// </summary>
         /// <param name="map"></param>
@@ -900,8 +912,11 @@ namespace Quaver.Shared.Screens.Gameplay
 
             try
             {
-                // Pause the audio if applicable.
-                AudioEngine.Track.Pause();
+                // Audio should be pitched when failing to provide a smooth sound.
+                AudioEngine.Track.ApplyRate(true);
+
+                AudioEngine.Track.FadeSpeed(0f, FailFadeTime);
+                AudioEngine.Track.Fade(0, FailFadeTime);
             }
             // No need to handle this exception.
             catch (Exception)
@@ -910,9 +925,6 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             CustomAudioSampleCache.StopAll();
-
-            // Play failure sound.
-            SkinManager.Skin.SoundFailure.CreateChannel().Play();
 
             FailureHandled = true;
         }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -912,11 +912,13 @@ namespace Quaver.Shared.Screens.Gameplay
 
             try
             {
-                // Audio should be pitched when failing to provide a smooth sound.
-                AudioEngine.Track.ApplyRate(true);
-
-                AudioEngine.Track.FadeSpeed(0f, FailFadeTime);
-                AudioEngine.Track.Fade(0, FailFadeTime);
+                if (!IsPaused && HasStarted)
+                {
+                    // Audio should be pitched when failing to provide a smooth sound.
+                    AudioEngine.Track.ApplyRate(true);
+                    AudioEngine.Track.FadeSpeed(0f, FailFadeTime);
+                    AudioEngine.Track.Fade(0, FailFadeTime);
+                }
             }
             // No need to handle this exception.
             catch (Exception)

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -683,8 +683,11 @@ namespace Quaver.Shared.Screens.Gameplay
 
             if (Screen.Exiting && Screen.Failed)
             {
-                if (Screen.TimeSincePlayEnded >= Screen.FailFadeTime)
+                if (Screen.TimeSincePlayEnded >= Screen.FailFadeTime && !AudioEngine.Track.IsDisposed)
+                {
                     AudioEngine.Track?.Dispose();
+                    Screen.IsPaused = true;
+                }
 
                 return;
             }
@@ -693,7 +696,9 @@ namespace Quaver.Shared.Screens.Gameplay
             // a red screen.
             if (Screen.Failed && !ScreenChangedToRedOnFailure)
             {
-                Transitioner.FadeTo(1, Easing.Linear, Screen.FailFadeTime);
+                var tint = Screen.HasQuit ? Color.Black : Color.Red;
+                Transitioner.FadeTo(Screen.HasQuit ? 1 : 0.75f, Easing.Linear, Screen.FailFadeTime);
+                Transitioner.Tint = tint;
                 ScreenChangedToRedOnFailure = true;
                 SkinManager.Skin.SoundFailure.CreateChannel().Play();
             }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -683,13 +683,8 @@ namespace Quaver.Shared.Screens.Gameplay
 
             if (Screen.Exiting && Screen.Failed)
             {
-                if (Screen.TimeSincePlayEnded >= Screen.FailFadeTime && AudioEngine.Track.IsPlaying)
-                {
-                    AudioEngine.Track?.Stop();
-
-                    if (!Screen.HasQuit)
-                        SkinManager.Skin.SoundFailure.CreateChannel().Play();
-                }
+                if (Screen.TimeSincePlayEnded >= Screen.FailFadeTime)
+                    AudioEngine.Track?.Dispose();
 
                 return;
             }
@@ -700,6 +695,7 @@ namespace Quaver.Shared.Screens.Gameplay
             {
                 Transitioner.FadeTo(1, Easing.Linear, Screen.FailFadeTime);
                 ScreenChangedToRedOnFailure = true;
+                SkinManager.Skin.SoundFailure.CreateChannel().Play();
             }
 
             if (!ResultsScreenLoadInitiated)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
@@ -105,7 +105,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets
         /// <param name="gameTime"></param>
         public virtual void Update(GameTime gameTime)
         {
-            if (!Screen.Failed && !Screen.IsPaused)
+            if (!Screen.IsPaused)
                 HitObjectManager.Update(gameTime);
 
             Playfield.Update(gameTime);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -455,6 +455,23 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 }
             }
 
+            ScoreActiveObjects();
+
+            // Update active objects.
+            foreach (var lane in ActiveNoteLanes)
+            {
+                foreach (var hitObject in lane)
+                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void ScoreActiveObjects()
+        {
+            if (Ruleset.Screen.Failed)
+                return;
+
             // Check to see if the player missed any active notes
             foreach (var lane in ActiveNoteLanes)
             {
@@ -509,13 +526,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     }
                 }
             }
-
-            // Update active objects.
-            foreach (var lane in ActiveNoteLanes)
-            {
-                foreach (var hitObject in lane)
-                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
-            }
         }
 
         /// <summary>
@@ -523,6 +533,23 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         private void UpdateAndScoreHeldObjects()
         {
+            ScoreHeldObjects();
+
+            // Update the currently held long notes.
+            foreach (var lane in HeldLongNoteLanes)
+            {
+                foreach (var hitObject in lane)
+                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void ScoreHeldObjects()
+        {
+            if (Ruleset.Screen.Failed)
+                return;
+
             // The release window. (Window * Multiplier)
             var window = Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay] * Ruleset.ScoreProcessor.WindowReleaseMultiplier[Judgement.Okay];
 
@@ -571,13 +598,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     // Update Pooling
                     KillHoldPoolObject(hitObject);
                 }
-            }
-
-            // Update the currently held long notes.
-            foreach (var lane in HeldLongNoteLanes)
-            {
-                foreach (var hitObject in lane)
-                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -14,6 +14,7 @@ using Quaver.Shared.Skinning;
 using System;
 using System.Linq;
 using Quaver.Shared.Screens.Gameplay.UI;
+using Quaver.Shared.Window;
 using Wobble;
 using Wobble.Graphics;
 using Wobble.Window;

--- a/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
@@ -265,7 +265,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             if (!Screen.IsPaused)
                 return;
 
-            Screen.IsPaused = false;
+            Visible = false;
             Screen.ForceFail = true;
             Screen.HasQuit = true;
 

--- a/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
+++ b/Quaver.Shared/Screens/Selection/Components/SelectJukebox.cs
@@ -73,8 +73,8 @@ namespace Quaver.Shared.Screens.Selection.Components
             {
                 MapManager.Selected.ValueChanged += OnMapChanged;
 
-                if (AudioEngine.Map != MapManager.Selected.Value || AudioEngine.Track.IsStopped)
-                    LoadTrackTask.Run(0);
+                /*if (AudioEngine.Map != MapManager.Selected.Value || AudioEngine.Track.IsStopped)
+                    LoadTrackTask.Run(0);*/
             }
         }
 
@@ -116,7 +116,7 @@ namespace Quaver.Shared.Screens.Selection.Components
             if (AudioTrackStoppedInLastFrame && !LoadTrackTask.IsRunning)
                 LoadTrackTask.Run(0);
 
-            AudioTrackStoppedInLastFrame = AudioEngine.Track.HasPlayed && AudioEngine.Track.IsDisposed;
+            AudioTrackStoppedInLastFrame = AudioEngine.Track.IsDisposed;
         }
 
         /// <summary>


### PR DESCRIPTION
Gets rid of that instant red screen and adds a gradual screen and track fade.

Only known issue is when playing rates with audio pitching off - it'll skip forward for a half second while its adjusting, so this should be fixed framework side.

Closes #411
Closes #869