### PR TITLE
Keep skin's column size if it fits inside the preview

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -114,7 +114,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 // Use skin's ColumnSize if it fits inside the preview, otherwise scale down.
                 var PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
                 var ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
-                if (Screen.IsSongSelectPreview && (PreviewWidth < ColumnWidth))
+                if (Screen.IsSongSelectPreview && PreviewWidth < ColumnWidth)
                     return PreviewWidth;
 
                 return ColumnWidth;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -105,16 +105,19 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         }
 
         /// <summary>
-        ///     The size of the each ane.
+        ///     The size of the each lane.
         /// </summary>
         public float LaneSize
         {
             get
             {
-                if (Screen.IsSongSelectPreview)
-                    return PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                // Use skin's ColumnSize if it fits inside the preview, otherwise scale down.
+                var PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                var ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
+                if (Screen.IsSongSelectPreview && (PreviewWidth < ColumnWidth))
+                    return PreviewWidth;
 
-                return SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;;
+                return ColumnWidth;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -112,12 +112,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             get
             {
                 // Use skin's ColumnSize if it fits inside the preview, otherwise scale down.
-                var PreviewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
-                var ColumnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
-                if (Screen.IsSongSelectPreview && PreviewWidth < ColumnWidth)
-                    return PreviewWidth;
+                var previewWidth = PREVIEW_PLAYFIELD_WIDTH / Screen.Map.GetKeyCount();
+                
+                var columnWidth = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnSize * WindowManager.BaseToVirtualRatio;
+                
+                if (Screen.IsSongSelectPreview && previewWidth < columnWidth)
+                    return previewWidth;
 
-                return ColumnWidth;
+                return columnWidth;
             }
         }
 


### PR DESCRIPTION
If the skin is narrower than the preview space, then it shouldn't scale it.