### PR TITLE
Visual offset fixes

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -830,7 +830,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             CurrentAudioPosition = Ruleset.Screen.Timing.Time + ConfigManager.GlobalAudioOffset.Value * AudioEngine.Track.Rate - MapManager.Selected.Value.LocalOffset;
 
             // Update SV index if necessary. Afterwards update Position.
-            while (CurrentSvIndex < Map.SliderVelocities.Count && CurrentAudioPosition >= Map.SliderVelocities[CurrentSvIndex].StartTime)
+            while (CurrentSvIndex < Map.SliderVelocities.Count && CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate >= Map.SliderVelocities[CurrentSvIndex].StartTime)
             {
                 CurrentSvIndex++;
             }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -834,7 +834,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 CurrentSvIndex++;
             }
-            CurrentTrackPosition = GetPositionFromTime(CurrentAudioPosition + ConfigManager.VisualOffset.Value, CurrentSvIndex);
+            CurrentTrackPosition = GetPositionFromTime(CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate, CurrentSvIndex);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -425,7 +425,7 @@ namespace Quaver.Shared.Screens.Results
             var newOffset = (int) Math.Round(Map.LocalOffset - change);
 
             var dialog = new YesNoDialog("FIX LOCAL OFFSET",
-                $"Your local offset for this map will be changed from {Map.LocalOffset} ms to {newOffset} ms...", () =>
+                $"Your local offset for this map will be changed from {Map.LocalOffset} ms to {newOffset} ms.", () =>
                 {
                     Map.LocalOffset = newOffset;
                     MapDatabaseCache.UpdateMap(Map);


### PR DESCRIPTION
Now the visual offset properly accounts for rate and stays consistent, and SV changes are no longer teleporting around.
closes https://github.com/Quaver/Quaver/issues/1997
closes https://github.com/Quaver/Quaver/issues/1992