### PR TITLE
Add EditScreen.SetHitObjectSelection() for plugins

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MoonSharp.Interpreter;
 using MoonSharp.Interpreter.Interop;
 using Quaver.API.Enums;
@@ -36,6 +37,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.Remove;
 using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.Reset;
 using Quaver.Shared.Screens.Edit.Components;
+using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.Edit.Actions
 {
@@ -67,7 +69,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <summary>
         ///    Detects if the user has made changes to the map before saving.
         /// </summary>
-        public bool HasUnsavedChanges => UndoStack.Count != 0  && UndoStack.Peek() != LastSaveAction || UndoStack.Count == 0 && LastSaveAction != null;
+        public bool HasUnsavedChanges => UndoStack.Count != 0 && UndoStack.Peek() != LastSaveAction || UndoStack.Count == 0 && LastSaveAction != null;
 
         /// <summary>
         ///     An action manager dedicated for lua plugins
@@ -414,6 +416,26 @@ namespace Quaver.Shared.Screens.Edit.Actions
         public void GoToObjects(string input) => EditScreen.GoToObjects(input);
 
         /// <summary>
+        /// </summary>
+        /// <param name="hitObjects"></param>
+        public void SetHitObjectSelection(List<HitObjectInfo> hitObjects)
+        {
+            EditScreen.SelectedHitObjects.Clear();
+
+            // Only select objects that exist in the map
+            var existingHitObjects = EditScreen.WorkingMap.HitObjects.Where(
+                a => hitObjects.Any(
+                    b => a.StartTime == b.StartTime && a.Lane == b.Lane
+                )
+            ).ToList();
+
+            if (existingHitObjects.Count == 0)
+                return;
+
+            EditScreen.SelectedHitObjects.AddRange(existingHitObjects);
+        }
+
+        /// <summary>
         ///     Detects the BPM of the map and returns the object instance
         /// </summary>
         /// <returns></returns>
@@ -434,88 +456,88 @@ namespace Quaver.Shared.Screens.Edit.Actions
             switch (type)
             {
                 case EditorActionType.PlaceHitObject:
-                    HitObjectPlaced?.Invoke(this, (EditorHitObjectPlacedEventArgs) args);
+                    HitObjectPlaced?.Invoke(this, (EditorHitObjectPlacedEventArgs)args);
                     break;
                 case EditorActionType.RemoveHitObject:
-                    HitObjectRemoved?.Invoke(this, (EditorHitObjectRemovedEventArgs) args);
+                    HitObjectRemoved?.Invoke(this, (EditorHitObjectRemovedEventArgs)args);
                     break;
                 case EditorActionType.ResizeLongNote:
-                    LongNoteResized?.Invoke(this, (EditorLongNoteResizedEventArgs) args);
+                    LongNoteResized?.Invoke(this, (EditorLongNoteResizedEventArgs)args);
                     break;
                 case EditorActionType.RemoveHitObjectBatch:
-                    HitObjectBatchRemoved?.Invoke(this, (EditorHitObjectBatchRemovedEventArgs) args);
+                    HitObjectBatchRemoved?.Invoke(this, (EditorHitObjectBatchRemovedEventArgs)args);
                     break;
                 case EditorActionType.PlaceHitObjectBatch:
-                    HitObjectBatchPlaced?.Invoke(this, (EditorHitObjectBatchPlacedEventArgs) args);
+                    HitObjectBatchPlaced?.Invoke(this, (EditorHitObjectBatchPlacedEventArgs)args);
                     break;
                 case EditorActionType.FlipHitObjects:
-                    HitObjectsFlipped?.Invoke(this, (EditorHitObjectsFlippedEventArgs) args);
+                    HitObjectsFlipped?.Invoke(this, (EditorHitObjectsFlippedEventArgs)args);
                     break;
                 case EditorActionType.MoveHitObjects:
-                    HitObjectsMoved?.Invoke(this, (EditorHitObjectsMovedEventArgs) args);
+                    HitObjectsMoved?.Invoke(this, (EditorHitObjectsMovedEventArgs)args);
                     break;
                 case EditorActionType.AddHitsound:
-                    HitsoundAdded?.Invoke(this, (EditorHitsoundAddedEventArgs) args);
+                    HitsoundAdded?.Invoke(this, (EditorHitsoundAddedEventArgs)args);
                     break;
                 case EditorActionType.RemoveHitsound:
-                    HitsoundRemoved?.Invoke(this, (EditorHitSoundRemovedEventArgs) args);
+                    HitsoundRemoved?.Invoke(this, (EditorHitSoundRemovedEventArgs)args);
                     break;
                 case EditorActionType.CreateLayer:
-                    LayerCreated?.Invoke(this, (EditorLayerCreatedEventArgs) args);
+                    LayerCreated?.Invoke(this, (EditorLayerCreatedEventArgs)args);
                     break;
                 case EditorActionType.RemoveLayer:
-                    LayerDeleted?.Invoke(this, (EditorLayerRemovedEventArgs) args);
+                    LayerDeleted?.Invoke(this, (EditorLayerRemovedEventArgs)args);
                     break;
                 case EditorActionType.RenameLayer:
-                    LayerRenamed?.Invoke(this, (EditorLayerRenamedEventArgs) args);
+                    LayerRenamed?.Invoke(this, (EditorLayerRenamedEventArgs)args);
                     break;
                 case EditorActionType.ColorLayer:
-                    LayerColorChanged?.Invoke(this, (EditorLayerColorChangedEventArgs) args);
+                    LayerColorChanged?.Invoke(this, (EditorLayerColorChangedEventArgs)args);
                     break;
                 case EditorActionType.AddScrollVelocity:
-                    ScrollVelocityAdded?.Invoke(this, (EditorScrollVelocityAddedEventArgs) args);
+                    ScrollVelocityAdded?.Invoke(this, (EditorScrollVelocityAddedEventArgs)args);
                     break;
                 case EditorActionType.RemoveScrollVelocity:
-                    ScrollVelocityRemoved?.Invoke(this, (EditorScrollVelocityRemovedEventArgs) args);
+                    ScrollVelocityRemoved?.Invoke(this, (EditorScrollVelocityRemovedEventArgs)args);
                     break;
                 case EditorActionType.AddScrollVelocityBatch:
-                    ScrollVelocityBatchAdded?.Invoke(this, (EditorScrollVelocityBatchAddedEventArgs) args);
+                    ScrollVelocityBatchAdded?.Invoke(this, (EditorScrollVelocityBatchAddedEventArgs)args);
                     break;
                 case EditorActionType.RemoveScrollVelocityBatch:
-                    ScrollVelocityBatchRemoved?.Invoke(this, (EditorScrollVelocityBatchRemovedEventArgs) args);
+                    ScrollVelocityBatchRemoved?.Invoke(this, (EditorScrollVelocityBatchRemovedEventArgs)args);
                     break;
                 case EditorActionType.AddTimingPoint:
-                    TimingPointAdded?.Invoke(this, (EditorTimingPointAddedEventArgs) args);
+                    TimingPointAdded?.Invoke(this, (EditorTimingPointAddedEventArgs)args);
                     break;
                 case EditorActionType.RemoveTimingPoint:
-                    TimingPointRemoved?.Invoke(this, (EditorTimingPointRemovedEventArgs) args);
+                    TimingPointRemoved?.Invoke(this, (EditorTimingPointRemovedEventArgs)args);
                     break;
                 case EditorActionType.AddTimingPointBatch:
-                    TimingPointBatchAdded?.Invoke(this, (EditorTimingPointBatchAddedEventArgs) args);
+                    TimingPointBatchAdded?.Invoke(this, (EditorTimingPointBatchAddedEventArgs)args);
                     break;
                 case EditorActionType.RemoveTimingPointBatch:
-                    TimingPointBatchRemoved?.Invoke(this, (EditorTimingPointBatchRemovedEventArgs) args);
+                    TimingPointBatchRemoved?.Invoke(this, (EditorTimingPointBatchRemovedEventArgs)args);
                     break;
                 case EditorActionType.ChangePreviewTime:
-                    PreviewTimeChanged?.Invoke(this, (EditorChangedPreviewTimeEventArgs) args);
+                    PreviewTimeChanged?.Invoke(this, (EditorChangedPreviewTimeEventArgs)args);
                     break;
                 case EditorActionType.ChangeTimingPointOffset:
-                    TimingPointOffsetChanged?.Invoke(this, (EditorTimingPointOffsetChangedEventArgs) args);
+                    TimingPointOffsetChanged?.Invoke(this, (EditorTimingPointOffsetChangedEventArgs)args);
                     break;
                 case EditorActionType.ChangeTimingPointBpm:
-                    TimingPointBpmChanged?.Invoke(this, (EditorTimingPointBpmChangedEventArgs) args);
+                    TimingPointBpmChanged?.Invoke(this, (EditorTimingPointBpmChangedEventArgs)args);
                     break;
                 case EditorActionType.ChangeTimingPointBpmBatch:
-                    TimingPointBpmBatchChanged?.Invoke(this, (EditorChangedTimingPointBpmBatchEventArgs) args);
+                    TimingPointBpmBatchChanged?.Invoke(this, (EditorChangedTimingPointBpmBatchEventArgs)args);
                     break;
                 case EditorActionType.ChangeTimingPointOffsetBatch:
-                    TimingPointOffsetBatchChanged?.Invoke(this, (EditorChangedTimingPointOffsetBatchEventArgs) args);
+                    TimingPointOffsetBatchChanged?.Invoke(this, (EditorChangedTimingPointOffsetBatchEventArgs)args);
                     break;
                 case EditorActionType.ChangeScrollVelocityOffsetBatch:
-                    ScrollVelocityOffsetBatchChanged?.Invoke(this, (EditorChangedScrollVelocityOffsetBatchEventArgs) args);
+                    ScrollVelocityOffsetBatchChanged?.Invoke(this, (EditorChangedScrollVelocityOffsetBatchEventArgs)args);
                     break;
                 case EditorActionType.ChangeScrollVelocityMultiplierBatch:
-                    ScrollVelocityMultiplierBatchChanged?.Invoke(this, (EditorChangedScrollVelocityMultiplierBatchEventArgs) args);
+                    ScrollVelocityMultiplierBatchChanged?.Invoke(this, (EditorChangedScrollVelocityMultiplierBatchEventArgs)args);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -138,6 +138,11 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
+        /// <param name="hitObjects"></param>
+        public void SetHitObjectSelection(List<HitObjectInfo> hitObjects) => ActionManager.SetHitObjectSelection(hitObjects);
+
+        /// <summary>
+        /// </summary>
         /// <returns></returns>
         public EditorBpmDetector DetectBpm() => ActionManager.DetectBpm();
 

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -110,7 +110,7 @@ namespace Quaver.Shared.Screens.Edit
         /// <summary>
         ///     All of the available beat snaps to use in the editor.
         /// </summary>
-        public List<int> AvailableBeatSnaps { get; } = new List<int> {1, 2, 3, 4, 6, 8, 12, 16};
+        public List<int> AvailableBeatSnaps { get; } = new List<int> { 1, 2, 3, 4, 6, 8, 12, 16 };
 
         /// <summary>
         /// </summary>
@@ -130,7 +130,7 @@ namespace Quaver.Shared.Screens.Edit
 
         /// <summary>
         /// </summary>
-        public Bindable<bool> EnableMetronome { get; } = ConfigManager.EditorPlayMetronome ?? new Bindable<bool>(true) {Value = true};
+        public Bindable<bool> EnableMetronome { get; } = ConfigManager.EditorPlayMetronome ?? new Bindable<bool>(true) { Value = true };
 
         /// <summary>
         /// </summary>
@@ -138,7 +138,7 @@ namespace Quaver.Shared.Screens.Edit
 
         /// <summary>
         /// </summary>
-        public Bindable<bool> EnableHitsounds { get; } = ConfigManager.EditorEnableHitsounds ?? new Bindable<bool>(true) {Value = true};
+        public Bindable<bool> EnableHitsounds { get; } = ConfigManager.EditorEnableHitsounds ?? new Bindable<bool>(true) { Value = true };
 
         /// <summary>
         /// </summary>
@@ -146,11 +146,11 @@ namespace Quaver.Shared.Screens.Edit
 
         /// <summary>
         /// </summary>
-        public Bindable<bool> ScaleScrollSpeedWithRate { get; } = ConfigManager.EditorScaleSpeedWithRate ?? new Bindable<bool>(true) {Value = true};
+        public Bindable<bool> ScaleScrollSpeedWithRate { get; } = ConfigManager.EditorScaleSpeedWithRate ?? new Bindable<bool>(true) { Value = true };
 
         /// <summary>
         /// </summary>
-        public Bindable<bool> ShowWaveform { get; } = ConfigManager.EditorShowWaveform ?? new Bindable<bool>(true) {Value = true};
+        public Bindable<bool> ShowWaveform { get; } = ConfigManager.EditorShowWaveform ?? new Bindable<bool>(true) { Value = true };
 
         /// <summary>
         /// </summary>
@@ -194,7 +194,7 @@ namespace Quaver.Shared.Screens.Edit
 
         /// <summary>
         /// </summary>
-        public BindableList<HitObjectInfo> SelectedHitObjects { get; } = new BindableList<HitObjectInfo>(new List<HitObjectInfo>());
+        public BindableList<HitObjectInfo> SelectedHitObjects { get; set; } = new BindableList<HitObjectInfo>(new List<HitObjectInfo>());
 
         /// <summary>
         /// </summary>
@@ -244,7 +244,7 @@ namespace Quaver.Shared.Screens.Edit
 
             ActionManager = new EditorActionManager(this, WorkingMap);
             UneditableMap = new Bindable<Qua>(null);
-            Metronome = new Metronome(WorkingMap, Track,  ConfigManager.GlobalAudioOffset ?? new BindableInt(0, -500, 500), MetronomePlayHalfBeats);
+            Metronome = new Metronome(WorkingMap, Track, ConfigManager.GlobalAudioOffset ?? new BindableInt(0, -500, 500), MetronomePlayHalfBeats);
 
             LoadSkin();
             SetHitSoundObjectIndex();
@@ -416,7 +416,7 @@ namespace Quaver.Shared.Screens.Edit
             if (DialogManager.Dialogs.Count != 0)
                 return;
 
-            var view = (EditScreenView) View;
+            var view = (EditScreenView)View;
 
             if (view.IsImGuiHovered)
                 return;
@@ -498,10 +498,10 @@ namespace Quaver.Shared.Screens.Edit
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Up))
                 return;
 
