### PR TITLE
Improve timing line intialization and recycling

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -111,7 +111,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
                 // Initialize timing lines between current timing point and target position
                 for (var songPos = map.TimingPoints[i].StartTime; songPos < target; songPos += increment)
-                    temp.Add(new TimingLineInfo(songPos, HitObjectManager.GetPositionFromTime(songPos)));
+                {
+                    var offset = HitObjectManager.GetPositionFromTime(songPos);
+
+                    // Do not initialize any timing lines that do not appear in gameplay
+                    if (!(HitObjectManager.CurrentTrackPosition - offset > HitObjectManager.RecycleObjectPosition && songPos < HitObjectManager.CurrentAudioPosition))
+                        temp.Add(new TimingLineInfo(songPos, offset));
+                }
             }
 
             // Sort timing lines by position instead of time
@@ -133,9 +139,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
             while (Info.Count > 0)
             {
-                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectPosition && Info.Peek().StartTime < HitObjectManager.CurrentAudioPosition)
-                    Info.Dequeue();
-                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
+                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
                     CreatePoolObject(Info.Dequeue());
                 else
                     break;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -133,7 +133,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
             while (Info.Count > 0)
             {
-                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
+                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectPosition && Info.Peek().StartTime < HitObjectManager.CurrentAudioPosition)
+                    Info.Dequeue();
+                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
                     CreatePoolObject(Info.Dequeue());
                 else
                     break;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -6,6 +6,7 @@
 */
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using Quaver.API.Enums;
 using Quaver.API.Helpers;
@@ -85,7 +86,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
         /// <param name="map"></param>
         public void GenerateTimingLineInfo(Qua map)
         {
-            Info = new Queue<TimingLineInfo>();
+            List<TimingLineInfo> temp = new List<TimingLineInfo>();
 
             for (var i = 0; i < map.TimingPoints.Count; i++)
             {
@@ -110,8 +111,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
                 // Initialize timing lines between current timing point and target position
                 for (var songPos = map.TimingPoints[i].StartTime; songPos < target; songPos += increment)
-                    Info.Enqueue(new TimingLineInfo(songPos, HitObjectManager.GetPositionFromTime(songPos)));
+                    temp.Add(new TimingLineInfo(songPos, HitObjectManager.GetPositionFromTime(songPos)));
             }
+
+            // Sort timing lines by position instead of time
+            Info = new Queue<TimingLineInfo>(temp.OrderBy(line => line.TrackOffset));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -149,7 +149,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             }
 
             // Recycle necessary pool objects
-            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectPosition)
+            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectPosition && Pool.Peek().Info.StartTime < HitObjectManager.CurrentAudioPosition)
             {
                 var line = Pool.Dequeue();
                 if (Info.Count > 0)


### PR DESCRIPTION
Check if audio has passed a timing line's StartTime before recycling to fix timing lines not appearing after using SVs to teleport the playfield backwards #2580.

Sort TimingLineInfo queue by TrackOffset instead of StartTIme to fix #2584. This way timing lines with a StartTime of 0 that appear at 100,000 offset don't prevent the timing lines at 0-100,000 offset from appearing. Will prevent the recycling of some timing lines if the playfield teleports backwards.

Don't initialize timing lines that don't appear in gameplay because otherwise a 600 BPM timing point at -100,000 offset adds a bajillion timing lines to the pool. Fixes #2591.