### PR TITLE
Add "Resnap" editor functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,6 +302,9 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-# Content 
+# Content
 Quaver/Content/*
 *.mgcb
+
+# Custom user VSCode settings
+.vscode/settings.json

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -454,7 +454,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     This results in a time of 1.56ms per snap, which is not accurate enough for our purposes.
         /// </remarks>
         /// <param name="snaps">List of snaps to snap to</param>
-        public void ResnapAllNotes(List<int> snaps) => Perform(new EditorActionResnapHitObjects(this, WorkingMap, snaps));
+        public void ResnapAllNotes(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap) => Perform(new EditorActionResnapHitObjects(this, WorkingMap, snaps, hitObjectsToResnap));
 
         /// <summary>
         ///     Detects the BPM of the map and returns the object instance

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -6,6 +6,8 @@ using MoonSharp.Interpreter.Interop;
 using Quaver.API.Enums;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Audio;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Flip;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Move;
@@ -38,6 +40,8 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.Reset;
 using Quaver.Shared.Screens.Edit.Components;
 using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Screens.Edit.Actions
 {
@@ -110,6 +114,11 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Event invoked when a batch of hitobjects have been moved
         /// </summary>
         public event EventHandler<EditorHitObjectsMovedEventArgs> HitObjectsMoved;
+
+        /// <summary>
+        ///     Event invoked when hitobjects have been resnapped
+        /// </summary>
+        public event EventHandler<EditorActionHitObjectsResnappedEventArgs> HitObjectsResnapped;
 
         /// <summary>
         ///     Event invoked when a hitsound has been added to a group of objects
@@ -436,6 +445,18 @@ namespace Quaver.Shared.Screens.Edit.Actions
         }
 
         /// <summary>
+        ///     Resnaps all notes in a given map to the closest of the specified snaps in the list.
+        /// </summary>
+        /// <remarks>
+        ///     The reason for working with multiple snaps is because using the first common multiple
+        ///     might not be accurate enough in terms of milliseconds. An example for this would be to
+        ///     resnap to 1/12 and 1/16 in a 200BPM map, which would result in a common multiple of 1/192.
+        ///     This results in a time of 1.56ms per snap, which is not accurate enough for our purposes.
+        /// </remarks>
+        /// <param name="snaps">List of snaps to snap to</param>
+        public void ResnapAllNotes(List<int> snaps) => Perform(new EditorActionResnapHitObjects(this, WorkingMap, snaps));
+
+        /// <summary>
         ///     Detects the BPM of the map and returns the object instance
         /// </summary>
         /// <returns></returns>
@@ -538,6 +559,9 @@ namespace Quaver.Shared.Screens.Edit.Actions
                     break;
                 case EditorActionType.ChangeScrollVelocityMultiplierBatch:
                     ScrollVelocityMultiplierBatchChanged?.Invoke(this, (EditorChangedScrollVelocityMultiplierBatchEventArgs)args);
+                    break;
+                case EditorActionType.ResnapHitObjects:
+                    HitObjectsResnapped?.Invoke(this, (EditorActionHitObjectsResnappedEventArgs)args);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, null);

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -601,6 +601,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             TimingPointOffsetBatchChanged = null;
             ScrollVelocityOffsetBatchChanged = null;
             ScrollVelocityMultiplierBatchChanged = null;
+            HitObjectsResnapped = null;
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
@@ -33,6 +33,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ChangeTimingPointOffsetBatch,
         ChangeScrollVelocityOffsetBatch,
         ChangeScrollVelocityMultiplierBatch,
-        ApplyOffset
+        ApplyOffset,
+        ResnapHitObjects
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Quaver.API.Maps.Structures;
+
+namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
+{
+    public class EditorActionHitObjectsResnappedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// </summary>
+        public List<int> Snaps { get; }
+
+        public EditorActionHitObjectsResnappedEventArgs(List<int> snaps) => Snaps = snaps;
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
@@ -10,6 +10,14 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
         /// </summary>
         public List<int> Snaps { get; }
 
-        public EditorActionHitObjectsResnappedEventArgs(List<int> snaps) => Snaps = snaps;
+        /// <summary>
+        /// </summary>
+        public List<HitObjectInfo> HitObjectsToResnap { get; }
+
+        public EditorActionHitObjectsResnappedEventArgs(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap)
+        {
+            Snaps = snaps;
+            HitObjectsToResnap = hitObjectsToResnap;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -62,13 +62,16 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
             {
                 // Using AudioEngine.GetNearestSnapTimeFromTime is unreliable since it might not return the current snap
                 var startTimeDelta = DiffToClosestSnap(note.StartTime);
+                
                 if (startTimeDelta != 0)
                     note.StartTime -= startTimeDelta;
 
                 var endTimeDelta = 0;
+
                 if (note.IsLongNote)
                 {
                     endTimeDelta = DiffToClosestSnap(note.EndTime);
+
                     if (endTimeDelta != 0f)
                         note.EndTime -= endTimeDelta;
                 }
@@ -82,6 +85,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
             {
                 var notifMessage = $"Resnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
                 NotificationManager.Show(NotificationLevel.Info, notifMessage);
+
                 ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
             }
             else
@@ -100,11 +104,13 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
             var msPerSnaps = Snaps.Select(s => timingPoint.MillisecondsPerBeat / s).ToList();
 
             var smallestDelta = float.MaxValue;
+
             foreach (var msPerSnap in msPerSnaps)
             {
                 var deltaForward = (time - timingPoint.StartTime) % msPerSnap;
                 var deltaBackward = deltaForward - msPerSnap;
                 var delta = deltaForward < -deltaBackward ? deltaForward : deltaBackward;
+
                 if (Math.Abs(delta) < Math.Abs(smallestDelta))
                     smallestDelta = delta;
             }
@@ -125,7 +131,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
             }
 
             ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
-            
+
             var offsnapCount = noteTimeAdjustments.Values.Count(x => x.Item1 != 0 || x.Item2 != 0);
             var notifMessage = $"Unsnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
             NotificationManager.Show(NotificationLevel.Info, notifMessage);

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.PlaceBatch;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
+{
+    public class EditorActionResnapHitObjects : IEditorAction
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public EditorActionType Type { get; } = EditorActionType.ResnapHitObjects;
+
+        /// <summary>
+        /// </summary>
+        private EditorActionManager ActionManager { get; }
+
+        /// <summary>
+        /// </summary>
+        private Qua WorkingMap { get; }
+
+        /// <summary>
+        /// </summary>
+        private List<int> Snaps { get; }
+
+        /// <summary>
+        ///     Unmodified notes, kept for undoing
+        /// </summary>
+        private List<HitObjectInfo> OldNotes { get; } = new List<HitObjectInfo>();
+
+        /// <summary>
+        ///     Modified notes, kept for undoing
+        /// </summary>
+        private List<HitObjectInfo> NewNotes { get; } = new List<HitObjectInfo>();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="actionManager"></param>
+        /// <param name="workingMap"></param>
+        /// <param name="hitObjects"></param>
+        public EditorActionResnapHitObjects(EditorActionManager actionManager, Qua workingMap, List<int> snaps)
+        {
+            ActionManager = actionManager;
+            WorkingMap = workingMap;
+            Snaps = snaps;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Perform()
+        {
+
+            // Using AudioEngine.GetNearestSnapTimeFromTime is unreliable since it might not return the current snap
+            foreach (var note in WorkingMap.HitObjects)
+            {
+                var startTimeDelta = DiffToClosestSnap(note.StartTime);
+                var endTimeDelta = DiffToClosestSnap(note.EndTime);
+                var startTimeNotSnapped = Math.Abs(startTimeDelta) >= 1;
+                var endTimeNotSnapped = Math.Abs(endTimeDelta) >= 1 && note.IsLongNote;
+
+                if (!startTimeNotSnapped && !endTimeNotSnapped)
+                    continue;
+
+                var resnappedNote = Helpers.ObjectHelper.DeepClone(note);
+
+                if (startTimeNotSnapped)
+                {
+                    resnappedNote.StartTime = (int)(resnappedNote.StartTime - startTimeDelta);
+                    Logger.Debug($"Resnapped {note.StartTime}|{note.Lane} to {resnappedNote.StartTime}", LogType.Runtime, false);
+                }
+
+                if (endTimeNotSnapped)
+                {
+                    resnappedNote.EndTime = (int)(resnappedNote.EndTime - endTimeDelta);
+                    Logger.Debug($"Resnapped {note.EndTime}|{note.Lane} to {resnappedNote.EndTime} (Long Note End)", LogType.Runtime, false);
+                }
+
+                OldNotes.Add(note);
+                NewNotes.Add(resnappedNote);
+            }
+
+            if (OldNotes.Count() > 0)
+            {
+                OldNotes.ForEach(n => WorkingMap.HitObjects.Remove(n));
+                WorkingMap.HitObjects.AddRange(NewNotes);
+                WorkingMap.Sort();
+                NotificationManager.Show(NotificationLevel.Info, $"Resnapped {NewNotes.Count} notes");
+                ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps));
+            }
+            else
+                NotificationManager.Show(NotificationLevel.Info, $"No notes to resnap");
+
+        }
+
+        private float DiffToClosestSnap(int time) {
+            var timingPoint = WorkingMap.GetTimingPointAt(time);
+            var msPerSnaps = Snaps.Select(s => timingPoint.MillisecondsPerBeat / s).ToList();
+
+            var smallestDelta = float.MaxValue;
+            foreach (var msPerSnap in msPerSnaps)
+            {
+                var deltaForward = (time - timingPoint.StartTime) % msPerSnap;
+                var deltaBackward = deltaForward - msPerSnap;
+                var delta = deltaForward < -deltaBackward ? deltaForward : deltaBackward;
+                if (Math.Abs(delta) < Math.Abs(smallestDelta))
+                    smallestDelta = delta;
+            }
+
+            return smallestDelta;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Undo()
+        {
+            NewNotes.ForEach(n => WorkingMap.HitObjects.Remove(n));
+            WorkingMap.HitObjects.AddRange(OldNotes);
+            WorkingMap.Sort();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -124,6 +124,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
                 note.EndTime += adjustment.Value.Item2;
             }
 
+            ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
+            
             var offsnapCount = noteTimeAdjustments.Values.Count(x => x.Item1 != 0 || x.Item2 != 0);
             var notifMessage = $"Unsnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
             NotificationManager.Show(NotificationLevel.Info, notifMessage);

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -270,6 +270,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
                 ImGui.EndMenu();
             }
 
+            if (ImGui.BeginMenu("Resnap Selected Notes"))
+            {
+                if (ImGui.MenuItem("Resnap to current selected snap"))
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { Screen.BeatSnap.Value }, Screen.SelectedHitObjects.Value);
+                if (ImGui.MenuItem("Resnap to 1/16 and 1/12 snaps"))
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { 16, 12 }, Screen.SelectedHitObjects.Value);
+                ImGui.EndMenu();
+            }
+
             if (ImGui.BeginMenu($"Apply Modifier To Map", Screen.Map.Game == MapGame.Quaver))
             {
                 if (ImGui.MenuItem("Mirror"))

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -261,6 +261,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.MenuItem("Apply Offset To Map"))
                 DialogManager.Show(new EditorApplyOffsetDialog(Screen));
 
+            if (ImGui.BeginMenu("Resnap All Notes"))
+            {
+                if (ImGui.MenuItem("Resnap to current selected snap"))
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { Screen.BeatSnap.Value });
+                if (ImGui.MenuItem("Resnap to 1/16 and 1/12 snaps"))
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { 16, 12 });
+                ImGui.EndMenu();
+            }
+
             if (ImGui.BeginMenu($"Apply Modifier To Map", Screen.Map.Game == MapGame.Quaver))
             {
                 if (ImGui.MenuItem("Mirror"))

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -264,9 +264,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.BeginMenu("Resnap All Notes"))
             {
                 if (ImGui.MenuItem("Resnap to current selected snap"))
-                    Screen.ActionManager.ResnapAllNotes(new List<int> { Screen.BeatSnap.Value });
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { Screen.BeatSnap.Value }, Screen.WorkingMap.HitObjects);
                 if (ImGui.MenuItem("Resnap to 1/16 and 1/12 snaps"))
-                    Screen.ActionManager.ResnapAllNotes(new List<int> { 16, 12 });
+                    Screen.ActionManager.ResnapAllNotes(new List<int> { 16, 12 }, Screen.WorkingMap.HitObjects);
                 ImGui.EndMenu();
             }
 

--- a/Quaver.Shared/Screens/Edit/UI/Panels/EditorPanelDetails.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/EditorPanelDetails.cs
@@ -98,6 +98,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
+            ActionManager.HitObjectsResnapped += OnHitObjectsResnapped;
             ActionManager.LongNoteResized += OnLongNoteResized;
         }
 
@@ -117,6 +118,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
             ActionManager.HitObjectBatchRemoved -= OnHitObjectBatchRemoved;
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
             ActionManager.HitObjectsMoved -= OnHitObjectsMoved;
+            ActionManager.HitObjectsResnapped -= OnHitObjectsResnapped;
             ActionManager.LongNoteResized -= OnLongNoteResized;
 
             base.Destroy();
@@ -297,6 +299,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnHitObjectsMoved(object sender, EditorHitObjectsMovedEventArgs e) => UpdateObjects();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnHitObjectsResnapped(object sender, EditorActionHitObjectsResnappedEventArgs e) => UpdateObjects();
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -350,6 +350,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
+            ActionManager.HitObjectsResnapped += OnHitObjectsResnapped;
             ActionManager.TimingPointAdded += OnTimingPointAdded;
             ActionManager.TimingPointRemoved += OnTimingPointRemoved;
             ActionManager.TimingPointBatchAdded += OnTimingPointBatchAdded;
@@ -453,6 +454,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ActionManager.HitObjectBatchPlaced -= OnHitObjectBatchPlaced;
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
             ActionManager.HitObjectsMoved -= OnHitObjectsMoved;
+            ActionManager.HitObjectsResnapped -= OnHitObjectsResnapped;
             ActionManager.TimingPointAdded -= OnTimingPointAdded;
             ActionManager.TimingPointRemoved -= OnTimingPointRemoved;
             ActionManager.TimingPointBatchAdded -= OnTimingPointBatchAdded;
@@ -989,6 +991,19 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
                 return;
 
             RefreshHitObjectBatch(e.HitObjects);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnHitObjectsResnapped(object sender, EditorActionHitObjectsResnappedEventArgs e)
+        {
+            if (IsUneditable)
+                return;
+
+            ResetObjectPositions();
+            InitializeHitObjectPool();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
@@ -58,6 +58,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
+            ActionManager.HitObjectsResnapped += OnHitObjectsResnapped;
             ActionManager.LongNoteResized += OnLongNoteResized;
             ActionManager.ScrollVelocityAdded += OnScrollVelocityAdded;
             ActionManager.ScrollVelocityRemoved += OnScrollVelocityRemoved;
@@ -86,6 +87,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
             ActionManager.HitObjectBatchPlaced -= OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved -= OnHitObjectBatchRemoved;
+            ActionManager.HitObjectsResnapped -= OnHitObjectsResnapped;
             ActionManager.LongNoteResized -= OnLongNoteResized;
             ActionManager.ScrollVelocityAdded -= OnScrollVelocityAdded;
             ActionManager.ScrollVelocityRemoved -= OnScrollVelocityRemoved;
@@ -127,6 +129,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
         private void OnHitObjectBatchPlaced(object sender, EditorHitObjectBatchPlacedEventArgs e) => Refresh();
 
         private void OnHitObjectBatchRemoved(object sender, EditorHitObjectBatchRemovedEventArgs e) => Refresh();
+
+        private void OnHitObjectsResnapped(object sender, EditorActionHitObjectsResnappedEventArgs e) => Refresh();
 
         private void OnLongNoteResized(object sender, EditorLongNoteResizedEventArgs e) => Refresh();
 


### PR DESCRIPTION
Adds two options in the editor under Edit > Resnap all notes, one to resnap to the current snap and one to resnap to 1/16 AND 1/12 by default (without using a common multiple). This will also resnap LN ends. Undo structure is also available.