### PR TITLE
Implement >1 Combo Requirement for CB in first 10 seconds of gameplay, and fix score consistency in Gameplay, and fix speedmod issue

### DIFF
--- a/Quaver.Shared/Helpers/StringHelper.cs
+++ b/Quaver.Shared/Helpers/StringHelper.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Helpers
         /// </summary>
         /// <param name="rating"></param>
         /// <returns></returns>
-        internal static string RatingToString(double rating) => rating.ToString("00.00");
+        internal static string RatingToString(double rating) => rating.ToString("0.00");
 
         /// <summary>
         ///     Converts an accuracy percentage into a string.

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -18,7 +18,7 @@ using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Online;
 using Wobble.Logging;
 using Wobble.Managers;
-using Quaver.Shared.Graphics.Notifications;
+//using Quaver.Shared.Graphics.Notifications;
 
 namespace Quaver.Shared.Modifiers
 {
@@ -166,7 +166,6 @@ namespace Quaver.Shared.Modifiers
         /// </summary>
         public static void RemoveMod(ModIdentifier modIdentifier, bool updateMultiplayerMods = false)
         {
-            NotificationManager.Show(NotificationLevel.Info, "ModRemoved");
             try
             {
                 // Try to find the removed gameplayModifier in the list
@@ -217,6 +216,7 @@ namespace Quaver.Shared.Modifiers
         /// <param name="rate"></param>
         public static void AddSpeedMods(float rate)
         {
+            Console.WriteLine("AddSpeedMods called");
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (rate == 1.0f)
             {
@@ -252,6 +252,8 @@ namespace Quaver.Shared.Modifiers
 
                 ModsChanged?.Invoke(typeof(ModManager), new ModsChangedEventArgs(ModChangeType.RemoveSpeed, Mods,
                     ModIdentifier.None));
+
+                
 
                 Logger.Debug("Removed all speed modifiers", LogType.Runtime, false);
             }

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Online;
 using Wobble.Logging;
 using Wobble.Managers;
+using Quaver.Shared.Graphics.Notifications;
 
 namespace Quaver.Shared.Modifiers
 {
@@ -165,6 +166,7 @@ namespace Quaver.Shared.Modifiers
         /// </summary>
         public static void RemoveMod(ModIdentifier modIdentifier, bool updateMultiplayerMods = false)
         {
+            NotificationManager.Show(NotificationLevel.Info, "ModRemoved");
             try
             {
                 // Try to find the removed gameplayModifier in the list
@@ -177,6 +179,8 @@ namespace Quaver.Shared.Modifiers
                     UpdateMultiplayerMods();
 
                 ModsChanged?.Invoke(typeof(ModManager), new ModsChangedEventArgs(ModChangeType.Removal, Mods, modIdentifier));
+
+                
 
                 Logger.Debug($"Removed mod: {removedMod.ModIdentifier}.", LogType.Runtime, false);
             }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -852,6 +852,10 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     Plays a combo break sound if we've
         /// </summary>
+        ///
+
+        private bool hasCBIntro = false;
+
         private void PlayComboBreakSound()
         {
             if (IsSongSelectPreview)
@@ -863,11 +867,16 @@ namespace Quaver.Shared.Screens.Gameplay
                 return;
             }
 
-            var timeSincePlay = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - TimePlayed;
-            var lastRecCom = (timeSincePlay < 10000) ? 1 : 20;
+            var FirstMiss = Ruleset.ScoreProcessor.CurrentJudgements[Judgement.Miss] == 1 && !hasCBIntro;
 
-            if ((LastRecordedCombo >= lastRecCom) && Ruleset.ScoreProcessor.Combo == 0)
+            if ((LastRecordedCombo > 20 || FirstMiss) && Ruleset.ScoreProcessor.Combo == 0)
+                NotificationManager.Show(NotificationLevel.Info, "cb");
                 SkinManager.Skin.SoundComboBreak.CreateChannel().Play();
+
+            if (FirstMiss)
+            {
+                hasCBIntro = true;
+            }
 
             LastRecordedCombo = Ruleset.ScoreProcessor.Combo;
         }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -866,10 +866,10 @@ namespace Quaver.Shared.Screens.Gameplay
                 DontPlayNextComboBreak = false;
                 return;
             }
-
+            
             var FirstMiss = Ruleset.ScoreProcessor.CurrentJudgements[Judgement.Miss] == 1 && !hasCBIntro;
 
-            if ((LastRecordedCombo > 20 || FirstMiss) && Ruleset.ScoreProcessor.Combo == 0)
+            if ((LastRecordedCombo > 20 || FirstMiss) && Ruleset.ScoreProcessor.Combo == 0 && !IsPlayComplete)
                 NotificationManager.Show(NotificationLevel.Info, "cb");
                 SkinManager.Skin.SoundComboBreak.CreateChannel().Play();
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -863,7 +863,10 @@ namespace Quaver.Shared.Screens.Gameplay
                 return;
             }
 
-            if (LastRecordedCombo >= 20 && Ruleset.ScoreProcessor.Combo == 0)
+            var timeSincePlay = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - TimePlayed;
+            var lastRecCom = (timeSincePlay < 10000) ? 1 : 20;
+
+            if ((LastRecordedCombo >= lastRecCom) && Ruleset.ScoreProcessor.Combo == 0)
                 SkinManager.Skin.SoundComboBreak.CreateChannel().Play();
 
             LastRecordedCombo = Ruleset.ScoreProcessor.Combo;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -870,7 +870,6 @@ namespace Quaver.Shared.Screens.Gameplay
             var FirstMiss = Ruleset.ScoreProcessor.CurrentJudgements[Judgement.Miss] == 1 && !hasCBIntro;
 
             if ((LastRecordedCombo > 20 || FirstMiss) && Ruleset.ScoreProcessor.Combo == 0 && !IsPlayComplete)
-                NotificationManager.Show(NotificationLevel.Info, "cb");
                 SkinManager.Skin.SoundComboBreak.CreateChannel().Play();
 
             if (FirstMiss)

--- a/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemMillisecondScroll.cs
+++ b/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemMillisecondScroll.cs
@@ -1,0 +1,70 @@
+using System;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended;
+using Quaver.Shared.Assets;
+using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Form;
+using Wobble.Managers;
+using Quaver.Shared.Config;
+using ColorHelper = Quaver.Shared.Helpers.ColorHelper;
+
+namespace Quaver.Shared.Screens.Options.Items.Custom
+{
+    public class OptionsItemMillisecondScroll : OptionsItem
+    {
+        /// <summary>
+        /// </summary>
+        protected Slider Slider { get; }
+
+        /// <summary>
+        /// </summary>
+        protected SpriteTextPlus Value { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="containerRect"></param>
+        /// <param name="name"></param>
+        /// <param name="bindedValue"></param>
+        /// <param name="valueModifier"></param>
+        public OptionsItemMillisecondScroll(RectangleF containerRect, string name, MSScroll keymode)
+            : base(containerRect, name)
+        {
+            var configVal = enumToConfigValue(keymode);
+
+            Value = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 22)
+            {
+                Parent = this,
+                Alignment = Alignment.MidCenter,
+                FontSize = 20,
+                UsePreviousSpriteBatchOptions = true,
+                X = -Name.X,
+                Text = configVal.Value.ToString()
+            };
+
+            configVal.ValueChanged += (sender, args) => ScheduleUpdate(() => {
+                Value.Text = calculateMSScrollSpeed(configVal.Value).ToString();
+            });
+        }
+
+        private int calculateMSScrollSpeed(int scrollSpeedQuaver)
+        {
+            var scrollSpeed = ((float)ConfigManager.WindowHeight.Value / (float)scrollSpeedQuaver)*100;
+            Console.WriteLine(scrollSpeed);
+            return (int)scrollSpeed;
+        }
+
+        private BindableInt enumToConfigValue(MSScroll m)
+        {
+            var ret = m == MSScroll.Keymode4k ? ConfigManager.ScrollSpeed4K : ConfigManager.ScrollSpeed7K;
+            return ret;
+        }
+
+        public enum MSScroll
+        {
+            Keymode4k,
+            Keymode7k
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -176,6 +176,8 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemScrollDirection(containerRect, "7K Scroll Direction", ConfigManager.ScrollDirection7K),
                         new OptionsSlider(containerRect, "4K Scroll Speed", ConfigManager.ScrollSpeed4K, i => $"{i / 10f:0.0}"),
                         new OptionsSlider(containerRect, "7K Scroll Speed", ConfigManager.ScrollSpeed7K, i => $"{i / 10f:0.0}"),
+                        new OptionsItemMillisecondScroll(containerRect, "4k scroll time (ms)", OptionsItemMillisecondScroll.MSScroll.Keymode4k),
+                        new OptionsItemMillisecondScroll(containerRect, "7k scroll time (ms)", OptionsItemMillisecondScroll.MSScroll.Keymode7k),
                     }),
                     new OptionsSubcategory("Background", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Result/ResultScreenView.cs
+++ b/Quaver.Shared/Screens/Result/ResultScreenView.cs
@@ -131,6 +131,7 @@ namespace Quaver.Shared.Screens.Result
         /// <param name="e"></param>
         private void OnBackgroundBlurred(object sender, BackgroundBlurredEventArgs e)
         {
+            
             HandleBackgroundChange();
         }
 
@@ -180,7 +181,6 @@ namespace Quaver.Shared.Screens.Result
                 Parent = Container,
                 Alignment = Alignment.TopCenter,
             };
-
             MapInformation.Y = -MapInformation.Height;
             MapInformation.MoveToY(46 + 20, Easing.OutQuint, 800);
         }

--- a/Quaver.Shared/Screens/Result/UI/ResultMapInformation.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultMapInformation.cs
@@ -62,6 +62,11 @@ namespace Quaver.Shared.Screens.Result.UI
         private Sprite Grade { get; set; }
 
         /// <summary>
+        ///     Displays the ruleset/keymode of the map.
+        /// </summary>
+        private SpriteTextBitmap Keymode { get; set; }
+
+        /// <summary>
         ///     Quick reference to the selected map.
         /// </summary>
         private static Map Map => MapManager.Selected.Value;
@@ -81,6 +86,7 @@ namespace Quaver.Shared.Screens.Result.UI
             CreateMapCreator();
             CreatePlayerName();
             CreateGrade();
+            CreateKeymode();
 
             BackgroundHelper.Loaded += OnBackgroundLoaded;
         }
@@ -111,6 +117,16 @@ namespace Quaver.Shared.Screens.Result.UI
             Thumbnail.AddBorder(ColorHelper.HexToColor("#236f9c"));
             UpdateThumbnailImage();
         }
+
+        private void CreateKeymode() => Keymode = new SpriteTextBitmap(FontsBitmap.GothamRegular, Screen.ScoreProcessor.Map.GetKeyCount().ToString() + "K")
+        {
+            Parent = this,
+            Alignment = Alignment.MidLeft,
+            X = 25,
+            Y = 40,
+            FontSize = 40,
+            Size = new ScalableVector2(222, 110)
+        };
 
         /// <summary>
         ///     Updates the thumbnail whenever we've received a new one.

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -328,6 +328,7 @@ namespace Quaver.Shared.Screens.Select
         /// <returns></returns>
         private static float GetNextRate(bool faster)
         {
+            NotificationManager.Show(NotificationLevel.Info, "RateChange");
             var current = ModHelper.GetRateFromMods(ModManager.Mods);
             var adjustment = 0.1f;
 
@@ -344,6 +345,7 @@ namespace Quaver.Shared.Screens.Select
         /// </summary>
         public static void HandleKeyPressControlRateChange()
         {
+            NotificationManager.Show(NotificationLevel.Info, "cntrl");
             if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
                 !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
                 return;

--- a/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifierSpeed.cs
+++ b/Quaver.Shared/Screens/Select/UI/Modifiers/DrawableModifierSpeed.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Online;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Form;
+using Quaver.Shared.Graphics.Notifications;
 
 namespace Quaver.Shared.Screens.Select.UI.Modifiers
 {
@@ -140,8 +141,7 @@ namespace Quaver.Shared.Screens.Select.UI.Modifiers
         /// <param name="val"></param>
         /// <param name="index"></param>
         private static void OnSelected(string val, int index)
-        {
-
+        {  
             if (val == "1.0x")
             {
                 ModManager.RemoveSpeedMods();

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -127,6 +127,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                 Track.Seeked += OnTrackSeeked;
         }
 
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -397,9 +397,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         /// <param name="e"></param>
         ///
 
-
-        private ModIdentifier previousMods = ModIdentifier.None;
-
         private bool IsSpeedMod(ModsChangedEventArgs e)
         {
             var isSpeedMod = e.ChangedMods == ModIdentifier.Speed05X || e.ChangedMods == ModIdentifier.Speed055X ||
@@ -407,7 +404,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                              e.ChangedMods == ModIdentifier.Speed07X || e.ChangedMods == ModIdentifier.Speed075X ||
                              e.ChangedMods == ModIdentifier.Speed08X || e.ChangedMods == ModIdentifier.Speed085X ||
                              e.ChangedMods == ModIdentifier.Speed09X || e.ChangedMods == ModIdentifier.Speed095X ||
-                             e.ChangedMods == ModIdentifier.None || e.ChangedMods == ModIdentifier.Speed105X ||
+                             e.Type.HasFlag(ModChangeType.RemoveSpeed) || e.ChangedMods == ModIdentifier.Speed105X ||
                              e.ChangedMods == ModIdentifier.Speed11X || e.ChangedMods == ModIdentifier.Speed115X ||
                              e.ChangedMods == ModIdentifier.Speed12X || e.ChangedMods == ModIdentifier.Speed125X ||
                              e.ChangedMods == ModIdentifier.Speed13X || e.ChangedMods == ModIdentifier.Speed135X ||
@@ -425,10 +422,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
-            
-            if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
-                || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
+            if ((e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
+                || e.ChangedMods.HasFlag(ModIdentifier.Randomize)) && !e.ChangedMods.HasFlag(ModIdentifier.None))
             {
+                NotificationManager.Show(NotificationLevel.Info, e.ChangedMods.ToString());
                 return;
             }
             else
@@ -438,7 +435,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
             var isSpeedMod = IsSpeedMod(e);
 
-            NotificationManager.Show(NotificationLevel.Info, (e.ChangedMods == ModIdentifier.None).ToString());
+            NotificationManager.Show(NotificationLevel.Info, e.ChangedMods.ToString());
 
             if (isSpeedMod)
             {
@@ -451,7 +448,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
             // Reload the entire
             RunLoadTask();
-            previousMods = e.Mods;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -11,6 +11,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Graphics.Graphs;
 using Quaver.Shared.Graphics.Menu.Border;
 using Quaver.Shared.Helpers;
@@ -394,17 +395,50 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
+        ///
+
+
+        private ModIdentifier previousMods = ModIdentifier.None;
+
+        private bool IsSpeedMod(ModsChangedEventArgs e)
+        {
+            var isSpeedMod = e.ChangedMods == ModIdentifier.Speed05X || e.ChangedMods == ModIdentifier.Speed055X ||
+                             e.ChangedMods == ModIdentifier.Speed06X || e.ChangedMods == ModIdentifier.Speed065X ||
+                             e.ChangedMods == ModIdentifier.Speed07X || e.ChangedMods == ModIdentifier.Speed075X ||
+                             e.ChangedMods == ModIdentifier.Speed08X || e.ChangedMods == ModIdentifier.Speed085X ||
+                             e.ChangedMods == ModIdentifier.Speed09X || e.ChangedMods == ModIdentifier.Speed095X ||
+                             e.ChangedMods == ModIdentifier.None || e.ChangedMods == ModIdentifier.Speed105X ||
+                             e.ChangedMods == ModIdentifier.Speed11X || e.ChangedMods == ModIdentifier.Speed115X ||
+                             e.ChangedMods == ModIdentifier.Speed12X || e.ChangedMods == ModIdentifier.Speed125X ||
+                             e.ChangedMods == ModIdentifier.Speed13X || e.ChangedMods == ModIdentifier.Speed135X ||
+                             e.ChangedMods == ModIdentifier.Speed14X || e.ChangedMods == ModIdentifier.Speed145X ||
+                             e.ChangedMods == ModIdentifier.Speed15X || e.ChangedMods == ModIdentifier.Speed155X ||
+                             e.ChangedMods == ModIdentifier.Speed16X || e.ChangedMods == ModIdentifier.Speed165X ||
+                             e.ChangedMods == ModIdentifier.Speed17X || e.ChangedMods == ModIdentifier.Speed175X ||
+                             e.ChangedMods == ModIdentifier.Speed18X || e.ChangedMods == ModIdentifier.Speed185X ||
+                             e.ChangedMods == ModIdentifier.Speed19X || e.ChangedMods == ModIdentifier.Speed195X ||
+                             e.ChangedMods == ModIdentifier.Speed20X;
+            // whew
+
+            return isSpeedMod;
+        }
+
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
+            
             if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
                 || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
             {
                 return;
             }
+            else
+            {
+                
+            }
 
-            var isSpeedMod = e.ChangedMods >= ModIdentifier.Speed05X && e.ChangedMods <= ModIdentifier.Speed20X ||
-                             e.ChangedMods >= ModIdentifier.Speed055X && e.ChangedMods <= ModIdentifier.Speed095X ||
-                             e.ChangedMods >= ModIdentifier.Speed105X && e.ChangedMods <= ModIdentifier.Speed195X;
+            var isSpeedMod = IsSpeedMod(e);
+
+            NotificationManager.Show(NotificationLevel.Info, (e.ChangedMods == ModIdentifier.None).ToString());
 
             if (isSpeedMod)
             {
@@ -417,6 +451,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
             // Reload the entire
             RunLoadTask();
+            previousMods = e.Mods;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -425,7 +425,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
             if ((e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
                 || e.ChangedMods.HasFlag(ModIdentifier.Randomize)) && !e.ChangedMods.HasFlag(ModIdentifier.None))
             {
-                NotificationManager.Show(NotificationLevel.Info, e.ChangedMods.ToString());
                 return;
             }
             else
@@ -434,8 +433,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
             }
 
             var isSpeedMod = IsSpeedMod(e);
-
-            NotificationManager.Show(NotificationLevel.Info, e.ChangedMods.ToString());
 
             if (isSpeedMod)
             {

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -424,7 +424,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
             if ((e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
-                || e.ChangedMods.HasFlag(ModIdentifier.Randomize)) && !e.ChangedMods.HasFlag(ModIdentifier.None))
+                || e.ChangedMods.HasFlag(ModIdentifier.Randomize)) &&
+                !e.ChangedMods.HasFlag(ModIdentifier.None))
             {
                 return;
             }

--- a/Quaver.sln
+++ b/Quaver.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quaver.Tests", "Quaver.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wobble.Extended", "Wobble\Wobble.Extended\Wobble.Extended.csproj", "{7EDF26D5-AE28-49E2-BA45-953B466A4CB0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpriteFontPlus", "Wobble\SpriteFontPlus\src\SpriteFontPlus\SpriteFontPlus.csproj", "{E6D4B576-2E45-40BF-9906-32FAD89BC2E1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpriteFontPlus", "Wobble\SpriteFontPlus\src\SpriteFontPlus\SpriteFontPlus.csproj", "{E6D4B576-2E45-40BF-9906-32FAD89BC2E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
As requested here: https://github.com/Quaver/Quaver/issues/1728

I made it so in the first 10 seconds of gameplay it will play a combo break sound if you have a combo >1. Used for letting the user know if they didn't FC in the intro.