### PR TITLE
HitError Fade Time option

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -382,6 +382,11 @@ namespace Quaver.Shared.Config
         /// </summary>
         internal static Bindable<bool> DisplayJudgementCounter { get; private set; }
 
+        /// <summary>
+        /// The amount of time in milliseconds a hit in the hiterror takes to disappear
+        /// </summary>
+        internal static BindableInt HitErrorFadeTime { get; private set; }
+
         /// <summary></summary>
         ///     If true, the user will skip the results screen after quitting the game.
         /// </summary>
@@ -887,6 +892,7 @@ namespace Quaver.Shared.Config
             EditorMetronomePlayHalfBeats = ReadValue(@"EditorMetronomePlayHalfBeats", false, data);
             DisplaySongTimeProgressNumbers = ReadValue(@"DisplaySongTimeProgressNumbers", true, data);
             DisplayJudgementCounter = ReadValue(@"DisplayJudgementCounter", true, data);
+            HitErrorFadeTime = ReadInt(@"HitErrorFadeTime", 1000, 100, 5000, data);
             SkipResultsScreenAfterQuit = ReadValue(@"SkipResultsScreenAfterQuit", false, data);
             DisplayComboAlerts = ReadValue(@"DisplayComboAlerts", true, data);
             LaneCoverTopHeight = ReadInt(@"LaneCoverTopHeight", 25, 0, 75, data);
@@ -1041,6 +1047,7 @@ namespace Quaver.Shared.Config
                     EditorMetronomePlayHalfBeats.ValueChanged += AutoSaveConfiguration;
                     DisplaySongTimeProgressNumbers.ValueChanged += AutoSaveConfiguration;
                     DisplayJudgementCounter.ValueChanged += AutoSaveConfiguration;
+                    HitErrorFadeTime.ValueChanged += AutoSaveConfiguration;
                     SkipResultsScreenAfterQuit.ValueChanged += AutoSaveConfiguration;
                     DisplayComboAlerts.ValueChanged += AutoSaveConfiguration;
                     LaneCoverTopHeight.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -11,6 +11,7 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Enums;
 using Quaver.API.Helpers;
 using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Skinning;
@@ -102,7 +103,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             // Gradually fade out the line.
             foreach (var line in LineObjectPool)
-                line.Alpha = MathHelper.Lerp(line.Alpha, 0, (float) Math.Min(dt / 960, 1));
+                line.Alpha = MathHelper.Lerp(line.Alpha, 0, (float) Math.Min(dt / ConfigManager.HitErrorFadeTime.Value, 1));
 
             // Tween the chevron to the last hit
             if (CurrentLinePoolIndex != -1)

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -31,7 +31,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// <summary>
         ///     The size of the hit error object pool.
         /// </summary>
-        private int PoolSize { get; } = 32;
+        private int PoolSize { get; } = 64;
 
         /// <summary>
         ///     The list of lines that are currently in the hit error.

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -212,6 +212,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Show Spectators", ConfigManager.ShowSpectators),
                         new OptionsItemCheckbox(containerRect, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                         new OptionsItemCheckbox(containerRect, "Display Judgement Counter", ConfigManager.DisplayJudgementCounter),
+                        new OptionsSlider(containerRect, "HitError Fade Time", ConfigManager.HitErrorFadeTime, i => $"{i / 1000f:0.0} secs"),
                         new OptionsItemCheckbox(containerRect, "Enable Combo Alerts", ConfigManager.DisplayComboAlerts),
                         new OptionsItemCheckbox(containerRect, "Enable Accuracy Display Animations", ConfigManager.SmoothAccuracyChanges),
                     }),

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -212,7 +212,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Show Spectators", ConfigManager.ShowSpectators),
                         new OptionsItemCheckbox(containerRect, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                         new OptionsItemCheckbox(containerRect, "Display Judgement Counter", ConfigManager.DisplayJudgementCounter),
-                        new OptionsSlider(containerRect, "HitError Fade Time", ConfigManager.HitErrorFadeTime, i => $"{i / 1000f:0.0} secs"),
+                        new OptionsSlider(containerRect, "Hit Error Fade Time", ConfigManager.HitErrorFadeTime, i => $"{i / 1000f:0.0} sec"),
                         new OptionsItemCheckbox(containerRect, "Enable Combo Alerts", ConfigManager.DisplayComboAlerts),
                         new OptionsItemCheckbox(containerRect, "Enable Accuracy Display Animations", ConfigManager.SmoothAccuracyChanges),
                     }),


### PR DESCRIPTION
Adds a new option enabling the user to customize the duration of each HitError hits

Also increases the amount of simultaneous hits on display, could debatably be an (advanced) option too.

Warning: I'm not currently sure about the fact that it's measured in milliseconds, it seems like the hits nearly last 8 seconds with a 4 seconds setting. Need to know what the base value "960" was doing.