### PR TITLE
Make CreateTimingPoint() for plugins take float values

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -54,7 +54,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="bpm"></param>
         /// <param name="signature"></param>
         /// <returns></returns>
-        public static TimingPointInfo CreateTimingPoint(float startTime, int bpm, TimeSignature signature = TimeSignature.Quadruple)
+        public static TimingPointInfo CreateTimingPoint(float startTime, float bpm, TimeSignature signature = TimeSignature.Quadruple)
         {
             var tp = new TimingPointInfo()
             {

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -54,7 +54,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="bpm"></param>
         /// <param name="signature"></param>
         /// <returns></returns>
-        public static TimingPointInfo CreateTimingPoint(int startTime, int bpm, TimeSignature signature = TimeSignature.Quadruple)
+        public static TimingPointInfo CreateTimingPoint(float startTime, int bpm, TimeSignature signature = TimeSignature.Quadruple)
         {
             var tp = new TimingPointInfo()
             {


### PR DESCRIPTION
It wasn't possible to use float values for creating timing points via plugins, which has been changed.

Fixes #2483