### PR TITLE
Temporary solution to force refresh mapsets.

### DIFF
--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -43,8 +43,11 @@ namespace Quaver.Shared.Database.Maps
             var quaFiles = Directory.GetFiles(ConfigManager.SongDirectory.Value, "*.qua", SearchOption.AllDirectories).ToList();
             Logger.Important($"Found {quaFiles.Count} .qua files inside the song directory", LogType.Runtime);
 
-            //SyncMissingOrUpdatedFiles(quaFiles);
-            //AddNonCachedFiles(quaFiles);
+            if (fullSync)
+            {
+                SyncMissingOrUpdatedFiles(quaFiles);
+                AddNonCachedFiles(quaFiles);
+            }
 
             OrderAndSetMapsets();
         }

--- a/Quaver.Shared/Screens/Importing/ImportingScreen.cs
+++ b/Quaver.Shared/Screens/Importing/ImportingScreen.cs
@@ -54,6 +54,12 @@ namespace Quaver.Shared.Screens.Importing
         /// </summary>
         private bool ComingFromSelect { get; set; }
 
+        /// <summary>
+        ///		Used to determine if the importing is a full sync of mapset.
+        ///		Usually performed from F5 in select screen.
+        ///	</summary>
+        private bool FullSync { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -62,9 +68,10 @@ namespace Quaver.Shared.Screens.Importing
 
         /// <summary>
         /// </summary>
-        public ImportingScreen(MultiplayerScreen multiplayerScreen = null, bool fromSelect = false)
+        public ImportingScreen(MultiplayerScreen multiplayerScreen = null, bool fromSelect = false, bool fullSync = false)
         {
             ComingFromSelect = fromSelect;
+            FullSync = fullSync;
             MultiplayerScreen = multiplayerScreen;
 
             PreviouslySelectedMap = MapManager.Selected.Value;
@@ -82,6 +89,9 @@ namespace Quaver.Shared.Screens.Importing
             {
                 if (MapDatabaseCache.MapsToUpdate.Count != 0)
                     MapDatabaseCache.ForceUpdateMaps();
+
+                if (FullSync)
+                    MapDatabaseCache.Load(true);
 
                 if (QuaverSettingsDatabaseCache.OutdatedMaps.Count != 0)
                 {

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -100,7 +100,7 @@ namespace Quaver.Shared.Screens.Main
                 return;
 
             HandleKeyPressEscape();
-            HandleKeyPressControlF5();
+            HandleKeyPressF5();
         }
 
         /// <summary>
@@ -117,9 +117,9 @@ namespace Quaver.Shared.Screens.Main
         /// <summary>
         ///		Sets the flag to begin a force refresh of mapsets when entering singleplayer.
         ///	</summary>
-        private void HandleKeyPressControlF5()
+        private void HandleKeyPressF5()
         {
-            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
+            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -53,12 +53,6 @@ namespace Quaver.Shared.Screens.Main
         private bool FlaggedForOsuImport { get; set; }
 
         /// <summary>
-        ///		If true, the user will be taken to the import screen where all of their maps will be synced.
-        ///		This involves removing any deleted maps, updating any out of date maps, and adding non-cached maps.
-        ///	</summary>
-        private bool FlaggedForForceRefresh { get; set; }
-
-        /// <summary>
         /// </summary>
         public MainMenuScreen()
         {
@@ -125,11 +119,7 @@ namespace Quaver.Shared.Screens.Main
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))
                 return;
 
-            if (!FlaggedForForceRefresh)
-            {
-                FlaggedForForceRefresh = true;
-                NotificationManager.Show(NotificationLevel.Default, "Mapsets will be force refreshed next time you enter singleplayer.");
-            }
+            DialogManager.Show(new RefreshDialog());
         }
 
         /// <summary>
@@ -141,12 +131,6 @@ namespace Quaver.Shared.Screens.Main
             if (MapsetImporter.Queue.Count != 0 || FlaggedForOsuImport)
             {
                 Exit(() => new ImportingScreen());
-                return;
-            }
-
-            if (FlaggedForForceRefresh)
-            {
-                Exit(() => new ImportingScreen(null, true, true));
                 return;
             }
 

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -21,6 +21,7 @@ using Quaver.Shared.Screens.Main.UI;
 using Quaver.Shared.Screens.Menu;
 using Quaver.Shared.Screens.MultiplayerLobby;
 using Quaver.Shared.Screens.Selection;
+using Quaver.Shared.Screens.Selection.UI.Dialogs;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -53,6 +53,12 @@ namespace Quaver.Shared.Screens.Main
         private bool FlaggedForOsuImport { get; set; }
 
         /// <summary>
+        ///		If true, the user will be taken to the import screen where all of their maps will be synced.
+        ///		This involves removing any deleted maps, updating any out of date maps, and adding non-cached maps.
+        ///	</summary>
+        private bool FlaggedForForceRefresh { get; set; }
+
+        /// <summary>
         /// </summary>
         public MainMenuScreen()
         {
@@ -94,6 +100,7 @@ namespace Quaver.Shared.Screens.Main
                 return;
 
             HandleKeyPressEscape();
+            HandleKeyPressControlF5();
         }
 
         /// <summary>
@@ -107,6 +114,21 @@ namespace Quaver.Shared.Screens.Main
             DialogManager.Show(new QuitDialog());
         }
 
+        private void HandleKeyPressControlF5()
+        {
+            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))
+                return;
+
+            if (!FlaggedForForceRefresh)
+            {
+                FlaggedForForceRefresh = true;
+                NotificationManager.Show(NotificationLevel.Default, "Mapsets will be force refreshed next time you enter singleplayer.");
+            }
+        }
+
         /// <summary>
         ///     Exits the screen and goes to single player
         /// </summary>
