### PR TITLE
Song select rate bindings

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -657,6 +657,16 @@ namespace Quaver.Shared.Config
         internal static Bindable<Keys> KeyToggleOverlay { get; private set; }
 
         /// <summary>
+        ///     The key to decrease the gameplay rate while in song select
+        /// </summary>
+        internal static Bindable<Keys> KeyDecreaseGameplayAudioRate { get; private set; }
+
+        /// <summary>
+        ///     The key to increase the gameplay rate while in song select
+        /// </summary>
+        internal static Bindable<Keys> KeyIncreaseGameplayAudioRate { get; private set; }
+
+        /// <summary>
         ///     The key pressed to restart the map.
         /// </summary>
         internal static Bindable<Keys> KeyRestartMap { get; private set; }
@@ -868,6 +878,8 @@ namespace Quaver.Shared.Config
             KeySkipIntro = ReadValue(@"KeySkipIntro", Keys.RightAlt, data);
             KeyPause = ReadValue(@"KeyPause", Keys.Escape, data);
             KeyToggleOverlay = ReadValue(@"KeyToggleOverlay", Keys.F8, data);
+            KeyDecreaseGameplayAudioRate = ReadValue(@"KeyDecreaseGameplayAudioRate", Keys.OemPlus, data);
+            KeyIncreaseGameplayAudioRate = ReadValue(@"KeyIncreaseGameplayAudioRate", Keys.OemMinus, data);
             KeyRestartMap = ReadValue(@"KeyRestartMap", Keys.OemTilde, data);
             KeyDecreaseScrollSpeed = ReadValue(@"KeyDecreaseScrollSpeed", Keys.F3, data);
             KeyIncreaseScrollSpeed = ReadValue(@"KeyIncreaseScrollSpeed", Keys.F4, data);
@@ -1025,6 +1037,8 @@ namespace Quaver.Shared.Config
                     KeySkipIntro.ValueChanged += AutoSaveConfiguration;
                     KeyPause.ValueChanged += AutoSaveConfiguration;
                     KeyToggleOverlay.ValueChanged += AutoSaveConfiguration;
+                    KeyDecreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
+                    KeyIncreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
                     KeyRestartMap.ValueChanged += AutoSaveConfiguration;
                     KeyIncreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;
                     KeyDecreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -657,24 +657,14 @@ namespace Quaver.Shared.Config
         internal static Bindable<Keys> KeyToggleOverlay { get; private set; }
 
         /// <summary>
-        ///     The first key to decrease the gameplay rate while in song select
+        ///     The key to decrease the gameplay rate while in song select
         /// </summary>
-        internal static Bindable<Keys> KeyDecreaseGameplayAudioRateK1 { get; private set; }
+        internal static Bindable<Keys> KeyDecreaseGameplayAudioRate { get; private set; }
 
         /// <summary>
-        ///     The first key to increase the gameplay rate while in song select
+        ///     The key to increase the gameplay rate while in song select
         /// </summary>
-        internal static Bindable<Keys> KeyIncreaseGameplayAudioRateK1 { get; private set; }
-
-        /// <summary>
-        ///     The second key to decrease the gameplay rate while in song select
-        /// </summary>
-        internal static Bindable<Keys> KeyDecreaseGameplayAudioRateK2 { get; private set; }
-
-        /// <summary>
-        ///     The second key to increase the gameplay rate while in song select
-        /// </summary>
-        internal static Bindable<Keys> KeyIncreaseGameplayAudioRateK2 { get; private set; }
+        internal static Bindable<Keys> KeyIncreaseGameplayAudioRate { get; private set; }
 
         /// <summary>
         ///     The key pressed to restart the map.
@@ -888,10 +878,8 @@ namespace Quaver.Shared.Config
             KeySkipIntro = ReadValue(@"KeySkipIntro", Keys.RightAlt, data);
             KeyPause = ReadValue(@"KeyPause", Keys.Escape, data);
             KeyToggleOverlay = ReadValue(@"KeyToggleOverlay", Keys.F8, data);
