### PR TITLE
Fixed importing error & other game mapset loading

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -292,6 +292,10 @@ namespace Quaver.Shared.Database.Maps
             }
 
             MapDatabaseCache.OrderAndSetMapsets();
+            Queue.Clear();
+
+            if (MapManager.Mapsets.Count == 0)
+                return;
 
             var mapset = MapManager.Mapsets.Find(x => x.Maps.Any(y => y.Md5Checksum == selectedMap?.Md5Checksum));
 
@@ -302,8 +306,6 @@ namespace Quaver.Shared.Database.Maps
             }
             else
                 MapManager.Selected.Value = mapset.Maps.Find(x => x.Md5Checksum == selectedMap?.Md5Checksum);
-
-            Queue.Clear();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Importing/ImportingScreen.cs
+++ b/Quaver.Shared/Screens/Importing/ImportingScreen.cs
@@ -14,6 +14,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Settings;
 using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Main;
 using Quaver.Shared.Screens.Multi;
 using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Music;
@@ -135,7 +136,10 @@ namespace Quaver.Shared.Screens.Importing
             }
             else
             {
-                Exit(() => new SelectionScreen());
+                if (MapManager.Mapsets.Count == 0)
+                    Exit(() => new MainMenuScreen());
+                else
+                    Exit(() => new SelectionScreen());
             }
         }
     }

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -43,11 +43,13 @@ namespace Quaver.Shared.Screens.Main
 
         /// <summary>
         ///	</summary>
-        private bool originalAutoLoadOsuBeatmapsValue { get; set; }
+        private bool OriginalAutoLoadOsuBeatmapsValue { get; }
 
         /// <summary>
+        ///     If true, the user will be taken to the import screen where all of their maps from other games
+        ///     will be loaded. This is to allow users with 0 maps installed to load all of them without restarting
         ///	</summary>
-        private bool flaggedForOsuImport { get; set; }
+        private bool FlaggedForOsuImport { get; set; }
 
         /// <summary>
         /// </summary>
@@ -58,7 +60,7 @@ namespace Quaver.Shared.Screens.Main
 #endif
             ModManager.RemoveSpeedMods();
 
-            originalAutoLoadOsuBeatmapsValue = ConfigManager.AutoLoadOsuBeatmaps.Value;
+            OriginalAutoLoadOsuBeatmapsValue = ConfigManager.AutoLoadOsuBeatmaps.Value;
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
 
             View = new MainMenuScreenView(this);
@@ -110,7 +112,7 @@ namespace Quaver.Shared.Screens.Main
         public void ExitToSinglePlayer()
         {
             // We have maps in the queue, so we need to go to the import screen first
-            if (MapsetImporter.Queue.Count != 0 || flaggedForOsuImport)
+            if (MapsetImporter.Queue.Count != 0 || FlaggedForOsuImport)
             {
                 Exit(() => new ImportingScreen());
                 return;
@@ -230,6 +232,6 @@ namespace Quaver.Shared.Screens.Main
         /// <param name="e"></param>
         /// <exception cref="NotImplementedException"></exception>
         private void OnAutoLoadOsuBeatmapsChanged(object sender, BindableValueChangedEventArgs<bool> e)
-            => flaggedForOsuImport = e.Value != originalAutoLoadOsuBeatmapsValue;
+            => FlaggedForOsuImport = e.Value != OriginalAutoLoadOsuBeatmapsValue;
     }
 }

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -41,8 +41,13 @@ namespace Quaver.Shared.Screens.Main
         /// </summary>
         public static bool FirstMenuLoad { get; private set; }
 
-        private bool originalAutoLoadOsuBeatmapsValue;
-        private bool flaggedForOsuImport;
+        /// <summary>
+        ///	</summary>
+        private bool originalAutoLoadOsuBeatmapsValue { get; set; }
+
+        /// <summary>
+        ///	</summary>
+        private bool flaggedForOsuImport { get; set; }
 
         /// <summary>
         /// </summary>


### PR DESCRIPTION
Fixed importing hang involving unloading cached maps from other games while in the select screen, when having _zero_ internal Quaver mapsets.

Made toggling the "Load Songs From Other Installed Games" while in the main menu flag for importing. (Previously, you'd have to restart the game.)