### PR TITLE
EditorNewSongDialog: use original filename

### DIFF
--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorNewSongDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorNewSongDialog.cs
@@ -33,7 +33,7 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
             if (!file.EndsWith(".mp3") && !file.EndsWith(".ogg"))
                 return;
 
-            EditScreen.CreateNewMapset(file);
+            EditScreen.CreateNewMapset(e);
             DialogManager.Dismiss(this);
         }
     }


### PR DESCRIPTION
Linux is case-sensitive. Using the lowercased filename effectively prevented this code from working in most cases.