### PR TITLE
Convert NPS value from int to float

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -212,14 +212,14 @@ namespace Quaver.Shared.Database.Maps
         ///    Returns the notes per second a map has
         /// </summary>
         [Ignore]
-        public int NotesPerSecond
+        public float NotesPerSecond
         {
             get
             {
                 var objectCount = LongNoteCount + RegularNoteCount;
                 var nps = objectCount / (SongLength / (1000 * ModHelper.GetRateFromMods(ModManager.Mods)));
 
-                return (int) nps.Clamp(0, int.MaxValue);
+                return nps.Clamp(0, float.MaxValue);
             }
         }
 

--- a/Quaver.Shared/Database/Maps/MapsetHelper.cs
+++ b/Quaver.Shared/Database/Maps/MapsetHelper.cs
@@ -596,7 +596,7 @@ namespace Quaver.Shared.Database.Maps
                                     exitLoop = true;
 
                                 var objectCount = map.LongNoteCount + map.RegularNoteCount;
-                                var nps = (int) (objectCount / (map.SongLength / (1000 * ModHelper.GetRateFromMods(ModManager.Mods))));
+                                var nps = (objectCount / (map.SongLength / (1000 * ModHelper.GetRateFromMods(ModManager.Mods))));
 
                                 if (!CompareValues(nps, valNps, searchQuery.Operator))
                                     exitLoop = true;

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
@@ -4,6 +4,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
 using Wobble.Bindables;
+using System;
 
 namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
 {
@@ -39,12 +40,12 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
         /// <summary>
         /// </summary>
         /// <returns></returns>
-        private int GetNotesPerSecond()
+        private double GetNotesPerSecond()
         {
             if (MapManager.Selected.Value == null)
                 return 0;
 
-            return MapManager.Selected.Value.NotesPerSecond;
+            return Math.Round(MapManager.Selected.Value.NotesPerSecond,1);
         }
 
         private void OnModsChanged(object sender, ModsChangedEventArgs e) => SetText();

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
@@ -45,7 +45,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
             if (MapManager.Selected.Value == null)
                 return 0;
 
-            return Math.Round(MapManager.Selected.Value.NotesPerSecond,1);
+            return Math.Round(MapManager.Selected.Value.NotesPerSecond,2);
         }
 
         private void OnModsChanged(object sender, ModsChangedEventArgs e) => SetText();

--- a/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
+++ b/Quaver.Shared/Screens/Selection/UI/FilterPanel/MapInformation/Metadata/FilterMetadataNotesPerSecond.cs
@@ -45,7 +45,7 @@ namespace Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata
             if (MapManager.Selected.Value == null)
                 return 0;
 
-            return Math.Round(MapManager.Selected.Value.NotesPerSecond,2);
+            return Math.Floor(MapManager.Selected.Value.NotesPerSecond * 100) / 100;
         }
 
         private void OnModsChanged(object sender, ModsChangedEventArgs e) => SetText();


### PR DESCRIPTION
NPS will be more precise for sorting and viewing in the map banner. However for the banner I have rounded the value down to 1 decimal, because I don't think any more decimals are required (initially I chose 2 but I think 1 is enough).

closes https://github.com/Quaver/Quaver/issues/1196