-            var index = (int) CompositionTool.Value;
+            var index = (int)CompositionTool.Value;
 
             if (index - 1 >= 0)
-                CompositionTool.Value = (EditorCompositionTool) index - 1;
+                CompositionTool.Value = (EditorCompositionTool)index - 1;
         }
 
         /// <summary>
@@ -511,11 +511,11 @@ namespace Quaver.Shared.Screens.Edit
             if (!KeyboardManager.IsUniqueKeyPress(Keys.Down))
                 return;
 
-            var index = (int) CompositionTool.Value;
+            var index = (int)CompositionTool.Value;
 
             // - 1 because mines aren't implemented yet
             if (index + 1 < Enum.GetNames(typeof(EditorCompositionTool)).Length - 1)
-                CompositionTool.Value = (EditorCompositionTool) index + 1;
+                CompositionTool.Value = (EditorCompositionTool)index + 1;
         }
 
         /// <summary>
@@ -697,7 +697,7 @@ namespace Quaver.Shared.Screens.Edit
                 if (!KeyboardManager.IsUniqueKeyPress(Keys.D1 + i))
                     continue;
 
-                var time = (int) Math.Round(Track.Time, MidpointRounding.AwayFromZero);
+                var time = (int)Math.Round(Track.Time, MidpointRounding.AwayFromZero);
                 ActionManager.PlaceHitObject(i + 1, time);
             }
         }
