### PR TITLE
 Separate UseAndRotateHitObjectSheet into two settings

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -293,7 +293,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Body.Image = TextureBody;
             Tail.Image = TextureTail;
 
-            if (SkinMode.UseAndRotateHitObjectSheet && !ViewLayers.Value)
+            if (SkinMode.RotateHitObjectsByColumn && !ViewLayers.Value)
                 Rotation = GameplayHitObjectKeys.GetObjectRotation(Map.Mode, Info.Lane - 1);
             else
                 Rotation = 0;

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/HitObjects/DrawableEditorHitObject.cs
@@ -72,7 +72,7 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling.HitObjects
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
-            if (!ConfigManager.EditorViewLayers.Value && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].UseAndRotateHitObjectSheet)
+            if (!ConfigManager.EditorViewLayers.Value && SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].RotateHitObjectsByColumn)
                 Rotation = GameplayHitObjectKeys.GetObjectRotation(MapManager.Selected.Value.Mode, Info.Lane - 1);
             else
                 Rotation = 0;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -192,7 +192,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             };
 
             // Handle rotating the objects automatically
-            if (SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].UseAndRotateHitObjectSheet)
+            if (SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].RotateHitObjectsByColumn)
                 HitObjectSprite.Rotation = GetObjectRotation(MapManager.Selected.Value.Mode, lane);
 
             // Create Hold Body

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -153,7 +153,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     Make a quicker and shorter reference to the game skin
         /// </summary>
-        private SkinKeys Skin => SkinManager.Skin.Keys[Screen.Map.Mode];
+        public SkinKeys Skin => SkinManager.Skin.Keys[Screen.Map.Mode];
 
         /// <summary>
         /// </summary>
@@ -565,13 +565,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             for (var i = 0; i < Screen.Map.GetKeyCount(Screen.Map.HasScratchKey); i++)
             {
-                var hl = new HitLighting()
+                var hl = new HitLighting(Playfield, i)
                 {
                     Parent = Playfield.ForegroundContainer,
                     Visible = false,
-                    Size = new ScalableVector2(Skin.HitLightingWidth, Skin.HitLightingHeight),
                     Position = new ScalableVector2(Skin.HitLightingX, Skin.HitLightingY)
                 };
+
+                var scale = Skin.HitLightingScale / 100;
+
+                hl.Image = Skin.HitLighting.First();
+                hl.Size = new ScalableVector2(hl.Image.Width * scale, hl.Image.Height * scale);
 
                 var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, hl.RelativeRectangle,
                     Receptors[i].ScreenRectangle);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended;
 using Quaver.API.Enums;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
@@ -19,6 +20,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 {
     public class HitLighting : AnimatableSprite
     {
+        private GameplayPlayfieldKeys Playfield { get; }
+
+        private int ColumnIndex { get; }
+
         /// <summary>
         ///     If we're curerntly holding a long note.
         ///     It'll loop through the animation until we aren't anymore.
@@ -39,7 +44,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <inheritdoc />
         /// <summary>
         /// </summary>
-        public HitLighting() : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitLighting) => FinishedLooping += OnLoopCompletion;
+        public HitLighting(GameplayPlayfieldKeys playfield, int columnIndex)
+            : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitLighting)
+        {
+            Playfield = playfield;
+            ColumnIndex = columnIndex;
+
+            FinishedLooping += OnLoopCompletion;
+        }
 
         /// <inheritdoc />
         /// <summary>
@@ -75,9 +87,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             Visible = true;
             Alpha = 1;
 
+            var scale = skin.HitLightingScale / 100;
+            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+
+            var relativeRect = new RectangleF(skin.HitLightingX, skin.HitLightingY,
+                RelativeRectangle.Width, RelativeRectangle.Height);
+
+            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect,
+                Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
+
+            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X,
+                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y);
+
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.
             PerformingOneFrameAnimation = Frames.Count == 1;
+
             if (PerformingOneFrameAnimation)
                 return;
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -116,9 +116,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             // Standard looping animations.
             if (!IsHoldingLongNote)
-                StartLoop(Direction.Forward, (int)(skin.HitLightingFps * AudioEngine.Track.Rate), 1);
+                StartLoop(Direction.Forward, skin.HitLightingFps, 1);
             else
-                StartLoop(Direction.Forward, (int)(skin.HoldLightingFps * AudioEngine.Track.Rate));
+                StartLoop(Direction.Forward, skin.HoldLightingFps);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -87,17 +87,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             Visible = true;
             Alpha = 1;
 
-            var scale = skin.HitLightingScale / 100;
+            var skinScale = IsHoldingLongNote ? skin.HoldLightingScale : skin.HitLightingScale;
+            var scale = skinScale / 100f;
+
             Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
 
