### PR TITLE
SV workflow improvements

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -209,8 +209,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 var currentPoint = Screen.WorkingMap.GetScrollVelocityAt(Screen.Track.Time);
                 if (currentPoint != null)
                 {
-                    SelectedScrollVelocities.Add(currentPoint);
                     NeedsToScrollToLastSelectedSv = true;
+                    if (!SelectedScrollVelocities.Contains(currentPoint))
+                        SelectedScrollVelocities.Add(currentPoint);
                 }
             }
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -92,9 +92,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// </summary>
         protected override void RenderImguiLayout()
         {
-            ImGui.SetNextWindowSize(new Vector2(356, 480));
+            ImGui.SetNextWindowSizeConstraints(new Vector2(356, 0), new Vector2(356, float.MaxValue));
             ImGui.PushFont(Options.Fonts.First().Context);
-            ImGui.Begin(Name, ImGuiWindowFlags.NoResize);
+            ImGui.Begin(Name);
 
             DrawHeaderText();
             ImGui.Dummy(new Vector2(0, 10));

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -374,8 +374,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                             var max = SelectedScrollVelocities.OrderBy(v => v.StartTime).Last().StartTime;
                             if (sv.StartTime < min || sv.StartTime > max)
                             {
-                                min = Math.Min(min, sv.StartTime);
-                                max = Math.Max(max, sv.StartTime);
+                                min = Math.Min(max, sv.StartTime);
+                                max = Math.Max(min, sv.StartTime);
                                 var svsInRange = Screen.WorkingMap.SliderVelocities.Where(v => v.StartTime >= min && v.StartTime <= max);
                                 SelectedScrollVelocities.AddRange(svsInRange);
                             }

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -53,6 +53,10 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
         /// <summary>
         /// </summary>
+        private SliderVelocityInfo SvToScrollTo { get; set; }
+
+        /// <summary>
+        /// </summary>
         private List<SliderVelocityInfo> SelectedScrollVelocities { get; } = new List<SliderVelocityInfo>();
 
         /// <summary>
@@ -99,7 +103,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             DrawHeaderText();
             ImGui.Dummy(new Vector2(0, 10));
 
-            DrawSelectCurrentSVButton();
+            DrawGoToCurrentSVButton();
 
             DrawAddButton();
             ImGui.SameLine();
@@ -154,8 +158,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
                 Screen.ActionManager.PlaceScrollVelocity(sv);
                 SelectedScrollVelocities.Add(sv);
+                SvToScrollTo = sv;
                 NeedsToScroll = true;
-                ImGui.SetKeyboardFocusHere(3); // Focus second input after the button, which is the multiplier
+                ImGui.SetKeyboardFocusHere(3); // Focus third input after the button, which is the multiplier
             }
         }
 
@@ -179,29 +184,36 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 if (newPoint != null)
                 {
                     if (!SelectedScrollVelocities.Contains(newPoint))
+                    {
                         SelectedScrollVelocities.Add(newPoint);
+                        SvToScrollTo = newPoint;
+                    }
                 }
                 else if (Screen.WorkingMap.SliderVelocities.Count > 0)
                 {
                     var point = Screen.WorkingMap.SliderVelocities.First();
 
                     if (!SelectedScrollVelocities.Contains(point))
+                    {
                         SelectedScrollVelocities.Add(point);
+                        SvToScrollTo = point;
+                    }
                 }
 
                 NeedsToScroll = true;
             }
         }
 
-        private void DrawSelectCurrentSVButton()
+        /// <summary>
+        /// </summary>
+        private void DrawGoToCurrentSVButton()
         {
-            if (ImGui.Button("Select current SV"))
+            if (ImGui.Button("Go to current SV"))
             {
                 var currentPoint = Screen.WorkingMap.GetScrollVelocityAt(Screen.Track.Time);
                 if (currentPoint != null)
                 {
-                    SelectedScrollVelocities.Clear();
-                    SelectedScrollVelocities.Add(currentPoint);
+                    SvToScrollTo = currentPoint;
                     NeedsToScroll = true;
                 }
             }
@@ -307,7 +319,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (NeedsToScroll && SelectedScrollVelocities.Count != 0 && Screen.WorkingMap.TimingPoints.Count == 0)
             {
-                ImGui.SetScrollHereY(-0.05f);
+                ImGui.SetScrollHereY(-0.025f);
                 NeedsToScroll = false;
             }
 
@@ -318,9 +330,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 if (!isSelected)
                     ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(100, 100, 100, 0));
 
