### PR TITLE
Set IsFixedTimeStep to false for Vsync

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -551,7 +551,7 @@ namespace Quaver.Shared
                     break;
                 case FpsLimitType.Vsync:
                     Graphics.SynchronizeWithVerticalRetrace = true;
-                    IsFixedTimeStep = true;
+                    IsFixedTimeStep = false;
                     WaylandVsync = false;
                     break;
                 case FpsLimitType.WaylandVsync:


### PR DESCRIPTION
Basically turns off the game's fps limiter while Vsync is enabled, the fps limiter isn't needed because Vsync limits fps on its own anyway.
fixes https://github.com/Quaver/Quaver/issues/2048