@@ -893,7 +893,7 @@ namespace Quaver.Shared.Screens.Edit
             // If no objects are selected, just select the time in the track instead
             if (SelectedHitObjects.Value.Count == 0)
             {
-                cb.SetText($"{(int) Math.Round(Track.Time, MidpointRounding.AwayFromZero)}");
+                cb.SetText($"{(int)Math.Round(Track.Time, MidpointRounding.AwayFromZero)}");
                 return;
             }
 
@@ -922,7 +922,7 @@ namespace Quaver.Shared.Screens.Edit
 
             var clonedObjects = new List<HitObjectInfo>();
 
-            var difference = (int) Math.Round(Track.Time - Clipboard.First().StartTime, MidpointRounding.AwayFromZero);
+            var difference = (int)Math.Round(Track.Time - Clipboard.First().StartTime, MidpointRounding.AwayFromZero);
 
             foreach (var h in Clipboard)
             {
@@ -1218,7 +1218,7 @@ namespace Quaver.Shared.Screens.Edit
                 map.NewlyCreated = true;
 
                 // Create a new mapset from the map
-                var mapset = MapsetHelper.ConvertMapsToMapsets(new List<Map> {map}).First();
+                var mapset = MapsetHelper.ConvertMapsToMapsets(new List<Map> { map }).First();
                 map.Mapset = mapset;
 
                 // Make sure the mapset is loaded
@@ -1343,7 +1343,7 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         /// <returns></returns>
         public override UserClientStatus GetClientStatus() => new UserClientStatus(ClientStatus.Editing, Map.MapId, "",
-            (byte) WorkingMap.Mode, $"{Map.Artist} - {Map.Title} [{Map.DifficultyName}]", 0);
+            (byte)WorkingMap.Mode, $"{Map.Artist} - {Map.Title} [{Map.DifficultyName}]", 0);
 
         /// <summary>
         ///     Returns if the user is able to seek through the track