-                if (NeedsToScroll && SelectedScrollVelocities.Count != 0 && SelectedScrollVelocities.First() == sv)
+                if (NeedsToScroll && SelectedScrollVelocities.Count != 0 && SvToScrollTo == sv)
                 {
-                    ImGui.SetScrollHereY(-0.05f);
+                    ImGui.SetScrollHereY(-0.025f);
                     NeedsToScroll = false;
                 }
 
@@ -454,6 +466,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             Screen.ActionManager.PlaceScrollVelocityBatch(clonedObjects);
             SelectedScrollVelocities.Clear();
             SelectedScrollVelocities.AddRange(clonedObjects);
+
+            SvToScrollTo = clonedObjects.First();
             NeedsToScroll = true;
         }
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -123,7 +123,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             var isHovered = ImGui.IsWindowHovered() || ImGui.IsAnyItemFocused();
 
             ImGui.Dummy(new Vector2(0, 10));
+            DrawSelectedCountLabel();
 
+            ImGui.Dummy(new Vector2(0, 10));
             DrawTable();
 
             IsWindowHovered = IsWindowHovered || isHovered;
@@ -289,6 +291,17 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (ImGui.InputFloat(" ", ref multiplier, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
                 Screen.ActionManager.ChangeScrollVelocityMultiplierBatch(new List<SliderVelocityInfo>(SelectedScrollVelocities), multiplier);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void DrawSelectedCountLabel()
+        {
+            var count = SelectedScrollVelocities.Count;
+            if (count > 1)
+            {
+                ImGui.Text($"{count} scroll velocities selected");
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -99,6 +99,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             DrawHeaderText();
             ImGui.Dummy(new Vector2(0, 10));
 
+            DrawSelectCurrentSVButton();
+
             DrawAddButton();
             ImGui.SameLine();
             DrawRemoveButton();
@@ -146,13 +148,14 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
                 var sv = new SliderVelocityInfo()
                 {
-                    StartTime = (float) Screen.Track.Time,
+                    StartTime = (float)Screen.Track.Time,
                     Multiplier = multiplier
                 };
 
                 Screen.ActionManager.PlaceScrollVelocity(sv);
                 SelectedScrollVelocities.Add(sv);
                 NeedsToScroll = true;
+                ImGui.SetKeyboardFocusHere(3); // Focus second input after the button, which is the multiplier
             }
         }
 
@@ -190,6 +193,19 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             }
         }
 
+        private void DrawSelectCurrentSVButton()
+        {
+            if (ImGui.Button("Select current SV"))
+            {
+                var currentPoint = Screen.WorkingMap.GetScrollVelocityAt(Screen.Track.Time);
+                if (currentPoint != null)
+                {
+                    SelectedScrollVelocities.Clear();
+                    SelectedScrollVelocities.Add(currentPoint);
+                }
+            }
+        }
+
         /// <summary>
         /// </summary>
         private void DrawTimeTextbox()
@@ -207,13 +223,13 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             ImGui.TextWrapped("Time");
 
