### PR TITLE
Make preview hitpos scale with ColumnSize

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -291,7 +291,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 var oldHitpos = skin.HitPosOffsetY;
 
                 if (Ruleset.Screen.IsSongSelectPreview)
-                    skin.HitPosOffsetY = PREVIEW_PLAYFIELD_WIDTH / Ruleset.Map.GetKeyCount();
+                    skin.HitPosOffsetY *= LaneSize / skin.ColumnSize;
                 else
                     skin.HitPosOffsetY *= WindowManager.BaseToVirtualRatio;
 


### PR DESCRIPTION
As mentioned here https://github.com/Quaver/Quaver/issues/2139, there are other variables that should be scaled this way as well.
The old hitposition for the preview was fixed, which broke any bar skin, or skins with custom hitposition. This new formula scales the hitposition correctly for any skin.