@@ -1352,7 +1352,7 @@ namespace Quaver.Shared.Screens.Edit
         /// <returns></returns>
         private bool CanSeek()
         {
-            var view = (EditScreenView) View;
+            var view = (EditScreenView)View;
             return !view.Layers.IsHovered();
         }
 
@@ -1364,7 +1364,7 @@ namespace Quaver.Shared.Screens.Edit
             {
                 DiscordHelper.Presence.Details = WorkingMap.ToString();
                 DiscordHelper.Presence.State = "Editing";
-                DiscordHelper.Presence.StartTimestamp = (long) (TimeHelper.GetUnixTimestampMilliseconds() / 1000);
+                DiscordHelper.Presence.StartTimestamp = (long)(TimeHelper.GetUnixTimestampMilliseconds() / 1000);
                 DiscordHelper.Presence.EndTimestamp = 0;
                 DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
                 DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(WorkingMap.Mode).ToLower();


### PR DESCRIPTION
This allows setting the current selection without relying on the EditScreen.GoToObjects() function.

Test plugin used to verify:

```lua
function draw()
    imgui.Begin("Test")

    imgui.TextWrapped(
        "Uses the bundled HyuN - Princess of Winter [Easy] to test")

    imgui.TextWrapped(
        "The button tries to set the first 4 notes of the map and a note that doesn't exist in the map")

    imgui.TextWrapped(
        "Ideally, only the first 4 notes should be set. The list at the bottom can be used to verify.")

    if imgui.Button("Test Selection") then

        -- 609|4,1065|2,1674|3,2284|4
        local objectsToSelect = {
            utils.CreateHitObject(609, 4), -- exists in map
            utils.CreateHitObject(1065, 2), -- exists in map
            utils.CreateHitObject(1674, 3), -- exists in map
            utils.CreateHitObject(2284, 4), -- exists in map
            utils.CreateHitObject(0, 1) -- does NOT exist in map
        }

        actions.SetHitObjectSelection(objectsToSelect)
    end

    imgui.Text("Selected Objects:")
    if #state.SelectedHitObjects == 0 then
        imgui.Text("None")
    else
        for i, hitObject in pairs(state.SelectedHitObjects) do
            imgui.Text(hitObject.StartTime .. "|" .. hitObject.Lane)
        end
    end
    imgui.End()
end```