### PR TITLE
Change Time to use frame time instead of audio time

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -161,7 +161,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     Whether to use frame time or audio time for notes.
         /// </summary>
-        internal static Bindable<bool> UseFrameTime { get; private set; }
+        internal static Bindable<bool> SmoothAudioTimingGameplay { get; private set; }
 
         /// <summary>
         ///     Determines if we should show the song time progress display in the
@@ -780,7 +780,7 @@ namespace Quaver.Shared.Config
             FpsCounter = ReadValue(@"FpsCounter", false, data);
             FpsLimiterType = ReadValue(@"FpsLimiterType", FpsLimitType.Unlimited, data);
             CustomFpsLimit = ReadInt(@"CustomFpsLimit", 240, 60, int.MaxValue, data);
-            UseFrameTime = ReadValue(@"UseFrameTime", false, data);
+            SmoothAudioTimingGameplay = ReadValue(@"UseFrameTime", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);
@@ -954,7 +954,7 @@ namespace Quaver.Shared.Config
                     FpsCounter.ValueChanged += AutoSaveConfiguration;
                     FpsLimiterType.ValueChanged += AutoSaveConfiguration;
                     CustomFpsLimit.ValueChanged += AutoSaveConfiguration;
-                    UseFrameTime.ValueChanged += AutoSaveConfiguration;
+                    SmoothAudioTimingGameplay.ValueChanged += AutoSaveConfiguration;
                     DisplaySongTimeProgress.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed4K.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed7K.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -780,7 +780,7 @@ namespace Quaver.Shared.Config
             FpsCounter = ReadValue(@"FpsCounter", false, data);
             FpsLimiterType = ReadValue(@"FpsLimiterType", FpsLimitType.Unlimited, data);
             CustomFpsLimit = ReadInt(@"CustomFpsLimit", 240, 60, int.MaxValue, data);
-            SmoothAudioTimingGameplay = ReadValue(@"UseFrameTime", false, data);
+            SmoothAudioTimingGameplay = ReadValue(@"SmoothAudioTimingGameplay", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -159,6 +159,11 @@ namespace Quaver.Shared.Config
         internal static BindableInt CustomFpsLimit { get; private set; }
 
         /// <summary>
+        ///     Whether to use frame time or audio time for notes.
+        /// </summary>
+        internal static Bindable<bool> UseFrameTime { get; private set; }
+
+        /// <summary>
         ///     Determines if we should show the song time progress display in the
         ///     gameplay screen.
         /// </summary>
@@ -775,6 +780,7 @@ namespace Quaver.Shared.Config
             FpsCounter = ReadValue(@"FpsCounter", false, data);
             FpsLimiterType = ReadValue(@"FpsLimiterType", FpsLimitType.Unlimited, data);
             CustomFpsLimit = ReadInt(@"CustomFpsLimit", 240, 60, int.MaxValue, data);
+            UseFrameTime = ReadValue(@"UseFrameTime", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);
@@ -948,6 +954,7 @@ namespace Quaver.Shared.Config
                     FpsCounter.ValueChanged += AutoSaveConfiguration;
                     FpsLimiterType.ValueChanged += AutoSaveConfiguration;
                     CustomFpsLimit.ValueChanged += AutoSaveConfiguration;
+                    UseFrameTime.ValueChanged += AutoSaveConfiguration;
                     DisplaySongTimeProgress.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed4K.ValueChanged += AutoSaveConfiguration;
                     ScrollSpeed7K.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -38,7 +38,7 @@ namespace Quaver.Shared.Screens.Gameplay
         public double Time { get; set; }
 
         /// <summary>
-        ///     Used to determine when to sync Time when UseFrameTime is on.
+        ///     Used to determine when to sync Time when SmoothAudioTiming is on.
         /// </summary>
         private double PreviousTime { get; set; }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -129,15 +129,16 @@ namespace Quaver.Shared.Screens.Gameplay
             {
                 Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
                 var CheckTime = AudioEngine.Track.Time - OldTime;
-
-                // If Time falls behind the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
-                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
+                
+                // If Time falls behind or goes too far ahead of the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
+                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed || Time > AudioEngine.Track.Time + 16 * AudioEngine.Track.Rate))
                 {
                     Time = AudioEngine.Track.Time;
                     OldTime = AudioEngine.Track.Time;
                 }
 
             }