-            KeyDecreaseGameplayAudioRateK1 = ReadValue(@"KeyDecreaseGameplayAudioRateK1", Keys.OemMinus, data);
-            KeyIncreaseGameplayAudioRateK1 = ReadValue(@"KeyIncreaseGameplayAudioRateK1", Keys.OemPlus, data);
-            KeyDecreaseGameplayAudioRateK2 = ReadValue(@"KeyDecreaseGameplayAudioRateK2", Keys.Subtract, data);
-            KeyIncreaseGameplayAudioRateK2 = ReadValue(@"KeyIncreaseGameplayAudioRateK2", Keys.Add, data);
+            KeyDecreaseGameplayAudioRate = ReadValue(@"KeyDecreaseGameplayAudioRate", Keys.OemMinus, data);
+            KeyIncreaseGameplayAudioRate = ReadValue(@"KeyIncreaseGameplayAudioRate", Keys.OemPlus, data);
             KeyRestartMap = ReadValue(@"KeyRestartMap", Keys.OemTilde, data);
             KeyDecreaseScrollSpeed = ReadValue(@"KeyDecreaseScrollSpeed", Keys.F3, data);
             KeyIncreaseScrollSpeed = ReadValue(@"KeyIncreaseScrollSpeed", Keys.F4, data);
@@ -1049,10 +1037,8 @@ namespace Quaver.Shared.Config
                     KeySkipIntro.ValueChanged += AutoSaveConfiguration;
                     KeyPause.ValueChanged += AutoSaveConfiguration;
                     KeyToggleOverlay.ValueChanged += AutoSaveConfiguration;
-                    KeyDecreaseGameplayAudioRateK1.ValueChanged += AutoSaveConfiguration;
-                    KeyIncreaseGameplayAudioRateK1.ValueChanged += AutoSaveConfiguration;
-                    KeyDecreaseGameplayAudioRateK2.ValueChanged += AutoSaveConfiguration;
-                    KeyIncreaseGameplayAudioRateK2.ValueChanged += AutoSaveConfiguration;
+                    KeyDecreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
+                    KeyIncreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
                     KeyRestartMap.ValueChanged += AutoSaveConfiguration;
                     KeyIncreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;
                     KeyDecreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -657,14 +657,24 @@ namespace Quaver.Shared.Config
         internal static Bindable<Keys> KeyToggleOverlay { get; private set; }
 
         /// <summary>
-        ///     The key to decrease the gameplay rate while in song select
+        ///     The first key to decrease the gameplay rate while in song select
         /// </summary>
-        internal static Bindable<Keys> KeyDecreaseGameplayAudioRate { get; private set; }
+        internal static Bindable<Keys> KeyDecreaseGameplayAudioRateK1 { get; private set; }
 
         /// <summary>
-        ///     The key to increase the gameplay rate while in song select
+        ///     The first key to increase the gameplay rate while in song select
         /// </summary>
-        internal static Bindable<Keys> KeyIncreaseGameplayAudioRate { get; private set; }
+        internal static Bindable<Keys> KeyIncreaseGameplayAudioRateK1 { get; private set; }
+
+        /// <summary>
+        ///     The second key to decrease the gameplay rate while in song select
+        /// </summary>
+        internal static Bindable<Keys> KeyDecreaseGameplayAudioRateK2 { get; private set; }
+
+        /// <summary>
+        ///     The second key to increase the gameplay rate while in song select
+        /// </summary>
+        internal static Bindable<Keys> KeyIncreaseGameplayAudioRateK2 { get; private set; }
 
         /// <summary>
         ///     The key pressed to restart the map.
@@ -878,8 +888,10 @@ namespace Quaver.Shared.Config
             KeySkipIntro = ReadValue(@"KeySkipIntro", Keys.RightAlt, data);
             KeyPause = ReadValue(@"KeyPause", Keys.Escape, data);
             KeyToggleOverlay = ReadValue(@"KeyToggleOverlay", Keys.F8, data);
