### PR TITLE
Hitlighting Skin.ini Additions

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -153,7 +153,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     Make a quicker and shorter reference to the game skin
         /// </summary>
-        private SkinKeys Skin => SkinManager.Skin.Keys[Screen.Map.Mode];
+        public SkinKeys Skin => SkinManager.Skin.Keys[Screen.Map.Mode];
 
         /// <summary>
         /// </summary>
@@ -565,13 +565,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             for (var i = 0; i < Screen.Map.GetKeyCount(Screen.Map.HasScratchKey); i++)
             {
-                var hl = new HitLighting()
+                var hl = new HitLighting(Playfield, i)
                 {
                     Parent = Playfield.ForegroundContainer,
                     Visible = false,
-                    Size = new ScalableVector2(Skin.HitLightingWidth, Skin.HitLightingHeight),
                     Position = new ScalableVector2(Skin.HitLightingX, Skin.HitLightingY)
                 };
+
+                var scale = Skin.HitLightingScale / 100;
+
+                hl.Image = Skin.HitLighting.First();
+                hl.Size = new ScalableVector2(hl.Image.Width * scale, hl.Image.Height * scale);
 
                 var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, hl.RelativeRectangle,
                     Receptors[i].ScreenRectangle);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended;
 using Quaver.API.Enums;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
@@ -19,6 +20,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 {
     public class HitLighting : AnimatableSprite
     {
+        private GameplayPlayfieldKeys Playfield { get; }
+
+        private int ColumnIndex { get; }
+
         /// <summary>
         ///     If we're curerntly holding a long note.
         ///     It'll loop through the animation until we aren't anymore.
@@ -39,7 +44,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <inheritdoc />
         /// <summary>
         /// </summary>
-        public HitLighting() : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitLighting) => FinishedLooping += OnLoopCompletion;
+        public HitLighting(GameplayPlayfieldKeys playfield, int columnIndex)
+            : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitLighting)
+        {
+            Playfield = playfield;
+            ColumnIndex = columnIndex;
+
+            FinishedLooping += OnLoopCompletion;
+        }
 
         /// <inheritdoc />
         /// <summary>
@@ -75,9 +87,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             Visible = true;
             Alpha = 1;
 
+            var scale = skin.HitLightingScale / 100;
+            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+
+            var relativeRect = new RectangleF(skin.HitLightingX, skin.HitLightingY,
+                RelativeRectangle.Width, RelativeRectangle.Height);
+
+            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect,
+                Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
+
+            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X,
+                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y);
+
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.
             PerformingOneFrameAnimation = Frames.Count == 1;
+
             if (PerformingOneFrameAnimation)
                 return;
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -87,17 +87,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             Visible = true;
             Alpha = 1;
 
-            var scale = skin.HitLightingScale / 100;
+            var skinScale = IsHoldingLongNote ? skin.HoldLightingScale : skin.HitLightingScale;
+            var scale = skinScale / 100f;
+
             Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
 
-            var relativeRect = new RectangleF(skin.HitLightingX, skin.HitLightingY,
-                RelativeRectangle.Width, RelativeRectangle.Height);
+            var relativeRect = new RectangleF(0, 0, RelativeRectangle.Width, RelativeRectangle.Height);
+            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect, Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
 
-            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect,
-                Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
-
-            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X,
-                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y);
+            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + skin.HitLightingX,
+                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + skin.HitLightingY);
 
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -12,6 +12,7 @@ using Quaver.API.Enums;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -97,6 +98,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + skin.HitLightingX,
                 pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + skin.HitLightingY);
+
+            // Rotation
+            var rotate = IsHoldingLongNote ? skin.HoldLightingColumnRotation : skin.HitLightingColumnRotation;
+
+            if (rotate)
+                Rotation = GameplayHitObjectKeys.GetObjectRotation(Playfield.Ruleset.Map.Mode, ColumnIndex);
+            else
+                Rotation = 0;
 
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -114,6 +114,8 @@ namespace Quaver.Shared.Skinning
 
         internal int HitLightingScale { get; private set; } = 100;
 
+        internal int HoldLightingScale { get; private set; } = 100;
+
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
 
@@ -438,6 +440,7 @@ namespace Quaver.Shared.Skinning
             HitLightingFps = ConfigHelper.ReadInt32(HitLightingFps, ini["HitLightingFps"]);
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
             HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
+            HoldLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HoldLightingScale"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -116,6 +116,10 @@ namespace Quaver.Shared.Skinning
 
         internal int HoldLightingScale { get; private set; } = 100;
 
+        internal bool HitLightingColumnRotation { get; private set; }
+
+        internal bool HoldLightingColumnRotation { get; private set; }
+
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
 
@@ -441,6 +445,8 @@ namespace Quaver.Shared.Skinning
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
             HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
             HoldLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HoldLightingScale"]);
+            HitLightingColumnRotation = ConfigHelper.ReadBool(HitLightingColumnRotation, ini["HitLightingColumnRotation"]);
+            HoldLightingColumnRotation = ConfigHelper.ReadBool(HoldLightingColumnRotation, ini["HoldLightingColumnRotation"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -112,11 +112,7 @@ namespace Quaver.Shared.Skinning
 
         internal int HoldLightingFps { get; private set; }
 
-        [FixedScale]
-        internal float HitLightingWidth { get; private set; }
-
-        [FixedScale]
-        internal float HitLightingHeight { get; private set; }
+        internal int HitLightingScale { get; private set; } = 100;
 
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
@@ -441,8 +437,7 @@ namespace Quaver.Shared.Skinning
             HitLightingX = ConfigHelper.ReadInt32((int) HitLightingX, ini["HitLightingX"]);
             HitLightingFps = ConfigHelper.ReadInt32(HitLightingFps, ini["HitLightingFps"]);
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
-            HitLightingWidth = ConfigHelper.ReadInt32((int) HitLightingWidth, ini["HitLightingWidth"]);
-            HitLightingHeight = ConfigHelper.ReadInt32((int) HitLightingHeight, ini["HitLightingHeight"]);
+            HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);


### PR DESCRIPTION
**Requires Wiki PR w/ changes**

* Adds `HitLightingScale` and `HoldLightingScale` and removes `HitLightingWidth/Height` (Closes #374. Closes #456)
* Implements `HitLightingColumnRotation` and `HoldLightingColumnRotation` to rotate lighting based on the given column (Closes #2302)