### PR TITLE
Fix local offset rate scaling

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -827,7 +827,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public void UpdateCurrentTrackPosition()
         {
             // Use necessary visual offset
-            CurrentAudioPosition = Ruleset.Screen.Timing.Time + ConfigManager.GlobalAudioOffset.Value * AudioEngine.Track.Rate - MapManager.Selected.Value.LocalOffset;
+            CurrentAudioPosition = Ruleset.Screen.Timing.Time + (ConfigManager.GlobalAudioOffset.Value - MapManager.Selected.Value.LocalOffset) * AudioEngine.Track.Rate; 
 
             // Update SV index if necessary. Afterwards update Position.
             while (CurrentSvIndex < Map.SliderVelocities.Count && CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate >= Map.SliderVelocities[CurrentSvIndex].StartTime)


### PR DESCRIPTION
Local offset didn't take into account rates.
On 80 ms local offset, this is a map on 1.0x with 10 scroll speed:
![unknown](https://user-images.githubusercontent.com/51453670/82261633-0eaba580-9968-11ea-8c5b-6253edd4b20f.png)

Same map on 0.5x, without any code changes:
![unknown](https://user-images.githubusercontent.com/51453670/82261657-1ec38500-9968-11ea-80e8-76a82e5cbccf.png)

Same map on 0.5x, after my proposed change:
![unknown](https://user-images.githubusercontent.com/51453670/82261673-271bc000-9968-11ea-9cac-c11240ea5db7.png)

While my rhythm sense is really bad, I can definitely feel the difference in offset when using the lower rate compared to 1.0x, but it should probably be tested by someone who doesn't suck at tapping through audio cues.
Also I probably hit later on the original 1.0x compared to the second 0.5x graph because it was significantly harder to play than 0.5x.