### PR TITLE
Remove Linux audio options

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -808,8 +808,8 @@ namespace Quaver.Shared.Config
             VolumeGlobal = ReadInt(@"VolumeGlobal", 50, 0, 100, data);
             VolumeEffect = ReadInt(@"VolumeEffect", 20, 0, 100, data);
             VolumeMusic = ReadInt(@"VolumeMusic", 50, 0, 100, data);
-            DevicePeriod = ReadInt(@"DevicePeriod", Bass.GetConfig(Configuration.DevicePeriod), 1, 100, data);
-            DeviceBufferLengthMultiplier = ReadInt(@"DeviceBufferLengthMultiplier", Bass.GetConfig(Configuration.DeviceBufferLength) / DevicePeriod.Value, 2, 10, data);
+            DevicePeriod = ReadInt(@"DevicePeriod", 2, 1, 100, data);
+            DeviceBufferLengthMultiplier = ReadInt(@"DeviceBufferLengthMultiplier", 4, 2, 10, data);
             BackgroundBrightness = ReadInt(@"BackgroundBrightness", 50, 0, 100, data);
             WindowHeight = ReadInt(@"WindowHeight", 768, 360, short.MaxValue, data);
             WindowWidth = ReadInt(@"WindowWidth", 1366, 640, short.MaxValue, data);

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -163,18 +163,6 @@ namespace Quaver.Shared.Screens.Options
                            Tags = new List<string> { "speed" }
                        }
                     }),
-                    new OptionsSubcategory("Linux", new List<OptionsItem>()
-                    {
-                        new OptionsSlider(containerRect, "Audio Device Period", ConfigManager.DevicePeriod, i => $"{i} ms")
-                        {
-                            Tags = new List<string> { "linux" }
-                        },
-                        new OptionsItemAudioBufferLength(containerRect, "Audio Device Buffer Length", ConfigManager.DeviceBufferLengthMultiplier,
-                            ConfigManager.DevicePeriod, (multiplier, period) => $"{multiplier * period} ms")
-                        {
-                            Tags = new List<string> { "linux" }
-                        },
-                    }),
                     new OptionsSubcategory("Experimental", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay)


### PR DESCRIPTION
🦀 Options are gone 🦀

After this change things work as they should out of the box with no configuration needed.