### PR TITLE
Map preview adjustments

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -281,10 +281,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
                 var oldHitpos = skin.HitPosOffsetY;
 
-                if (Ruleset.Screen.IsSongSelectPreview)
-                    skin.HitPosOffsetY = PREVIEW_PLAYFIELD_WIDTH / Ruleset.Map.GetKeyCount();
-                else
-                    skin.HitPosOffsetY *= WindowManager.BaseToVirtualRatio;
+                skin.HitPosOffsetY = LaneSize;
 
                 switch (ScrollDirections[i])
                 {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -279,9 +279,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 else
                     LongNoteSizeAdjustment[i] = holdHitObOffset / 2;
 
-                var oldHitpos = skin.HitPosOffsetY;
-
-                skin.HitPosOffsetY = LaneSize;
 
                 switch (ScrollDirections[i])
                 {
@@ -303,7 +300,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                         throw new Exception($"Scroll Direction in current lane index {i} does not exist.");
                 }
 
-                skin.HitPosOffsetY = oldHitpos;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -279,6 +279,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 else
                     LongNoteSizeAdjustment[i] = holdHitObOffset / 2;
 
+                skin.HitPosOffsetY *= WindowManager.BaseToVirtualRatio;
 
                 switch (ScrollDirections[i])
                 {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -111,8 +111,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             get
             {
-                float PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
-                float ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
+                var PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                var ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
                 if (Screen.IsSongSelectPreview && (PreviewWidth < ColumnWidth))
                     return PreviewWidth;
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -111,10 +111,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             get
             {
-                if (Screen.IsSongSelectPreview)
-                    return PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                float PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                float ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
+                if (Screen.IsSongSelectPreview && (PreviewWidth < ColumnWidth))
+                    return PreviewWidth;
 
-                return SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;;
+                return ColumnWidth;
             }
         }
 


### PR DESCRIPTION
Ok so I messed around a bit trying to fix the positioning of column lighting and hitlighting for the preview (when the columnsize is scaled down) but I couldn't do that.

Instead I did the following:
- added a check so that if the skin's columnsize happens to be narrower than the available space in the preview, then it doesn't use the preview's columnsize, as that makes the skin wider for no reason
- removed the custom preview hitposition, as I don't think it was helping but rather making things worse.

In order for everything to be positioned correctly for different columnsizes, there need to be several things done, for which I will make an issue to list them.

Edit: https://github.com/Quaver/Quaver/issues/2041 probably needs to be resolved before pulling this in order to fix any hitposition scaling issues.