+
             // Otherwise use AudioEngine time.
             else
             {

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -33,14 +33,19 @@ namespace Quaver.Shared.Screens.Gameplay
         public static int StartDelay { get; } = 3000;
 
         /// <summary>
+        ///     The time in the audio/play.
+        /// </summary>
+        public double Time { get; set; }
+
+        /// <summary>
         ///     Used to determine when to sync Time when UseFrameTime is on.
         /// </summary>
         public double OldTime = 0;
 
         /// <summary>
-        ///     The time in the audio/play.
+        ///     The threshold of milliseconds that Time cannot exceed the audio time when UseFrameTime is on.
         /// </summary>
-        public double Time { get; set; }
+        const int FRAME_TIME = 16;
 
         /// <summary>
         ///     Ctor
@@ -131,7 +136,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 var CheckTime = AudioEngine.Track.Time - OldTime;
                 
                 // If Time falls behind or goes too far ahead of the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
-                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed || Time > AudioEngine.Track.Time + 16 * AudioEngine.Track.Rate))
+                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || Time > AudioEngine.Track.Time + FRAME_TIME * AudioEngine.Track.Rate || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
                 {
                     Time = AudioEngine.Track.Time;
                     OldTime = AudioEngine.Track.Time;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -125,7 +125,7 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             // Use frame time if the option is enabled.
-            if (ConfigManager.SmoothAudioTimingGameplay.Value && !Screen.IsSongSelectPreview)
+            if (ConfigManager.SmoothAudioTimingGameplay.Value)
             {
                 Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
                 var checkTime = AudioEngine.Track.Time - PreviousTime;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -45,7 +45,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     The threshold of milliseconds that Time cannot exceed the audio time when UseFrameTime is on.
         /// </summary>
-        const int FRAME_TIME = 16;
+        private const int THRESHOLD = 16;
 
         /// <summary>
         ///     Ctor
@@ -136,7 +136,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 var CheckTime = AudioEngine.Track.Time - OldTime;
                 
                 // If Time falls behind or goes too far ahead of the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
-                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || Time > AudioEngine.Track.Time + FRAME_TIME * AudioEngine.Track.Rate || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
+                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || Time > AudioEngine.Track.Time + THRESHOLD * AudioEngine.Track.Rate || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
                 {
                     Time = AudioEngine.Track.Time;
                     OldTime = AudioEngine.Track.Time;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -117,7 +117,6 @@ namespace Quaver.Shared.Screens.Gameplay
                 {
                     Screen.HasStarted = true;
                     AudioEngine.Track?.Play();
-                    Time = AudioEngine.Track.Time;
                 }
                 catch (Exception e)
                 {
@@ -132,7 +131,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 var CheckTime = AudioEngine.Track.Time - OldTime;
 
                 // If Time falls behind the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
-                if (Time < AudioEngine.Track.Time || CheckTime >= 1000 || CheckTime <= -1000 || Screen.Failed)
+                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
                 {
                     Time = AudioEngine.Track.Time;
                     OldTime = AudioEngine.Track.Time;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -111,6 +111,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 {
                     Screen.HasStarted = true;
                     AudioEngine.Track?.Play();
+                    Time = AudioEngine.Track.Time;
                 }
                 catch (Exception e)
                 {
@@ -118,13 +119,13 @@ namespace Quaver.Shared.Screens.Gameplay
                 }
             }
 
-            // If the audio track is playing, use that time.
-            if (AudioEngine.Track.IsPlaying)
-                Time = AudioEngine.Track.Time;
+            double PreviousTime = Math.Floor(Time / 1000);
 
-            // Otherwise use deltatime to calculate the proposed time.
-            else
-                Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
+            Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
+
+            // If Time falls behind the audio track and once every second, resync. If Failed, use audio track time for slowdown animation.
+            if (Time < AudioEngine.Track.Time || Math.Floor(Time / 1000) - PreviousTime == 1 || Screen.Failed)
+                Time = AudioEngine.Track.Time;
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -32,6 +32,11 @@ namespace Quaver.Shared.Screens.Gameplay
         public static int StartDelay { get; } = 3000;
 
         /// <summary>
+        ///     Used to calculate when to sync Time.
+        /// </summary>
+        public double OldTime = 0;
+
+        /// <summary>
         ///     The time in the audio/play.
         /// </summary>
         public double Time { get; set; }
@@ -119,13 +124,15 @@ namespace Quaver.Shared.Screens.Gameplay
                 }
             }
 
-            double PreviousTime = Math.Floor(Time / 1000);
 
             Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
 
-            // If Time falls behind the audio track and once every second, resync. If Failed, use audio track time for slowdown animation.
-            if (Time < AudioEngine.Track.Time || Math.Floor(Time / 1000) - PreviousTime == 1 || Screen.Failed)
+            // If Time falls behind the audio track and once a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
+            if (Time < AudioEngine.Track.Time || Math.Floor(AudioEngine.Track.Time / 1000) - OldTime >= 1 || Screen.Failed)
+            {
                 Time = AudioEngine.Track.Time;
+                OldTime = Math.Floor(AudioEngine.Track.Time / 1000);
+            }
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -130,7 +130,7 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             // Use frame time if the option is enabled.
-            if (ConfigManager.UseFrameTime.Value)
+            if (ConfigManager.SmoothAudioTimingGameplay.Value)
             {
                 Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
                 var CheckTime = AudioEngine.Track.Time - OldTime;

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -33,7 +33,7 @@ namespace Quaver.Shared.Screens.Gameplay
         public static int StartDelay { get; } = 3000;
 
         /// <summary>
-        ///     Used to calculate when to sync Time.
+        ///     Used to determine when to sync Time when UseFrameTime is on.
         /// </summary>
         public double OldTime = 0;
 
@@ -125,7 +125,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 }
             }
 
-            // Use frame time if the option is enabled
+            // Use frame time if the option is enabled.
             if (ConfigManager.UseFrameTime.Value)
             {
                 Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
@@ -139,7 +139,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 }
 
             }