-            KeyDecreaseGameplayAudioRate = ReadValue(@"KeyDecreaseGameplayAudioRate", Keys.OemPlus, data);
-            KeyIncreaseGameplayAudioRate = ReadValue(@"KeyIncreaseGameplayAudioRate", Keys.OemMinus, data);
+            KeyDecreaseGameplayAudioRateK1 = ReadValue(@"KeyDecreaseGameplayAudioRateK1", Keys.OemMinus, data);
+            KeyIncreaseGameplayAudioRateK1 = ReadValue(@"KeyIncreaseGameplayAudioRateK1", Keys.OemPlus, data);
+            KeyDecreaseGameplayAudioRateK2 = ReadValue(@"KeyDecreaseGameplayAudioRateK2", Keys.Subtract, data);
+            KeyIncreaseGameplayAudioRateK2 = ReadValue(@"KeyIncreaseGameplayAudioRateK2", Keys.Add, data);
             KeyRestartMap = ReadValue(@"KeyRestartMap", Keys.OemTilde, data);
             KeyDecreaseScrollSpeed = ReadValue(@"KeyDecreaseScrollSpeed", Keys.F3, data);
             KeyIncreaseScrollSpeed = ReadValue(@"KeyIncreaseScrollSpeed", Keys.F4, data);
@@ -1037,8 +1049,10 @@ namespace Quaver.Shared.Config
                     KeySkipIntro.ValueChanged += AutoSaveConfiguration;
                     KeyPause.ValueChanged += AutoSaveConfiguration;
                     KeyToggleOverlay.ValueChanged += AutoSaveConfiguration;
-                    KeyDecreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
-                    KeyIncreaseGameplayAudioRate.ValueChanged += AutoSaveConfiguration;
+                    KeyDecreaseGameplayAudioRateK1.ValueChanged += AutoSaveConfiguration;
+                    KeyIncreaseGameplayAudioRateK1.ValueChanged += AutoSaveConfiguration;
+                    KeyDecreaseGameplayAudioRateK2.ValueChanged += AutoSaveConfiguration;
+                    KeyIncreaseGameplayAudioRateK2.ValueChanged += AutoSaveConfiguration;
                     KeyRestartMap.ValueChanged += AutoSaveConfiguration;
                     KeyIncreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;
                     KeyDecreaseScrollSpeed.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -345,6 +345,11 @@ namespace Quaver.Shared.Screens.Options
                     {
                         new OptionsItemKeybind(containerRect, "Toggle Chat Overlay", ConfigManager.KeyToggleOverlay)
                     }),
+                    new OptionsSubcategory("Song Selection", new List<OptionsItem>()
+                    {
+                        new OptionsItemKeybind(containerRect, "Decrease Gameplay Rate", ConfigManager.KeyDecreaseGameplayAudioRate),
+                        new OptionsItemKeybind(containerRect, "Increase Gameplay Rate", ConfigManager.KeyIncreaseGameplayAudioRate),
+                    }),
                     new OptionsSubcategory("Editor", new List<OptionsItem>()
                     {
                         new OptionsItemKeybind(containerRect, "Pause/Play Track", ConfigManager.KeyEditorPausePlay),

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -347,8 +347,16 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Song Selection", new List<OptionsItem>()
                     {
-                        new OptionsItemKeybind(containerRect, "Decrease Gameplay Rate", ConfigManager.KeyDecreaseGameplayAudioRate),
-                        new OptionsItemKeybind(containerRect, "Increase Gameplay Rate", ConfigManager.KeyIncreaseGameplayAudioRate),
+                        new OptionsItemKeybindMultiple(containerRect, "Decrease Gameplay Rate", new List<Bindable<Keys>>()
+                        {
+                            ConfigManager.KeyDecreaseGameplayAudioRateK1,
+                            ConfigManager.KeyDecreaseGameplayAudioRateK2,
+                        }),
+                        new OptionsItemKeybindMultiple(containerRect, "Increase Gameplay Rate", new List<Bindable<Keys>>()
+                        {
+                            ConfigManager.KeyIncreaseGameplayAudioRateK1,
+                            ConfigManager.KeyIncreaseGameplayAudioRateK2,
+                        }),
                     }),
                     new OptionsSubcategory("Editor", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -347,16 +347,8 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Song Selection", new List<OptionsItem>()
                     {
-                        new OptionsItemKeybindMultiple(containerRect, "Decrease Gameplay Rate", new List<Bindable<Keys>>()
-                        {
-                            ConfigManager.KeyDecreaseGameplayAudioRateK1,
-                            ConfigManager.KeyDecreaseGameplayAudioRateK2,
-                        }),
-                        new OptionsItemKeybindMultiple(containerRect, "Increase Gameplay Rate", new List<Bindable<Keys>>()
-                        {
-                            ConfigManager.KeyIncreaseGameplayAudioRateK1,
-                            ConfigManager.KeyIncreaseGameplayAudioRateK2,
-                        }),
+                        new OptionsItemKeybind(containerRect, "Decrease Gameplay Rate", ConfigManager.KeyDecreaseGameplayAudioRate),
+                        new OptionsItemKeybind(containerRect, "Increase Gameplay Rate", ConfigManager.KeyIncreaseGameplayAudioRate),
                     }),
                     new OptionsSubcategory("Editor", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -352,11 +352,13 @@ namespace Quaver.Shared.Screens.Select
                 return;
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK1.Value)
+                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK2.Value))
                 ModManager.AddSpeedMods(GetNextRate(true));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK1.Value)
