### PR TITLE
Remove smooth accuracy option

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -333,11 +333,6 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> DisplayComboAlerts { get; private set; }
 
         /// <summary>
-        ///     If enabled, accuracy display is smoothed.
-        /// </summary>
-        internal static Bindable<bool> SmoothAccuracyChanges { get; private set; }
-
-        /// <summary>
         ///     The scroll speed used in the editor.
         /// </summary>
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
@@ -923,7 +918,6 @@ namespace Quaver.Shared.Config
             LaneCoverTop = ReadValue(@"LaneCoverTop", false, data);
             LaneCoverBottom = ReadValue(@"LaneCoverBottom", false, data);
             UIElementsOverLaneCover = ReadValue(@"UIElementsOverLaneCover", true, data);
-            SmoothAccuracyChanges = ReadValue(@"SmoothAccuracyChanges", true, data);
             EditorVisualizationGraph = ReadValue(@"EditorVisualizationGraph", EditorVisualizationGraphType.Tick, data);
             EditorViewLayers = ReadValue(@"EditorViewLayers", false, data);
             LobbyFilterHasPassword = ReadValue(@"LobbyFilterHasPassword", true, data);
@@ -1082,7 +1076,6 @@ namespace Quaver.Shared.Config
                     LaneCoverBottom.ValueChanged += AutoSaveConfiguration;
                     EditorViewLayers.ValueChanged += AutoSaveConfiguration;
                     UIElementsOverLaneCover.ValueChanged += AutoSaveConfiguration;
-                    SmoothAccuracyChanges.ValueChanged += AutoSaveConfiguration;
                     EditorVisualizationGraph.ValueChanged += AutoSaveConfiguration;
                     LobbyFilterHasPassword.ValueChanged += AutoSaveConfiguration;
                     LobbyFilterFullGame.ValueChanged += AutoSaveConfiguration;

--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -129,15 +129,8 @@ namespace Quaver.Shared.Graphics
                         CurrentValue = TargetValue;
                         break;
                     case NumberDisplayType.Accuracy:
-                        if (ConfigManager.SmoothAccuracyChanges.Value)
-                        {
-                            CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
-                                (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / animTime, 1));
-                        }
-                        else
-                        {
-                            CurrentValue = TargetValue;
-                        }
+                        CurrentValue = MathHelper.Lerp((float) CurrentValue, (float) TargetValue,
+                            (float) Math.Min(gameTime.ElapsedGameTime.TotalMilliseconds / animTime, 1));
                         break;
                     case NumberDisplayType.SongTime:
                         break;

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -215,7 +215,6 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Display Ranked Accuracy With Custom Judgements", ConfigManager.DisplayRankedAccuracy),
                         new OptionsSlider(containerRect, "Hit Error Fade Time", ConfigManager.HitErrorFadeTime, i => $"{i / 1000f:0.0} sec"),
                         new OptionsItemCheckbox(containerRect, "Enable Combo Alerts", ConfigManager.DisplayComboAlerts),
-                        new OptionsItemCheckbox(containerRect, "Enable Accuracy Display Animations", ConfigManager.SmoothAccuracyChanges),
                     }),
                     new OptionsSubcategory("Scoreboard", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -363,7 +363,6 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsBool(this, "Top Lane Cover", ConfigManager.LaneCoverTop),
                     new SettingsBool(this, "Bottom Lane Cover", ConfigManager.LaneCoverBottom),
                     new SettingsBool(this, "Display UI Elements Over Lane Covers", ConfigManager.UIElementsOverLaneCover),
-                    new SettingsBool(this, "Smooth Accuracy Changes", ConfigManager.SmoothAccuracyChanges),
                     new SettingsBool(this, "Enable Battle Royale Background Flashing", ConfigManager.EnableBattleRoyaleBackgroundFlashing),
                     new SettingsBool(this, "Enable Battle Royale Alerts", ConfigManager.EnableBattleRoyaleAlerts),
                     new SettingsBool(this, "Display Unbeatable Scores", ConfigManager.DisplayUnbeatableScoresDuringGameplay),


### PR DESCRIPTION
If someone needs it off then I would argue it's best to unconditionally make it off without an option. But it's currently pretty good after the animation speed-up.