-            // Otherwise use AudioEngine time
+            // Otherwise use AudioEngine time.
             else
             {
                 // If the audio track is playing, use that time.

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -121,7 +121,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 try
                 {
                     Screen.HasStarted = true;
-                    AudioEngine.Track?.Play();
+                    AudioEngine.Track.Play();
                 }
                 catch (Exception e)
                 {
@@ -130,21 +130,18 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             // Use frame time if the option is enabled.
-            if (ConfigManager.SmoothAudioTimingGameplay.Value)
+            if (ConfigManager.SmoothAudioTimingGameplay.Value && !Screen.IsSongSelectPreview)
             {
                 Time += gameTime.ElapsedGameTime.TotalMilliseconds * AudioEngine.Track.Rate;
-                var CheckTime = AudioEngine.Track.Time - OldTime;
-                
+                var checkTime = AudioEngine.Track.Time - OldTime;
+
                 // If Time falls behind or goes too far ahead of the audio track or more than a second passes without syncing, resync. If Failed, use audio track time for slowdown animation.
-                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || Time > AudioEngine.Track.Time + THRESHOLD * AudioEngine.Track.Rate || CheckTime >= 1000 || CheckTime <= -1000 || OldTime == 0 || Screen.Failed))
+                if (AudioEngine.Track.IsPlaying && (Time < AudioEngine.Track.Time || Time > AudioEngine.Track.Time + THRESHOLD * AudioEngine.Track.Rate || checkTime >= 1000 || checkTime <= -1000 || OldTime == 0 || Screen.Failed))
                 {
                     Time = AudioEngine.Track.Time;
                     OldTime = AudioEngine.Track.Time;
                 }
-
             }