+                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK2.Value))
                 ModManager.AddSpeedMods(GetNextRate(false));
 
             // Change from pitched to non-pitched

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -352,11 +352,11 @@ namespace Quaver.Shared.Screens.Select
                 return;
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(Keys.OemPlus) || KeyboardManager.IsUniqueKeyPress(Keys.Add))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(true));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(Keys.OemMinus) || KeyboardManager.IsUniqueKeyPress(Keys.Subtract))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(false));
 
             // Change from pitched to non-pitched

--- a/Quaver.Shared/Screens/Select/SelectScreen.cs
+++ b/Quaver.Shared/Screens/Select/SelectScreen.cs
@@ -352,13 +352,11 @@ namespace Quaver.Shared.Screens.Select
                 return;
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK1.Value)
-                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK2.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(true));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK1.Value)
-                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK2.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(false));
 
             // Change from pitched to non-pitched

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -440,11 +440,11 @@ namespace Quaver.Shared.Screens.Selection
                             KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift);
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(Keys.OemPlus) || KeyboardManager.IsUniqueKeyPress(Keys.Add))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(true, !shiftHeld));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(Keys.OemMinus) || KeyboardManager.IsUniqueKeyPress(Keys.Subtract))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(false, !shiftHeld));
 
             // Change from pitched to non-pitched

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -440,11 +440,13 @@ namespace Quaver.Shared.Screens.Selection
                             KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift);
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK1.Value)
+                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK2.Value))
                 ModManager.AddSpeedMods(GetNextRate(true, !shiftHeld));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK1.Value)
+                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK2.Value))
                 ModManager.AddSpeedMods(GetNextRate(false, !shiftHeld));
 
             // Change from pitched to non-pitched

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -440,13 +440,11 @@ namespace Quaver.Shared.Screens.Selection
                             KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift);
 
             // Increase rate.
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK1.Value)
-                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRateK2.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(true, !shiftHeld));
 
             // Decrease Rate
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK1.Value)
-                || KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRateK2.Value))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseGameplayAudioRate.Value))
                 ModManager.AddSpeedMods(GetNextRate(false, !shiftHeld));
 
             // Change from pitched to non-pitched


### PR DESCRIPTION
Added keybinds for rating a song.

There are two choices :
1- Pull as-is, and get two keybinds per option and keep the default ones (Add, + and Substract, -), but it forces to set two keybinds in the options
2- Revert the second commit, **unmix the default keys OemMinus and OemPlus because they're mixed up in the older version**, then pull to get only one keybind per option (defaulting to the Oem keys. But you could prefer Add and Subtract, I picked it at random)