### PR TITLE
Fix LN end sprite position

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -118,6 +118,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         private float HitPosition { get; set; }
 
         /// <summary>
+        ///     Position for LN ends.
+        /// </summary>
+        private float HoldEndHitPosition { get; set; }
+
+        /// <summary>
         ///     Difference between the actual LN length and the LN body sprite length.
         ///
         ///     LN bodies are drawn from the middle of the start object to the middle of the end object, and this
@@ -232,6 +237,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         {
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
             HitPosition = info.IsLongNote ? playfield.HoldHitPositionY[info.Lane - 1] : playfield.HitPositionY[info.Lane - 1];
+            HoldEndHitPosition = playfield.HoldEndHitPositionY[info.Lane - 1];
             Info = info;
 
             var scale = ConfigManager.GameplayNoteScale.Value / 100f;
@@ -348,6 +354,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         public float GetSpritePosition(long offset, float initialPos) => HitPosition + ((initialPos - offset) * (ScrollDirection.Equals(ScrollDirection.Down) ? -HitObjectManagerKeys.ScrollSpeed : HitObjectManagerKeys.ScrollSpeed) / HitObjectManagerKeys.TrackRounding);
 
         /// <summary>
+        ///     Calculates the position of the end Hit Object with a position offset.
+        /// </summary>
+        /// <returns></returns>
+        public float GetEndSpritePosition(long offset, float initialPos) => HoldEndHitPosition + ((initialPos - offset) * (ScrollDirection.Equals(ScrollDirection.Down) ? -HitObjectManagerKeys.ScrollSpeed : HitObjectManagerKeys.ScrollSpeed) / HitObjectManagerKeys.TrackRounding);
+
+        /// <summary>
         ///     Updates the earliest and latest track positions as well as the current LN body size.
         /// </summary>
         public void UpdateLongNoteSize(long offset, double curTime)
@@ -444,7 +456,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             else
                 LongNoteBodySprite.Y = earliestSpritePosition + LongNoteBodyOffset;
 
-            LongNoteEndSprite.Y = GetSpritePosition(offset, EndTrackPosition);
+            LongNoteEndSprite.Y = GetEndSpritePosition(offset, EndTrackPosition);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -153,6 +153,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         internal float[] HoldHitPositionY { get; private set; }
 
         /// <summary>
+        ///     LN end Target Position relative from the top of the screen.
+        /// </summary>
+        internal float[] HoldEndHitPositionY { get; private set; }
+
+        /// <summary>
         ///     Position for each Timing Line relative from the top of the screen.
         /// </summary>
         internal float[] TimingLinePositionY { get; private set; }
@@ -261,6 +266,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             ColumnLightingPositionY = new float[ScrollDirections.Length];
             HitPositionY = new float[ScrollDirections.Length];
             HoldHitPositionY = new float[ScrollDirections.Length];
+            HoldEndHitPositionY = new float[ScrollDirections.Length];
             TimingLinePositionY = new float[ScrollDirections.Length];
             LongNoteSizeAdjustment = new float[ScrollDirections.Length];
 
@@ -291,12 +297,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                         ColumnLightingPositionY[i] = ReceptorPositionY[i] - skin.ColumnLightingOffsetY - skin.ColumnLightingScale * LaneSize * skin.ColumnLighting.Height / skin.ColumnLighting.Width;
                         HitPositionY[i] = ReceptorPositionY[i] + skin.HitPosOffsetY - hitObOffset;
                         HoldHitPositionY[i] = ReceptorPositionY[i] + skin.HitPosOffsetY - holdHitObOffset;
+                        HoldEndHitPositionY[i] = ReceptorPositionY[i] + skin.HitPosOffsetY - holdEndOffset;
                         TimingLinePositionY[i] = ReceptorPositionY[i] + skin.HitPosOffsetY;
                         break;
                     case ScrollDirection.Up:
                         ReceptorPositionY[i] = skin.ReceptorPosOffsetY;
                         HitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + receptorOffset;
                         HoldHitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + receptorOffset;
+                        HoldEndHitPositionY[i] = ReceptorPositionY[i] - skin.HitPosOffsetY + receptorOffset;
                         ColumnLightingPositionY[i] = ReceptorPositionY[i] + receptorOffset + skin.ColumnLightingOffsetY;
                         TimingLinePositionY[i] = HitPositionY[i];
                         break;


### PR DESCRIPTION
Broke during #2033 where I changed the LN end sprite position from being computed using via offsetting the LN start position by the LN size to being computed directly as the LN size no longer always corresponds to the distance between the LN start and LN end. In particular, this is an issue for skins where the LN start has a different size than the LN end.