-            if (ImGui.InputFloat("", ref time, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue))
+            if (ImGui.InputFloat("", ref time, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
             {
                 if (SelectedScrollVelocities.Count == 1)
                 {
                     var sv = SelectedScrollVelocities.First();
 
-                    Screen.ActionManager.ChangeScrollVelocityOffsetBatch(new List<SliderVelocityInfo> {sv},
+                    Screen.ActionManager.ChangeScrollVelocityOffsetBatch(new List<SliderVelocityInfo> { sv },
                         time - sv.StartTime);
                 }
             }
@@ -255,7 +271,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             ImGui.TextWrapped("Multiplier");
 
-            if (ImGui.InputFloat(" ", ref multiplier, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue))
+            if (ImGui.InputFloat(" ", ref multiplier, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
                 Screen.ActionManager.ChangeScrollVelocityMultiplierBatch(new List<SliderVelocityInfo>(SelectedScrollVelocities), multiplier);
         }
 
@@ -276,8 +292,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             ImGui.TextWrapped("Time");
             ImGui.NextColumn();
             ImGui.TextWrapped("Multiplier");
-            ImGui.Columns();
             ImGui.Separator();
+            ImGui.Columns();
         }
 
         /// <summary>
@@ -288,7 +304,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             ImGui.Columns(2);
             ImGui.SetColumnWidth(0, 160);
 
-            if (NeedsToScroll && SelectedScrollVelocities.Count != 0  && Screen.WorkingMap.TimingPoints.Count == 0)
+            if (NeedsToScroll && SelectedScrollVelocities.Count != 0 && Screen.WorkingMap.TimingPoints.Count == 0)
             {
                 ImGui.SetScrollHereY(-0.05f);
                 NeedsToScroll = false;
@@ -375,6 +391,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.V))
                 PasteClipboard();
+
         }
 
         /// <summary>
@@ -403,7 +420,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         {
             var clonedObjects = new List<SliderVelocityInfo>();
 
-            var difference = (int) Math.Round(Screen.Track.Time - Clipboard.First().StartTime, MidpointRounding.AwayFromZero);
+            var difference = (int)Math.Round(Screen.Track.Time - Clipboard.First().StartTime, MidpointRounding.AwayFromZero);
 
             foreach (var obj in Clipboard)
             {

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -336,6 +336,21 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                                 SelectedScrollVelocities.Add(sv);
                         }
                     }
+                    else if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift))
+                    {
+                        if (SelectedScrollVelocities.Count > 0)
+                        {
+                            var min = SelectedScrollVelocities.OrderBy(v => v.StartTime).First().StartTime;
+                            var max = SelectedScrollVelocities.OrderBy(v => v.StartTime).Last().StartTime;
+                            if (sv.StartTime < min || sv.StartTime > max)
+                            {
+                                min = Math.Min(min, sv.StartTime);
+                                max = Math.Max(max, sv.StartTime);
+                                var svsInRange = Screen.WorkingMap.SliderVelocities.Where(v => v.StartTime >= min && v.StartTime <= max);
+                                SelectedScrollVelocities.AddRange(svsInRange);
+                            }
+                        }
+                    }
                     else
                     {
                         if (isSelected)

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -103,7 +103,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             DrawHeaderText();
             ImGui.Dummy(new Vector2(0, 10));
 
-            DrawGoToCurrentSVButton();
+            DrawSelectCurrentSVButton();
             ImGui.Dummy(new Vector2(0, 10));
 
             DrawAddButton();
@@ -200,9 +200,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
         /// <summary>
         /// </summary>
-        private void DrawGoToCurrentSVButton()
+        private void DrawSelectCurrentSVButton()
         {
-            if (ImGui.Button("Go to current SV"))
+            if (ImGui.Button("Select current SV"))
             {
                 var currentPoint = Screen.WorkingMap.GetScrollVelocityAt(Screen.Track.Time);
                 if (currentPoint != null)

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -382,17 +382,20 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                     // User holds down shift, so range select if the clicked element is outside of the bounds of the currently selected points
                     else if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift))
                     {
-                        if (SelectedScrollVelocities.Count > 0)
+                        var sorted = SelectedScrollVelocities.OrderBy(tp => tp.StartTime);
+                        var min = sorted.First().StartTime;
+                        var max = sorted.Last().StartTime;
+                        if (sv.StartTime < min)
                         {
-                            var min = SelectedScrollVelocities.OrderBy(v => v.StartTime).First().StartTime;
-                            var max = SelectedScrollVelocities.OrderBy(v => v.StartTime).Last().StartTime;
-                            if (sv.StartTime < min || sv.StartTime > max)
-                            {
-                                min = Math.Min(max, sv.StartTime);
-                                max = Math.Max(min, sv.StartTime);
-                                var svsInRange = Screen.WorkingMap.SliderVelocities.Where(v => v.StartTime >= min && v.StartTime <= max);
-                                SelectedScrollVelocities.AddRange(svsInRange);
-                            }
+                            var svsInRange = Screen.WorkingMap.SliderVelocities
+                                .Where(v => v.StartTime >= sv.StartTime && v.StartTime <= min);
+                            SelectedScrollVelocities.AddRange(svsInRange);
+                        }
+                        else if (sv.StartTime > max)
+                        {
+                            var svsInRange = Screen.WorkingMap.SliderVelocities
+                                .Where(v => v.StartTime >= max && v.StartTime <= sv.StartTime);
+                            SelectedScrollVelocities.AddRange(svsInRange);
                         }
                     }
                     else

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -104,6 +104,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             ImGui.Dummy(new Vector2(0, 10));
 
             DrawGoToCurrentSVButton();
+            ImGui.Dummy(new Vector2(0, 10));
 
             DrawAddButton();
             ImGui.SameLine();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -412,10 +412,16 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
                 KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
             {
+                // Select all
                 if (KeyboardManager.IsUniqueKeyPress(Keys.A))
                 {
                     SelectedScrollVelocities.Clear();
                     SelectedScrollVelocities.AddRange(Screen.WorkingMap.SliderVelocities);
+                }
+                // Deselect
+                else if (KeyboardManager.IsUniqueKeyPress(Keys.D))
+                {
+                    SelectedScrollVelocities.Clear();
                 }
             }
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -202,6 +202,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 {
                     SelectedScrollVelocities.Clear();
                     SelectedScrollVelocities.Add(currentPoint);
+                    NeedsToScroll = true;
                 }
             }
         }

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -298,10 +298,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         private void DrawSelectedCountLabel()
         {
             var count = SelectedScrollVelocities.Count;
-            if (count > 1)
-            {
-                ImGui.Text($"{count} scroll velocities selected");
-            }
+            var labelText = count > 1 ? $"{count} scroll velocities selected" : "";
+            ImGui.Text(labelText);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -372,8 +372,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                             var max = SelectedTimingPoints.OrderBy(v => v.StartTime).Last().StartTime;
                             if (point.StartTime < min || point.StartTime > max)
                             {
-                                min = Math.Min(min, point.StartTime);
-                                max = Math.Max(max, point.StartTime);
+                                min = Math.Min(max, point.StartTime);
+                                max = Math.Max(min, point.StartTime);
                                 var pointsInRange = Screen.WorkingMap.TimingPoints.Where(v => v.StartTime >= min && v.StartTime <= max);
                                 SelectedTimingPoints.AddRange(pointsInRange);
                             }

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -105,6 +105,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             ImGui.Dummy(new Vector2(0, 10));
 
             DrawGoToCurrentTimingPointButton();
+            ImGui.Dummy(new Vector2(0, 10));
 
             DrawAddButton();
             ImGui.SameLine();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -379,19 +379,22 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                         }
                     }
                     // User holds down shift, so range select if the clicked element is outside of the bounds of the currently selected points