-
-            // Otherwise use AudioEngine time.
             else
             {
                 // If the audio track is playing, use that time.

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -128,8 +128,7 @@ namespace Quaver.Shared.Screens.Options
                             Tags = new List<string> { "fps", "limited", "unlimited", "vsync", "wayland"}
                         },
                         new OptionsItemCheckbox(containerRect, "Display FPS Counter", ConfigManager.FpsCounter),
-                        new OptionsItemCheckbox(containerRect, "Lower FPS On Inactive Window", ConfigManager.LowerFpsOnWindowInactive),
-                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time (Experimental)", ConfigManager.UseFrameTime)
+                        new OptionsItemCheckbox(containerRect, "Lower FPS On Inactive Window", ConfigManager.LowerFpsOnWindowInactive)
                     })
                 }),
                 new OptionsSection("Audio", UserInterface.OptionsAudio, new List<OptionsSubcategory>
@@ -370,6 +369,10 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("Song Select", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores)
+                    }),
+                    new OptionsSubcategory("Experimental", new List<OptionsItem>()
+                    {
+                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time", ConfigManager.UseFrameTime)
                     }),
                 }),
             };

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -169,7 +169,7 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Experimental", new List<OptionsItem>()
                     {
-                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing In Gameplay", ConfigManager.SmoothAudioTimingGameplay)
+                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay)
                     }),
                 }),
                 new OptionsSection("Gameplay", UserInterface.OptionsGameplay, new List<OptionsSubcategory>

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -166,7 +166,11 @@ namespace Quaver.Shared.Screens.Options
                         {
                             Tags = new List<string> { "linux" }
                         },
-                    })
+                    }),
+                    new OptionsSubcategory("Experimental", new List<OptionsItem>()
+                    {
+                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing In Gameplay", ConfigManager.SmoothAudioTimingGameplay)
+                    }),
                 }),
                 new OptionsSection("Gameplay", UserInterface.OptionsGameplay, new List<OptionsSubcategory>
                 {
@@ -369,10 +373,6 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("Song Select", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores)
-                    }),
-                    new OptionsSubcategory("Experimental", new List<OptionsItem>()
-                    {
-                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time", ConfigManager.SmoothAudioTimingGameplay)
                     }),
                 }),
             };

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -372,7 +372,7 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Experimental", new List<OptionsItem>()
                     {
-                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time", ConfigManager.UseFrameTime)
+                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time", ConfigManager.SmoothAudioTimingGameplay)
                     }),
                 }),
             };

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -128,7 +128,8 @@ namespace Quaver.Shared.Screens.Options
                             Tags = new List<string> { "fps", "limited", "unlimited", "vsync", "wayland"}
                         },
                         new OptionsItemCheckbox(containerRect, "Display FPS Counter", ConfigManager.FpsCounter),
-                        new OptionsItemCheckbox(containerRect, "Lower FPS On Inactive Window", ConfigManager.LowerFpsOnWindowInactive)
+                        new OptionsItemCheckbox(containerRect, "Lower FPS On Inactive Window", ConfigManager.LowerFpsOnWindowInactive),
+                        new OptionsItemCheckbox(containerRect, "Use Frame Time Instead Of Audio Time (Experimental)", ConfigManager.UseFrameTime)
                     })
                 }),
                 new OptionsSection("Audio", UserInterface.OptionsAudio, new List<OptionsSubcategory>


### PR DESCRIPTION
Falling notes no longer rely on bass audio library time, as doing that causes constant stuttering/frameskips. Instead now it only syncs with bass time if the frame time falls behind, once every second (as a fallback in case the frame time runs ahead of audio time), and during the fail animation in order to keep the slowdown animation.

This should result in much smoother frames on high refresh rate monitors.



closes https://github.com/Quaver/Quaver/issues/1684