### PR TITLE
Restructure qua-based values and add new qua-based functions for Lua editor scripts

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -39,6 +39,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// </summary>
         public bool IsBuiltIn { get; set; }
 
+        public EditorPluginMap EditorPluginMap { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -55,6 +57,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             Author = author;
             Description = description;
             IsBuiltIn = isResource;
+
+            EditorPluginMap = new EditorPluginMap();
 
             UserData.RegisterType<GameMode>();
             UserData.RegisterType<HitSounds>();
@@ -79,16 +83,16 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             WorkingScript.Globals["time_signature"] = typeof(TimeSignature);
             WorkingScript.Globals["actions"] = Editor.ActionManager.PluginActionManager;
 
-            var state = (EditorPluginState) State;
+            var state = (EditorPluginState)State;
 
-            state.SongTime = (int) Math.Round(Editor.Track.Time, MidpointRounding.AwayFromZero);
-            state.GameMode = Editor.WorkingMap.Mode;
+            state.SongTime = (int)Math.Round(Editor.Track.Time, MidpointRounding.AwayFromZero);
             state.UnixTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            state.ScrollVelocities = Editor.WorkingMap.SliderVelocities;
-            state.HitObjects = Editor.WorkingMap.HitObjects;
-            state.TimingPoints = Editor.WorkingMap.TimingPoints;
             state.SelectedHitObjects = Editor.SelectedHitObjects.Value;
             state.CurrentTimingPoint = Editor.WorkingMap.GetTimingPointAt(state.SongTime);
+
+            EditorPluginMap.Map = Editor.WorkingMap;
+            EditorPluginMap.SetFrameState();
+            WorkingScript.Globals["map"] = EditorPluginMap;
 
             base.SetFrameState();
 

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
@@ -1,0 +1,57 @@
+using MoonSharp.Interpreter;
+using MoonSharp.Interpreter.Interop;
+using Quaver.API.Enums;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using MoonSharp.Interpreter;
+using MoonSharp.Interpreter.Interop;
+using Quaver.API.Enums;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Quaver.Shared.Screens.Edit.Plugins
+{
+    [MoonSharpUserData]
+    public class EditorPluginMap
+    {
+        [MoonSharpVisible(false)]
+        public Qua Map;
+
+        /// <summary>
+        ///     The game mode of the map
+        /// </summary>
+        public GameMode Mode { get; [MoonSharpVisible(false)] set; }
+
+        /// <summary>
+        ///     The slider velocities present in the map
+        /// </summary>
+        public List<SliderVelocityInfo> ScrollVelocities { get; [MoonSharpVisible(false)] set; }
+
+        /// <summary>
+        ///     The HitObjects that are currently in the map
+        /// </summary>
+        public List<HitObjectInfo> HitObjects { get; [MoonSharpVisible(false)] set; }
+
+        /// <summary>
+        ///     The timing points that are currently in the map
+        /// </summary>
+        public List<TimingPointInfo> TimingPoints { get; [MoonSharpVisible(false)] set; }
+
+        [MoonSharpVisible(false)]
+        public void SetFrameState()
+        {
+            Mode = Map.Mode;
+            TimingPoints = Map.TimingPoints;
+            ScrollVelocities = Map.SliderVelocities; // Original name was SliderVelocities but that name doesn't really make sense
+            HitObjects = Map.HitObjects;
+        }
+
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
@@ -7,15 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 
-using MoonSharp.Interpreter;
-using MoonSharp.Interpreter.Interop;
-using Quaver.API.Enums;
-using Quaver.API.Maps;
-using Quaver.API.Maps.Structures;
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Quaver.Shared.Screens.Edit.Plugins
 {
     [MoonSharpUserData]
@@ -52,6 +43,33 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             ScrollVelocities = Map.SliderVelocities; // Original name was SliderVelocities but that name doesn't really make sense
             HitObjects = Map.HitObjects;
         }
+
+        /// <summary>
+        ///     Finds the most common BPM in the current map
+        /// </summary>
+        /// <returns></returns>
+        public float GetCommonBpm() => Map.GetCommonBpm();
+
+        /// <summary>
+        ///     Gets the timing point at a particular time in the current map.
+        /// </summary>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public TimingPointInfo GetTimingPointAt(double time) => Map.GetTimingPointAt(time);
+
+        /// <summary>
+        ///     Gets the scroll velocity at a particular time in the current map
+        /// </summary>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public SliderVelocityInfo GetScrollVelocityAt(double time) => Map.GetScrollVelocityAt(time);
+
+        /// <summary>
+        ///    Finds the length of a timing point.
+        /// </summary>
+        /// <param name="point"></param>
+        /// <returns></returns>
+        public double GetTimingPointLength(TimingPointInfo point) => Map.GetTimingPointLength(point);
 
     }
 }

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
@@ -19,26 +19,6 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         public int SongTime { get; [MoonSharpVisible(false)] set; }
 
         /// <summary>
-        ///     The game mode of the map
-        /// </summary>
-        public GameMode GameMode { get; [MoonSharpVisible(false)] set; }
-
-        /// <summary>
-        ///     The slider velocities present in the map
-        /// </summary>
-        public List<SliderVelocityInfo> ScrollVelocities { get; [MoonSharpVisible(false)] set; }
-
-        /// <summary>
-        ///     The HitObjects that are currently in the map
-        /// </summary>
-        public List<HitObjectInfo> HitObjects { get; [MoonSharpVisible(false)] set; }
-
-        /// <summary>
-        ///     The timing points that are currently in the map
-        /// </summary>
-        public List<TimingPointInfo> TimingPoints { get; [MoonSharpVisible(false)] set; }
-
-        /// <summary>
         ///     The objects that are currently selected by the user
         /// </summary>
         public List<HitObjectInfo> SelectedHitObjects { get; [MoonSharpVisible(false)] set; }
@@ -51,7 +31,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <summary>
         ///     ImGui options used to set styles/fonts for the window
         /// </summary>
-        [MoonSharpVisible((false))]
+        [MoonSharpVisible(false)]
         private ImGuiOptions Options { get; }
 
         [MoonSharpVisible(false)]

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -1,9 +1,9 @@
 using System;
 using Microsoft.Xna.Framework.Input;
 using MoonSharp.Interpreter;
-using osu_database_reader.Components.HitObjects;
 using Quaver.API.Enums;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Helpers;
 using Wobble.Input;
 
 namespace Quaver.Shared.Screens.Edit.Plugins
@@ -72,6 +72,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="time"></param>
         /// <returns></returns>
         public static string MillisecondsToTime(float time) => TimeSpan.FromMilliseconds(time).ToString(@"mm\:ss\.fff");
+
+        public static void OpenUrl(string url, bool forceNormalBrowser = false) => BrowserHelper.OpenURL(url, forceNormalBrowser);
 
         public static bool IsKeyPressed(Keys k) => KeyboardManager.IsUniqueKeyPress(k);
 


### PR DESCRIPTION
- Adds `OpenUrl` from the `BrowserHelper` class to be accessable to Lua scripts via `util.OpenUrl()`

    - This makes it possible to open URLs from a Lua script

- Moves following state variables to the new `EditorPluginMap` class, that can be accessed with `map.variable` in the Lua script (this breaks scripts relying on those variables being in `state`, but doesn't affect any of the built-in plugins since they don't use them):

    - Mode (renamed from "GameMode" to "Mode" to stay consistent with the way it's called in Qua.cs)

    - ScrollVelocities

    - HitObjects

    - TimingPoints

- Adds following qua-based utility functions to the new map class

    - GetCommonBpm()

    - GetTimingPointAt()

    - GetScrollVelocityAt()

    - GetTimingPointLength()