-            var relativeRect = new RectangleF(skin.HitLightingX, skin.HitLightingY,
-                RelativeRectangle.Width, RelativeRectangle.Height);
+            var relativeRect = new RectangleF(0, 0, RelativeRectangle.Width, RelativeRectangle.Height);
+            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect, Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
 
-            var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect,
-                Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
-
-            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X,
-                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y);
+            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + skin.HitLightingX,
+                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + skin.HitLightingY);
 
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -12,6 +12,7 @@ using Quaver.API.Enums;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -97,6 +98,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
             Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + skin.HitLightingX,
                 pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + skin.HitLightingY);
+
+            // Rotation
+            var rotate = IsHoldingLongNote ? skin.HoldLightingColumnRotation : skin.HitLightingColumnRotation;
+
+            if (rotate)
+                Rotation = GameplayHitObjectKeys.GetObjectRotation(Playfield.Ruleset.Map.Mode, ColumnIndex);
+            else
+                Rotation = 0;
 
             // If we are performing a one frame animation however, we don't want to handle it
             // through standard looping, but rather through our own rolled out animation.

--- a/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
@@ -96,7 +96,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             Visible = true;
 
             if (Frames.Count != 1)
-                StartLoop(Direction.Forward, (int)(30 * AudioEngine.Track.Rate), 1);
+                StartLoop(Direction.Forward, 30, 1);
             else
             {
                 // Set the position to slightly above, so we can tween it back down in the animation.
@@ -119,11 +119,11 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             // Tween the position if need be
             if (Math.Abs(Y - OriginalPosY) > 0.01)
-                Y = MathHelper.Lerp(Y, OriginalPosY, (float) Math.Min(dt / (30 / AudioEngine.Track.Rate), 1));
+                Y = MathHelper.Lerp(Y, OriginalPosY, (float) Math.Min(dt / 30, 1));
             // If we've already tweened it, then we can begin to fade it out.
             else
             {
-                Alpha = MathHelper.Lerp(Alpha, 0, (float) Math.Min(dt / ( 240 / AudioEngine.Track.Rate ), 1));
+                Alpha = MathHelper.Lerp(Alpha, 0, (float) Math.Min(dt / 240, 1));
 
                 if (Alpha <= 0)
                     IsAnimatingWithOneFrame = false;

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -228,10 +228,12 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float HealthBarPosOffsetY { get; private set; }
 
-        internal bool UseAndRotateHitObjectSheet { get; private set; }
+        internal bool UseHitObjectSheet { get; private set; }
 
         [FixedScale]
         internal float ScratchLaneSize { get; private set; }
+
+        internal bool RotateHitObjectsByColumn { get; private set; }
 
         #endregion
 
@@ -488,8 +490,9 @@ namespace Quaver.Shared.Skinning
             BattleRoyaleEliminatedPosY = ConfigHelper.ReadInt32((int) BattleRoyaleEliminatedPosY, ini["BattleRoyaleEliminatedPosY"]);
             HealthBarPosOffsetX = ConfigHelper.ReadInt32((int) HealthBarPosOffsetX, ini["HealthBarPosOffsetX"]);
             HealthBarPosOffsetY = ConfigHelper.ReadInt32((int) HealthBarPosOffsetY, ini["HealthBarPosOffsetY"]);
-            UseAndRotateHitObjectSheet = ConfigHelper.ReadBool(UseAndRotateHitObjectSheet, ini["UseAndRotateHitObjectSheet"]);
+            UseHitObjectSheet = ConfigHelper.ReadBool(UseHitObjectSheet, ini["UseHitObjectSheet"]);
             ScratchLaneSize = ConfigHelper.ReadFloat(ScratchLaneSize, ini["ScratchLaneSize"]);
+            RotateHitObjectsByColumn = ConfigHelper.ReadBool(RotateHitObjectsByColumn, ini["RotateHitObjectsByColumn"]);
 
             var defaultSkin = ini["DefaultSkin"];
 
@@ -647,7 +650,7 @@ namespace Quaver.Shared.Skinning
                     ColumnColors[i] = ConfigHelper.ReadColor(ColumnColors[i], Store.Config[ModeHelper.ToShortHand(Mode).ToUpper()][$"ColumnColor{i + 1}"]);
 
                 // HitObjects
-                if (!UseAndRotateHitObjectSheet)
+                if (!UseHitObjectSheet)
                 {
                     LoadHitObjects(NoteHitObjects, $"note-hitobject-{i + 1}", i);
                     LoadHitObjects(NoteHoldHitObjects, $"note-holdhitobject-{i + 1}", i);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -114,6 +114,8 @@ namespace Quaver.Shared.Skinning
 
         internal int HitLightingScale { get; private set; } = 100;
 
+        internal int HoldLightingScale { get; private set; } = 100;
+
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
 
@@ -438,6 +440,7 @@ namespace Quaver.Shared.Skinning
             HitLightingFps = ConfigHelper.ReadInt32(HitLightingFps, ini["HitLightingFps"]);
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
             HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
+            HoldLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HoldLightingScale"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -116,6 +116,10 @@ namespace Quaver.Shared.Skinning
 
         internal int HoldLightingScale { get; private set; } = 100;
 
+        internal bool HitLightingColumnRotation { get; private set; }
+
+        internal bool HoldLightingColumnRotation { get; private set; }
+
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
 
@@ -441,6 +445,8 @@ namespace Quaver.Shared.Skinning
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
             HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
             HoldLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HoldLightingScale"]);
+            HitLightingColumnRotation = ConfigHelper.ReadBool(HitLightingColumnRotation, ini["HitLightingColumnRotation"]);
+            HoldLightingColumnRotation = ConfigHelper.ReadBool(HoldLightingColumnRotation, ini["HoldLightingColumnRotation"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -39,7 +39,7 @@ namespace Quaver.Shared.Skinning
 
         /// <summary>
         /// </summary>
-        private string DefaultSkin { get; }
+        private string DefaultSkin { get; set; }
 
         #region SKIN.INI VALUES
 
@@ -360,8 +360,10 @@ namespace Quaver.Shared.Skinning
 
             // Set the generic config variables, and THEN try to read from
             // skin.ini.
+            ReadConfig(false);
             ReadConfig(true);
             ReadConfig(false);
+
             FixScale();
             FixValues();
             LoadTextures();
@@ -488,6 +490,11 @@ namespace Quaver.Shared.Skinning
             HealthBarPosOffsetY = ConfigHelper.ReadInt32((int) HealthBarPosOffsetY, ini["HealthBarPosOffsetY"]);
             UseAndRotateHitObjectSheet = ConfigHelper.ReadBool(UseAndRotateHitObjectSheet, ini["UseAndRotateHitObjectSheet"]);
             ScratchLaneSize = ConfigHelper.ReadFloat(ScratchLaneSize, ini["ScratchLaneSize"]);
+
+            var defaultSkin = ini["DefaultSkin"];
+
+            if (!string.IsNullOrEmpty(defaultSkin) && Enum.IsDefined(typeof(DefaultSkins), defaultSkin))
+                DefaultSkin = defaultSkin;
         }
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -112,11 +112,7 @@ namespace Quaver.Shared.Skinning
 
         internal int HoldLightingFps { get; private set; }
 
-        [FixedScale]
-        internal float HitLightingWidth { get; private set; }
-
-        [FixedScale]
-        internal float HitLightingHeight { get; private set; }
+        internal int HitLightingScale { get; private set; } = 100;
 
         [FixedScale]
         internal float ScoreDisplayPosX { get; private set; }
@@ -441,8 +437,7 @@ namespace Quaver.Shared.Skinning
             HitLightingX = ConfigHelper.ReadInt32((int) HitLightingX, ini["HitLightingX"]);
             HitLightingFps = ConfigHelper.ReadInt32(HitLightingFps, ini["HitLightingFps"]);
             HoldLightingFps = ConfigHelper.ReadInt32(HoldLightingFps, ini["HoldLightingFps"]);
-            HitLightingWidth = ConfigHelper.ReadInt32((int) HitLightingWidth, ini["HitLightingWidth"]);
-            HitLightingHeight = ConfigHelper.ReadInt32((int) HitLightingHeight, ini["HitLightingHeight"]);
+            HitLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HitLightingScale"]);
             ScoreDisplayPosX = ConfigHelper.ReadInt32((int) ScoreDisplayPosX, ini["ScoreDisplayPosX"]);
             ScoreDisplayPosY = ConfigHelper.ReadInt32((int) ScoreDisplayPosY, ini["ScoreDisplayPosY"]);
             RatingDisplayPosX = ConfigHelper.ReadInt32((int) RatingDisplayPosX, ini["RatingDisplayPosX"]);


### PR DESCRIPTION
Closes #2279
Requires #2552

Removes `UseAndRotateHitObjectSheet` and separates it into two options.

Adds the following: 

* `UseHitObjectSheet = True` - Uses `note-hitobject-sheet@{rows}x{columns}.png` instead of `note-hitobject-{n}.png`
* `RotateHitObjectsByColumn = True` - Automatically rotates each hitobject depending on the column they're in.