-                    else if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift))
+                    else if ((KeyboardManager.CurrentState.IsKeyDown(Keys.LeftShift) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightShift)) && SelectedTimingPoints.Count > 0)
                     {
-                        if (SelectedTimingPoints.Count > 0)
+                        var sorted = SelectedTimingPoints.OrderBy(tp => tp.StartTime);
+                        var min = sorted.First().StartTime;
+                        var max = sorted.Last().StartTime;
+                        if (point.StartTime < min)
                         {
-                            var min = SelectedTimingPoints.OrderBy(v => v.StartTime).First().StartTime;
-                            var max = SelectedTimingPoints.OrderBy(v => v.StartTime).Last().StartTime;
-                            if (point.StartTime < min || point.StartTime > max)
-                            {
-                                min = Math.Min(max, point.StartTime);
-                                max = Math.Max(min, point.StartTime);
-                                var pointsInRange = Screen.WorkingMap.TimingPoints.Where(v => v.StartTime >= min && v.StartTime <= max);
-                                SelectedTimingPoints.AddRange(pointsInRange);
-                            }
+                            var pointsInRange = Screen.WorkingMap.TimingPoints
+                                .Where(v => v.StartTime >= point.StartTime && v.StartTime <= min);
+                            SelectedTimingPoints.AddRange(pointsInRange);
+                        }
+                        else if (point.StartTime > max)
+                        {
+                            var pointsInRange = Screen.WorkingMap.TimingPoints
+                                .Where(v => v.StartTime >= min && v.StartTime <= point.StartTime);
+                            SelectedTimingPoints.AddRange(pointsInRange);
                         }
                     }
                     else

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -296,10 +296,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         private void DrawSelectedCountLabel()
         {
             var count = SelectedTimingPoints.Count;
-            if (count > 1)
-            {
-                ImGui.Text($"{count} timing points selected");
-            }
+            var labelText = count > 1 ? $"{count} timing points selected" : "";
+            ImGui.Text(labelText);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -124,6 +124,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             var isHovered = ImGui.IsWindowHovered() || ImGui.IsAnyItemFocused();
 
             ImGui.Dummy(new Vector2(0, 10));
+            DrawSelectedCountLabel();
+
+            ImGui.Dummy(new Vector2(0, 10));
             DrawTable();
 
             IsWindowHovered = IsWindowHovered || isHovered;
@@ -285,6 +288,17 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                     Screen.ActionManager.ChangeTimingPointBpm(SelectedTimingPoints.First(), bpm);
                 else
                     Screen.ActionManager.ChangeTimingPointBpmBatch(SelectedTimingPoints, bpm);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        private void DrawSelectedCountLabel()
+        {
+            var count = SelectedTimingPoints.Count;
+            if (count > 1)
+            {
+                ImGui.Text($"{count} timing points selected");
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -104,7 +104,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             DrawHeaderText();
             ImGui.Dummy(new Vector2(0, 10));
 
-            DrawGoToCurrentTimingPointButton();
+            DrawSelectCurrentTimingPointButton();
             ImGui.Dummy(new Vector2(0, 10));
 
             DrawAddButton();
@@ -199,9 +199,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
         /// <summary>
         /// </summary>
-        private void DrawGoToCurrentTimingPointButton()
+        private void DrawSelectCurrentTimingPointButton()
         {
-            if (ImGui.Button("Go to current timing point"))
+            if (ImGui.Button("Select current timing point"))
             {
                 var currentPoint = Screen.WorkingMap.GetTimingPointAt(Screen.Track.Time);
                 if (currentPoint != null)

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -412,10 +412,16 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
                 KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
             {
+                // Select all
                 if (KeyboardManager.IsUniqueKeyPress(Keys.A))
                 {
                     SelectedTimingPoints.Clear();
                     SelectedTimingPoints.AddRange(Screen.WorkingMap.TimingPoints);
+                }
+                // Deselect
+                else if (KeyboardManager.IsUniqueKeyPress(Keys.D))
+                {
+                    SelectedTimingPoints.Clear();
                 }
             }
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -209,8 +209,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 var currentPoint = Screen.WorkingMap.GetTimingPointAt(Screen.Track.Time);
                 if (currentPoint != null)
                 {
-                    SelectedTimingPoints.Add(currentPoint);
                     NeedsToScrollToLastSelectedPoint = true;
+                    if (!SelectedTimingPoints.Contains(currentPoint))
+                        SelectedTimingPoints.Add(currentPoint);
                 }
 
             }


### PR DESCRIPTION
Partially addresses #2319 

- Make the panel vertically resizable
- Range selection with Shift+Click
- Add "Select current SV" button to jump to the current SV (as in current editor timestamp) in the list and add it to the current selection
- Select the "Multiplier" field when creating a new SV
- Deselect all keybind (Ctrl+D)
- All changes also applied to timing points panel