### PR TITLE
Fix difficulty seek bar not changing when removing rate modifiers.

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -13,6 +13,7 @@ using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Graphics.Graphs;
 using Quaver.Shared.Graphics.Menu.Border;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Scheduling;
@@ -421,15 +422,19 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         /// <param name="e"></param>
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
-            if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
-                || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
+            var isNone = e.ChangedMods.HasFlag(ModIdentifier.None);
+            if (!isNone)
             {
-                return;
+                if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
+                    || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
+                {
+                    return;
+                }
             }
 
             var isSpeedMod = e.ChangedMods >= ModIdentifier.Speed05X && e.ChangedMods <= ModIdentifier.Speed20X ||
                              e.ChangedMods >= ModIdentifier.Speed055X && e.ChangedMods <= ModIdentifier.Speed095X ||
-                             e.ChangedMods >= ModIdentifier.Speed105X && e.ChangedMods <= ModIdentifier.Speed195X;
+                             e.ChangedMods >= ModIdentifier.Speed105X && e.ChangedMods <= ModIdentifier.Speed195X || isNone;
 
             if (isSpeedMod)
             {

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -423,13 +423,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
             var isNone = e.ChangedMods.HasFlag(ModIdentifier.None);
+
             if (!isNone)
             {
-                if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop)
-                    || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
-                {
+                if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop) || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
                     return;
-                }
             }
 
             var isSpeedMod = e.ChangedMods >= ModIdentifier.Speed05X && e.ChangedMods <= ModIdentifier.Speed20X ||


### PR DESCRIPTION
This fixes the NPS graph not updating when you change the rate back to 1.0x from any other rate.

Fixes #1690 