### PR TITLE
Fix LN rendering with SV direction changes in the middle

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -161,7 +161,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             var playfield = (GameplayPlayfieldKeys)ruleset.Playfield;
             var posX = playfield.Stage.Receptors[lane].X;
             var flipNoteBody = direction.Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteImagesOnUpscroll;
-            var flipNoteEnd = direction.Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
             ScrollDirection = direction;
 
             var scale = ConfigManager.GameplayNoteScale.Value / 100f;
@@ -195,8 +194,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 Alignment = Alignment.TopLeft,
                 Position = new ScalableVector2(posX, 0),
                 Size = new ScalableVector2(laneSize, 0),
-                Parent = playfield.Stage.HitObjectContainer,
-                SpriteEffect = flipNoteEnd ? SpriteEffects.FlipVertically : SpriteEffects.None
+                Parent = playfield.Stage.HitObjectContainer
             };
 
             // Set long note end properties.
@@ -271,6 +269,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 InitialLongNoteTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 UpdateLongNoteSize(InitialTrackPosition);
                 InitialLongNoteSize = CurrentLongNoteSize;
+                var flipNoteEnd = playfield.ScrollDirections[info.Lane - 1].Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
+                LongNoteEndSprite.SpriteEffect = flipNoteEnd ? SpriteEffects.FlipVertically : SpriteEffects.None;
             }
 
             InitializeHits();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -50,11 +50,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public long InitialLongNoteTrackPosition { get; private set; }
 
         /// <summary>
-        ///     The Y position of the HitObject Sprites.
-        /// </summary>
-        private float SpritePosition { get; set; }
-
-        /// <summary>
         ///     The initial size of this object's long note.
         /// </summary>
         public float InitialLongNoteSize { get; set; }
@@ -359,26 +354,27 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             //
             // If the LN end is not drawn, don't move the LN start up with time since it ends up sliding above the LN in
             // the end.
