### PR TITLE
Make pausing possible using only the configured hotkey

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -648,7 +648,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 return;
 
             // If the pause key is not pressed...
-            if (KeyboardManager.CurrentState.IsKeyUp(Keys.Escape) && KeyboardManager.CurrentState.IsKeyUp(ConfigManager.KeyPause.Value))
+            if (KeyboardManager.CurrentState.IsKeyUp(ConfigManager.KeyPause.Value))
             {
                 if (Failed || IsPlayComplete || IsPaused)
                     return;
@@ -665,7 +665,7 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             // If the pause key was just pressed...
-            if (!IsSongSelectPreview && KeyboardManager.IsUniqueKeyPress(Keys.Escape) || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyPause.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyPause.Value))
             {
                 // Go back to editor if we're currently play testing.
                 if (IsPlayTesting)


### PR DESCRIPTION
It was possible to pause with Esc even when setting pause to another key, and this made Esc unusable when bound to another action.
closes https://github.com/Quaver/Quaver/issues/2053