### PR TITLE
Switch Quaver.Shared to netcoreapp3.1

### DIFF
--- a/Quaver.Shared/Quaver.Shared.csproj
+++ b/Quaver.Shared/Quaver.Shared.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
     <Configurations>Debug;Release;Visual Tests</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
Needed to be able to switch Wobble to netstandard2.1.

Required for https://github.com/Quaver/Wobble/pull/96