+            float spritePosition;
             if (CurrentlyBeingHeld && SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
             {
                 if (offset > InitialTrackPosition)
                 {
                     UpdateLongNoteSize(offset);
-                    SpritePosition = HitPosition;
+                    spritePosition = HitPosition;
                 }
                 else
                 {
                     CurrentLongNoteSize = InitialLongNoteSize;
                 }
-                    SpritePosition = GetSpritePosition(offset, InitialTrackPosition);
+                    spritePosition = GetSpritePosition(offset, InitialTrackPosition);
             }
             else
             {
-                SpritePosition = GetSpritePosition(offset, InitialTrackPosition);
+                spritePosition = GetSpritePosition(offset, InitialTrackPosition);
             }
 
             // Update HitBody
-            HitObjectSprite.Y = SpritePosition;
+            HitObjectSprite.Y = spritePosition;
 
             PressHit.UpdateSpritePositions(offset);
             ReleaseHit.UpdateSpritePositions(offset);
@@ -404,13 +400,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             if (ScrollDirection.Equals(ScrollDirection.Down))
             {
-                LongNoteBodySprite.Y = SpritePosition + LongNoteBodyOffset - CurrentLongNoteSize;
-                LongNoteEndSprite.Y = SpritePosition + LongNoteBodyOffset - CurrentLongNoteSize - LongNoteEndOffset;
+                LongNoteBodySprite.Y = spritePosition + LongNoteBodyOffset - CurrentLongNoteSize;
+                LongNoteEndSprite.Y = spritePosition + LongNoteBodyOffset - CurrentLongNoteSize - LongNoteEndOffset;
             }
             else
             {
-                LongNoteBodySprite.Y = SpritePosition + LongNoteBodyOffset;
-                LongNoteEndSprite.Y = SpritePosition + LongNoteBodyOffset + CurrentLongNoteSize - LongNoteEndOffset;
+                LongNoteBodySprite.Y = spritePosition + LongNoteBodyOffset;
+                LongNoteEndSprite.Y = spritePosition + LongNoteBodyOffset + CurrentLongNoteSize - LongNoteEndOffset;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -382,7 +382,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         {
             // When LN end is not drawn, the LNs don't change their size as they are held.
             // So we only need to update if DrawLongNoteEnd is true.
-            if (SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
+            // The IsLongNote check is because UpdateLongNoteSize uses a property that is only initialized for LNs.
+            if (Info.IsLongNote && SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
                 UpdateLongNoteSize(offset, curTime);
 
             UpdateSpritePositions(offset, curTime);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -327,7 +327,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     Calculates the position of the Hit Object with a position offset.
         /// </summary>
         /// <returns></returns>
-        public float GetSpritePosition(long offset) => HitPosition + ((InitialTrackPosition - offset) * (ScrollDirection.Equals(ScrollDirection.Down) ? -HitObjectManagerKeys.ScrollSpeed : HitObjectManagerKeys.ScrollSpeed) / HitObjectManagerKeys.TrackRounding);
+        public float GetSpritePosition(long offset, float initialPos) => HitPosition + ((initialPos - offset) * (ScrollDirection.Equals(ScrollDirection.Down) ? -HitObjectManagerKeys.ScrollSpeed : HitObjectManagerKeys.ScrollSpeed) / HitObjectManagerKeys.TrackRounding);
 
         /// <summary>
         ///     Updates LN size
@@ -369,12 +369,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 else
                 {
                     CurrentLongNoteSize = InitialLongNoteSize;
-                    SpritePosition = GetSpritePosition(offset);
                 }
+                    SpritePosition = GetSpritePosition(offset, InitialTrackPosition);
             }
             else
             {
-                SpritePosition = GetSpritePosition(offset);
+                SpritePosition = GetSpritePosition(offset, InitialTrackPosition);
             }
 
             // Update HitBody

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -265,6 +265,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 UpdateLongNoteSize(InitialTrackPosition);
                 InitialLongNoteSize = CurrentLongNoteSize;
                 var flipNoteEnd = playfield.ScrollDirections[info.Lane - 1].Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
+                if (HitObjectManager.IsSVNegative(info.EndTime))
+                    // LN ends on negative SV => end should be flipped (since it's going upside down).
+                    flipNoteEnd = !flipNoteEnd;
+
                 LongNoteEndSprite.SpriteEffect = flipNoteEnd ? SpriteEffects.FlipVertically : SpriteEffects.None;
             }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -45,9 +45,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public long InitialTrackPosition { get; set; }
 
         /// <summary>
-        ///     The long note Y offset from the receptor.
+        ///     Latest position of this object.
         /// </summary>
-        public long InitialLongNoteTrackPosition { get; private set; }
+        public long LatestTrackPosition { get; private set; }
 
         /// <summary>
         ///     The initial size of this object's long note.
@@ -253,7 +253,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 LongNoteEndSprite.Visible = false;
                 LongNoteBodySprite.Visible = false;
-                InitialLongNoteTrackPosition = InitialTrackPosition;
+                LatestTrackPosition = InitialTrackPosition;
             }
             else
             {
@@ -261,7 +261,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 LongNoteEndSprite.Tint = tint;
                 LongNoteEndSprite.Visible = SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd;
                 LongNoteBodySprite.Visible = true;
-                InitialLongNoteTrackPosition = manager.GetPositionFromTime(Info.EndTime);
+                LatestTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 UpdateLongNoteSize(InitialTrackPosition);
                 InitialLongNoteSize = CurrentLongNoteSize;
                 var flipNoteEnd = playfield.ScrollDirections[info.Lane - 1].Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
@@ -332,7 +332,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     Updates LN size
         /// </summary>
         /// <param name="offset"></param>
-        public void UpdateLongNoteSize(long offset) => CurrentLongNoteSize = (InitialLongNoteTrackPosition - offset) * HitObjectManagerKeys.ScrollSpeed / HitObjectManagerKeys.TrackRounding - LongNoteSizeDifference;
+        public void UpdateLongNoteSize(long offset) => CurrentLongNoteSize = (LatestTrackPosition - offset) * HitObjectManagerKeys.ScrollSpeed / HitObjectManagerKeys.TrackRounding - LongNoteSizeDifference;
 
         /// <summary>
         ///     Will forcibly update LN on scroll speed change or specific modifier.

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -267,7 +267,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 LongNoteEndSprite.Visible = SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd;
                 LongNoteBodySprite.Visible = true;
                 LatestTrackPosition = manager.GetPositionFromTime(Info.EndTime);
-                UpdateLongNoteSize(InitialTrackPosition);
+                UpdateLongNoteSize(InitialTrackPosition, Info.StartTime);
                 InitialLongNoteSize = CurrentLongNoteSize;
                 EndTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 var flipNoteEnd = playfield.ScrollDirections[info.Lane - 1].Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
@@ -281,7 +281,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             InitializeHits();
 
             // Update Positions
-            UpdateSpritePositions(manager.CurrentTrackPosition);
+            UpdateSpritePositions(manager.CurrentTrackPosition, manager.CurrentVisualPosition);
         }
 
         /// <summary>
@@ -337,28 +337,27 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <summary>
         ///     Updates LN size
         /// </summary>
-        /// <param name="offset"></param>
-        public void UpdateLongNoteSize(long offset) => CurrentLongNoteSize = (LatestTrackPosition - offset) * HitObjectManagerKeys.ScrollSpeed / HitObjectManagerKeys.TrackRounding - LongNoteSizeDifference;
+        public void UpdateLongNoteSize(long offset, double curTime) => CurrentLongNoteSize = (LatestTrackPosition - offset) * HitObjectManagerKeys.ScrollSpeed / HitObjectManagerKeys.TrackRounding - LongNoteSizeDifference;
 
         /// <summary>
         ///     Will forcibly update LN on scroll speed change or specific modifier.
         /// </summary>
-        public void ForceUpdateLongnote(long offset)
+        public void ForceUpdateLongnote(long offset, double curTime)
         {
             // When LN end is not drawn, the LNs don't change their size as they are held.
             if (offset < InitialTrackPosition || !SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
             {
-                UpdateLongNoteSize(InitialTrackPosition);
+                UpdateLongNoteSize(InitialTrackPosition, curTime);
                 InitialLongNoteSize = CurrentLongNoteSize;
             }
 
-            UpdateSpritePositions(offset);
+            UpdateSpritePositions(offset, curTime);
         }
 
         /// <summary>
         ///     Updates the HitObject sprite positions
         /// </summary>
-        public void UpdateSpritePositions(long offset)
+        public void UpdateSpritePositions(long offset, double curTime)
         {
             // Update Sprite position with regards to LN's state
             //
@@ -369,7 +368,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 if (offset > InitialTrackPosition)
                 {
-                    UpdateLongNoteSize(offset);
+                    UpdateLongNoteSize(offset, curTime);
                     spritePosition = HitPosition;
                 }
                 else

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -45,6 +45,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public long InitialTrackPosition { get; set; }
 
         /// <summary>
+        ///     Position of the LN end sprite.
+        /// </summary>
+        public long EndTrackPosition { get; set; }
+
+        /// <summary>
         ///     Latest position of this object.
         /// </summary>
         public long LatestTrackPosition { get; private set; }
@@ -264,6 +269,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 LatestTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 UpdateLongNoteSize(InitialTrackPosition);
                 InitialLongNoteSize = CurrentLongNoteSize;
+                EndTrackPosition = manager.GetPositionFromTime(Info.EndTime);
                 var flipNoteEnd = playfield.ScrollDirections[info.Lane - 1].Equals(ScrollDirection.Up) && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].FlipNoteEndImagesOnUpscroll;
                 if (HitObjectManager.IsSVNegative(info.EndTime))
                     // LN ends on negative SV => end should be flipped (since it's going upside down).
@@ -403,15 +409,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             LongNoteBodySprite.Height = CurrentLongNoteSize;
 
             if (ScrollDirection.Equals(ScrollDirection.Down))
-            {
                 LongNoteBodySprite.Y = spritePosition + LongNoteBodyOffset - CurrentLongNoteSize;
-                LongNoteEndSprite.Y = spritePosition + LongNoteBodyOffset - CurrentLongNoteSize - LongNoteEndOffset;
-            }
             else
-            {
                 LongNoteBodySprite.Y = spritePosition + LongNoteBodyOffset;
-                LongNoteEndSprite.Y = spritePosition + LongNoteBodyOffset + CurrentLongNoteSize - LongNoteEndOffset;
-            }
+
+            LongNoteEndSprite.Y = GetSpritePosition(offset, EndTrackPosition);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -745,30 +745,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <returns></returns>
         public long GetPositionFromTime(double time)
         {
-            long curPos = 0;
-
-            if (Map.SliderVelocities.Count == 0 || time < Map.SliderVelocities[0].StartTime)
+            int i;
+            for (i = 0; i < Map.SliderVelocities.Count; i++)
             {
-                curPos = GetPositionFromTime(time, 0);
-            }
-            else if (time >= Map.SliderVelocities[Map.SliderVelocities.Count - 1].StartTime)
-            {
-                curPos = GetPositionFromTime(time, Map.SliderVelocities.Count);
-            }
-            else
-            {
-                // Get index
-                for (var i = 0; i < Map.SliderVelocities.Count; i++)
-                {
-                    if (time < Map.SliderVelocities[i].StartTime)
-                    {
-                        curPos = GetPositionFromTime(time, i);
-                        break;
-                    }
-                }
+                if (time < Map.SliderVelocities[i].StartTime)
+                    break;
             }
 
-            return curPos;
+            return GetPositionFromTime(time, i);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -143,6 +143,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public double CurrentAudioPosition { get; private set; }
 
         /// <summary>
+        ///     Current audio position with song, user and visual offset values applied.
+        /// </summary>
+        public double CurrentVisualPosition { get; private set; }
+
+        /// <summary>
         ///     A mapping from hit objects to the associated hit stats from a replay.
         ///
         ///     Set to null when not applicable (e.g. outside of a replay).
@@ -789,13 +794,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         {
             // Use necessary visual offset
             CurrentAudioPosition = Ruleset.Screen.Timing.Time + ConfigManager.GlobalAudioOffset.Value * AudioEngine.Track.Rate - MapManager.Selected.Value.LocalOffset;
+            CurrentVisualPosition = CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate;
 
             // Update SV index if necessary. Afterwards update Position.
-            while (CurrentSvIndex < Map.SliderVelocities.Count && CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate >= Map.SliderVelocities[CurrentSvIndex].StartTime)
+            while (CurrentSvIndex < Map.SliderVelocities.Count && CurrentVisualPosition >= Map.SliderVelocities[CurrentSvIndex].StartTime)
             {
                 CurrentSvIndex++;
             }
-            CurrentTrackPosition = GetPositionFromTime(CurrentAudioPosition + ConfigManager.VisualOffset.Value * AudioEngine.Track.Rate, CurrentSvIndex);
+            CurrentTrackPosition = GetPositionFromTime(CurrentVisualPosition, CurrentSvIndex);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -711,7 +711,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public void KillHoldPoolObject(GameplayHitObjectKeys gameplayHitObject, bool setTint = true)
         {
             // Change start time and LN size.
-            gameplayHitObject.InitialTrackPosition = GetPositionFromTime(CurrentAudioPosition);
+            gameplayHitObject.InitialTrackPosition = GetPositionFromTime(CurrentVisualPosition);
             gameplayHitObject.CurrentlyBeingHeld = false;
             gameplayHitObject.UpdateLongNoteSize(gameplayHitObject.InitialTrackPosition);
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -617,7 +617,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             foreach (var lane in DeadNoteLanes)
             {
                 while (lane.Count > 0 &&
-                    (CurrentTrackPosition - lane.Peek().InitialLongNoteTrackPosition > RecycleObjectPosition))
+                    (CurrentTrackPosition - lane.Peek().LatestTrackPosition > RecycleObjectPosition))
                 {
                     RecyclePoolObject(lane.Dequeue());
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -787,6 +787,40 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         }
 
         /// <summary>
+        ///     Returns true if the playfield is going backwards at the given time.
+        /// </summary>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public bool IsSVNegative(double time)
+        {
+            if (ModManager.IsActivated(ModIdentifier.NoSliderVelocity))
+                return false;
+
+            // Find the SV index at time.
+            int i;
+            for (i = 0; i < Map.SliderVelocities.Count; i++)
+            {
+                if (time < Map.SliderVelocities[i].StartTime)
+                    break;
+            }
+
+            i--;
+
+            // Find index of the last non-zero SV.
+            for (; i >= 0; i--)
+            {
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if (Map.SliderVelocities[i].Multiplier != 0)
+                    break;
+            }
+
+            if (i == -1)
+                return Map.InitialScrollVelocity < 0;
+
+            return Map.SliderVelocities[i].Multiplier < 0;
+        }
+
+        /// <summary>
         ///     Update Current position of the hit objects
         /// </summary>
         /// <param name="audioTime"></param>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -784,39 +784,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             if (ModManager.IsActivated(ModIdentifier.NoSliderVelocity))
                 return (long)(time * TrackRounding);
 
-            // Continue if SV is enabled
-            long curPos = 0;
-
-            // Time starts before the first SV point
             if (index == 0)
-                curPos = (long)(time * Map.InitialScrollVelocity * TrackRounding);
-
-            // Time starts after the first SV point and before the last SV point
-            else if (index < VelocityPositionMarkers.Count)
             {
-                // Reference the correct ScrollVelocities index by subracting 1
-                index--;
-
-                // Get position
-                curPos = VelocityPositionMarkers[index];
-                curPos += (long)((time - Map.SliderVelocities[index].StartTime) * Map.SliderVelocities[index].Multiplier * TrackRounding);
+                // Time starts before the first SV point
+                return (long) (time * Map.InitialScrollVelocity * TrackRounding);
             }
 
-            // Time starts after the last SV point
-            else
-            {
-                // Throw exception if index exceeds list size for some reason
-                if (index > VelocityPositionMarkers.Count)
-                    throw new Exception("index exceeds Velocity Position Marker List Size");
+            index--;
 
-                // Reference the correct ScrollVelocities index by subracting 1
-                index--;
-
-                // Get position
-                curPos = VelocityPositionMarkers[index];
-                curPos += (long)((time - Map.SliderVelocities[index].StartTime) * Map.SliderVelocities[index].Multiplier * TrackRounding);
-            }
-
+            var curPos = VelocityPositionMarkers[index];
+            curPos += (long)((time - Map.SliderVelocities[index].StartTime) * Map.SliderVelocities[index].Multiplier * TrackRounding);
             return curPos;
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -468,7 +468,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             foreach (var lane in ActiveNoteLanes)
             {
                 foreach (var hitObject in lane)
-                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
+                    hitObject.UpdateSpritePositions(CurrentTrackPosition, CurrentVisualPosition);
             }
         }
 
@@ -546,7 +546,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             foreach (var lane in HeldLongNoteLanes)
             {
                 foreach (var hitObject in lane)
-                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
+                    hitObject.UpdateSpritePositions(CurrentTrackPosition, CurrentVisualPosition);
             }
         }
 
@@ -628,7 +628,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 foreach (var hitObject in lane)
                 {
-                    hitObject.UpdateSpritePositions(CurrentTrackPosition);
+                    hitObject.UpdateSpritePositions(CurrentTrackPosition, CurrentVisualPosition);
                 }
             }
         }
@@ -645,11 +645,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             for (var i = 0; i < ActiveNoteLanes.Count; i++)
             {
                 foreach (var hitObject in ActiveNoteLanes[i])
-                    hitObject.ForceUpdateLongnote(CurrentTrackPosition);
+                    hitObject.ForceUpdateLongnote(CurrentTrackPosition, CurrentVisualPosition);
                 foreach (var hitObject in DeadNoteLanes[i])
-                    hitObject.ForceUpdateLongnote(CurrentTrackPosition);
+                    hitObject.ForceUpdateLongnote(CurrentTrackPosition, CurrentVisualPosition);
                 foreach (var hitObject in HeldLongNoteLanes[i])
-                    hitObject.ForceUpdateLongnote(CurrentTrackPosition);
+                    hitObject.ForceUpdateLongnote(CurrentTrackPosition, CurrentVisualPosition);
             }
         }
 
@@ -714,7 +714,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Change start time and LN size.
             gameplayHitObject.InitialTrackPosition = GetPositionFromTime(CurrentVisualPosition);
             gameplayHitObject.CurrentlyBeingHeld = false;
-            gameplayHitObject.UpdateLongNoteSize(gameplayHitObject.InitialTrackPosition);
+            gameplayHitObject.UpdateLongNoteSize(CurrentTrackPosition, CurrentVisualPosition);
 
             if (setTint)
                 gameplayHitObject.Kill();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
@@ -1,0 +1,18 @@
+namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys
+{
+    /// <summary>
+    ///     Represents a change in the SV direction (positive to negative or negative to positive).
+    /// </summary>
+    public struct SVDirectionChange
+    {
+        /// <summary>
+        ///     Start time of the SV that changed the direction.
+        /// </summary>
+        public float StartTime;
+
+        /// <summary>
+        ///     Position at the time of the direction change.
+        /// </summary>
+        public long Position;
+    }
+}


### PR DESCRIPTION
[Video](https://cdn.discordapp.com/attachments/526869603515760659/713710244366123098/out.mp4)

LN bodies span from the earliest visible LN position to the latest visible LN position. LN ends are flipped if the LN ends during a negative SV.

Closes #249 at last.

I've tested this a bunch but something may come up as usual so I'll report after playing a session with this.

Unfortunately, this makes a "flashing" gimmick on https://quavergame.com/mapsets/map/11611 broken as it relied on the previous (broken) behavior of the LN rendering (already notified the author).

There's also a certain limitation of the current negative SV implementation that came to my mind: since negative SVs break note position non-decreasing, notes far in the future don't load in even if they should be currently on screen due to negative SVs later on in the map. I guess this isn't a big priority currently but it's something to keep in mind and perhaps make an issue about.