### PR TITLE
Change formulas for combo, hiterror and judgement positions in preview

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -273,14 +273,24 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                     case ScrollDirection.Split:
                         playfield.Container.Alignment = Alignment.BotLeft;
                         playfield.Container.Y = -MenuBorder.HEIGHT - Y;
+
+                        if (skin.HitErrorPosY < 0)
+                            playfield.Stage.HitError.Y = skin.HitErrorPosY * 3 / 4;
+
+                        if (skin.JudgementBurstPosY < 0)
+                            playfield.Stage.JudgementHitBurst.OriginalPosY = skin.JudgementBurstPosY * 3 / 4;
+
+                        if (skin.ComboPosY < 0)
+                            playfield.Stage.OriginalComboDisplayY = skin.ComboPosY * 3 / 4;
+
+                        playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
                         break;
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
-                        playfield.Stage.HitError.Y = -skin.HitErrorPosY - MenuBorder.HEIGHT;
-                        playfield.Stage.OriginalComboDisplayY = -skin.ComboPosY - MenuBorder.HEIGHT - filterPanelHeight - Y;
+                        playfield.Stage.HitError.Y = (skin.HitErrorPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
+                        playfield.Stage.JudgementHitBurst.OriginalPosY = (skin.JudgementBurstPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
+                        playfield.Stage.OriginalComboDisplayY = (skin.ComboPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
                         playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
-                        playfield.Stage.JudgementHitBurst.OriginalPosY = skin.JudgementBurstPosY + MenuBorder.HEIGHT - filterPanelHeight - Y;
-                        playfield.Stage.JudgementHitBurst.Y = playfield.Stage.JudgementHitBurst.OriginalPosY;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -267,29 +267,42 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
                 const int filterPanelHeight = 88;
 
+                // Multiplier for preview to move the top half of the elements downwards by 11/15, as that is the amount that is covered by UI.
+                const float previewMultiplier = 11 / 15f;
+
                 switch (scroll.Value)
                 {
                     case ScrollDirection.Down:
                     case ScrollDirection.Split:
                         playfield.Container.Alignment = Alignment.BotLeft;
                         playfield.Container.Y = -MenuBorder.HEIGHT - Y;
+                        
+                        if (playfield.Stage.HitError.Y < 0)
+                            playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (skin.HitErrorPosY < 0)
-                            playfield.Stage.HitError.Y = skin.HitErrorPosY * 3 / 4;
+                        if (playfield.Stage.JudgementHitBurst.OriginalPosY < 0)
+                            playfield.Stage.JudgementHitBurst.OriginalPosY *= previewMultiplier;
 
-                        if (skin.JudgementBurstPosY < 0)
-                            playfield.Stage.JudgementHitBurst.OriginalPosY = skin.JudgementBurstPosY * 3 / 4;
-
-                        if (skin.ComboPosY < 0)
-                            playfield.Stage.OriginalComboDisplayY = skin.ComboPosY * 3 / 4;
+                        if (playfield.Stage.OriginalComboDisplayY < 0)
+                            playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
 
                         playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
                         break;
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
-                        playfield.Stage.HitError.Y = (skin.HitErrorPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
-                        playfield.Stage.JudgementHitBurst.OriginalPosY = (skin.JudgementBurstPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
-                        playfield.Stage.OriginalComboDisplayY = (skin.ComboPosY - filterPanelHeight - MenuBorder.HEIGHT) * 4 / 5;
+                        playfield.Stage.HitError.Y = skin.HitErrorPosY - filterPanelHeight - MenuBorder.HEIGHT;
+                        playfield.Stage.JudgementHitBurst.OriginalPosY = skin.JudgementBurstPosY - filterPanelHeight - MenuBorder.HEIGHT;
+                        playfield.Stage.OriginalComboDisplayY = skin.ComboPosY - filterPanelHeight - MenuBorder.HEIGHT;
+
+                        if (playfield.Stage.HitError.Y < 0)
+                            playfield.Stage.HitError.Y *= previewMultiplier;
+
+                        if (playfield.Stage.JudgementHitBurst.OriginalPosY < 0)
+                            playfield.Stage.JudgementHitBurst.OriginalPosY *= previewMultiplier;
+
+                        if (playfield.Stage.OriginalComboDisplayY < 0)
+                            playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
+
                         playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
                         break;
                     default:

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -290,9 +290,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         break;
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
-                        playfield.Stage.HitError.Y = skin.HitErrorPosY - filterPanelHeight - MenuBorder.HEIGHT;
-                        playfield.Stage.JudgementHitBurst.OriginalPosY = skin.JudgementBurstPosY - filterPanelHeight - MenuBorder.HEIGHT;
-                        playfield.Stage.OriginalComboDisplayY = skin.ComboPosY - filterPanelHeight - MenuBorder.HEIGHT;
+                        playfield.Stage.HitError.Y -= filterPanelHeight + MenuBorder.HEIGHT;
+                        playfield.Stage.JudgementHitBurst.OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
+                        playfield.Stage.OriginalComboDisplayY -= filterPanelHeight + MenuBorder.HEIGHT;
 
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;


### PR DESCRIPTION
This is the best I could come up with so far that tries to keep the positions as similar as gameplay. Ultimately they end up a bit closer together than gameplay, since part of the field is cut off.

It should look much more similar to the gameplay positions on a wide variety of skins, compared to what it used to be. Test it out and see if it works I guess.