@@ -116,6 +138,12 @@ namespace Quaver.Shared.Screens.Main
             if (MapsetImporter.Queue.Count != 0 || FlaggedForOsuImport)
             {
                 Exit(() => new ImportingScreen());
+                return;
+            }
+
+            if (FlaggedForForceRefresh)
+            {
+                Exit(() => new ImportingScreen(null, true, true));
                 return;
             }
 

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -114,6 +114,9 @@ namespace Quaver.Shared.Screens.Main
             DialogManager.Show(new QuitDialog());
         }
 
+        /// <summary>
+        ///		Sets the flag to begin a force refresh of mapsets when entering singleplayer.
+        ///	</summary>
         private void HandleKeyPressControlF5()
         {
             if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))

--- a/Quaver.Shared/Screens/Selection/RefreshDialog.cs
+++ b/Quaver.Shared/Screens/Selection/RefreshDialog.cs
@@ -1,0 +1,22 @@
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Importing;
+using Wobble;
+
+namespace Quaver.Shared.Screens.Selection
+{
+    public class RefreshDialog : YesNoDialog
+    {
+        /// <summary>
+        /// </summary>
+        public RefreshDialog()
+            : base("REFRESH MAPSETS", $"Are you sure you would like to refresh?", () =>
+            {
+                var game = (QuaverGame) GameBase.Game;
+                game.CurrentScreen.Exit(() => new ImportingScreen(null, true, true));
+            })
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -31,6 +31,7 @@ using Quaver.Shared.Screens.Multi;
 using Quaver.Shared.Screens.Multiplayer;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
 using Quaver.Shared.Screens.Selection.UI;
+using Quaver.Shared.Screens.Selection.UI.Dialogs;
 using Quaver.Shared.Screens.Selection.UI.FilterPanel.Search;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -251,6 +251,7 @@ namespace Quaver.Shared.Screens.Selection
             HandleKeyPressF2();
             HandleKeyPressF3();
             HandleKeyPressF4();
+            HandleKeyPressF5();
             HandleKeyPressEnter();
             HandleKeyPressControlInput();
             HandleThumb1MouseButtonClick();
@@ -352,6 +353,17 @@ namespace Quaver.Shared.Screens.Selection
                 ActiveLeftPanel.Value = SelectContainerPanel.Leaderboard;
             else
                 ActiveLeftPanel.Value = SelectContainerPanel.UserProfile;
+        }
+
+        private void HandleKeyPressF5()
+        {
+            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                return;
+
+            if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))
+                return;
+
+            DialogManager.Show(new RefreshDialog());
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -355,6 +355,9 @@ namespace Quaver.Shared.Screens.Selection
                 ActiveLeftPanel.Value = SelectContainerPanel.UserProfile;
         }
 
+        /// <summary>
+        ///		Prompts the user to begin a force refresh for mapsets.
+        ///	</summary>
         private void HandleKeyPressF5()
         {
             if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))

--- a/Quaver.Shared/Screens/Selection/UI/Dialogs/RefreshDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Dialogs/RefreshDialog.cs
@@ -1,17 +1,15 @@
-using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics;
-using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Importing;
 using Wobble;
 
-namespace Quaver.Shared.Screens.Selection
+namespace Quaver.Shared.Screens.Selection.UI.Dialogs
 {
     public class RefreshDialog : YesNoDialog
     {
         /// <summary>
         /// </summary>
         public RefreshDialog()
-            : base("REFRESH MAPSETS", $"Are you sure you would like to refresh?", () =>
+            : base("REFRESH MAPSETS", $"Are you sure you would like to refresh all of your maps?", () =>
             {
                 var game = (QuaverGame) GameBase.Game;
                 game.CurrentScreen.Exit(() => new ImportingScreen(null, true, true));


### PR DESCRIPTION
This temporary solution just allows for the end user to begin a force refresh if they so desire. This can be done with **F5** in the select screen, and **CTRL+F5** in the main menu, to flag for a force refresh when entering singleplayer.

The functions that are being re-used will have to be optimized at a later date. This is only to counter having to rebuild the cache on the old steam build/develop branch.

Closes #1185