### PR TITLE
Some result screen adjustments

### DIFF
--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderContentContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderContentContainer.cs
@@ -126,9 +126,9 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
         private void CreateSongTitle() => SongTitle = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
             $"{Map.Artist} - {Map.Title}", 32)
         {
-              Parent = this,
-              X = Avatar.X + Avatar.Width + 32,
-              Y = 20,
+            Parent = this,
+            X = Avatar.X + Avatar.Width + 32,
+            Y = 20,
         };
 
         /// <summary>
@@ -139,20 +139,20 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
             var rate = ModHelper.GetRateFromMods(Processor.Value.Mods);
 
             var rateStr = rate != 1.0f ? $" {rate}x" : "";
-            
+
             Difficulty = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
                 $"[{Map.DifficultyName}{rateStr}] ({StringHelper.RatingToString(difficulty)})", 26)
             {
                 Parent = this,
                 X = SongTitle.X,
                 Y = SongTitle.Y + SongTitle.Height + TEXT_SPACING,
-                Tint = ColorHelper.DifficultyToColor((float) difficulty)
+                Tint = ColorHelper.DifficultyToColor((float)difficulty)
             };
         }
 
         /// <summary>
         /// </summary>
-        private void CreateCreator() => Creator = new TextKeyValue("By: ", Map.Creator, 23,
+        private void CreateCreator() => Creator = new TextKeyValue("Mapped by: ", Map.Creator, 23,
             ColorHelper.HexToColor("#CACACA"))
         {
             Parent = this,

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/ResultsOverviewTab.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/ResultsOverviewTab.cs
@@ -59,9 +59,9 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview
             : base(map, processor, activeTab, isSubmittingScore, scoreSubmissionStats)
         {
             CreateContentContainer();
-            CreateJudgementWindowPreset();
-            CreateDateAndTime();
             CreatePlayedBy();
+            CreateDateAndTime();
+            CreateJudgementWindowPreset();
             CreateScoreContainer();
             CreateGraphContainer();
         }
@@ -77,13 +77,12 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview
 
         /// <summary>
         /// </summary>
-        private void CreateJudgementWindowPreset() => JudgementWindows = new TextKeyValue("Judgement Preset:", Processor.Value.Windows.Name,
-            22, Color.White)
+        private void CreatePlayedBy() => PlayedBy = new TextKeyValue("Played by", $"{Processor.Value.PlayerName}", 22, Color.White)
         {
             Parent = ContentContainer,
             X = PADDING_X,
-            Key = { Tint =  TextDarkGray },
-            Value = { Tint = ColorHelper.HexToColor("#FFE76B")}
+            Key = { Tint = TextDarkGray },
+            Value = { Tint = ColorHelper.HexToColor("#00D1FF") }
         };
 
         /// <summary>
@@ -96,20 +95,20 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview
                 $"on {Processor.Value.Date.ToShortDateString()} @ {time}", 22)
             {
                 Parent = ContentContainer,
-                Alignment = Alignment.TopRight,
+                X = PADDING_X + PlayedBy.Width + 4,
                 Tint = TextDarkGray
             };
         }
 
         /// <summary>
         /// </summary>
-        private void CreatePlayedBy() => PlayedBy = new TextKeyValue("Played by", $"{Processor.Value.PlayerName}", 22, Color.White)
+        private void CreateJudgementWindowPreset() => JudgementWindows = new TextKeyValue("Judgement Preset:", Processor.Value.Windows.Name,
+            22, Color.White)
         {
             Parent = ContentContainer,
             Alignment = Alignment.TopRight,
-            X = -DateAndTime.Width - 4,
-            Key = { Tint =  TextDarkGray },
-            Value = { Tint = ColorHelper.HexToColor("#00D1FF")}
+            Key = { Tint = TextDarkGray },
+            Value = { Tint = ColorHelper.HexToColor("#FFE76B") }
         };
 
         /// <summary>


### PR DESCRIPTION
Added "Mapped by:" instead of "By:" next to the mapper name to remove ambiguity
Swapped judgement preset text and "Played by" text so that it's slightly more intuitive (and now the player name is next to the profile picture as it should be)
End result looks like this:
![5192020 17-37-27-398](https://user-images.githubusercontent.com/51453670/82343130-2122ef00-99fb-11ea-8545-79e8cacf878b.jpg)
