### PR TITLE
Fix editor crash related to quick exiting during test play

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -94,7 +94,7 @@ namespace Quaver.Shared.Screens.Edit
         public EditorVisualTestBackground BackgroundStore { get; }
 
         /// <summary>
-        ///     The cvrrently active skin
+        ///     The currently active skin
         /// </summary>
         public Bindable<SkinStore> Skin { get; private set; }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -825,6 +825,24 @@ namespace Quaver.Shared.Screens.Gameplay
             if (IsSongSelectPreview || InReplayMode && !Failed && !IsPlayComplete || Exiting)
                 return;
 
+            // Go back to editor if we're currently play testing.
+            // Copied from HandlePauseInput()
+            if (IsPlayTesting)
+            {
+                if (AudioEngine.Track.IsPlaying)
+                {
+                    AudioEngine.Track.Pause();
+                    AudioEngine.Track.Seek(PlayTestAudioTime);
+                }
+
+                CustomAudioSampleCache.StopAll();
+
+                if (IsTestPlayingInNewEditor)
+                    ExitToNewEditor();
+                else
+                    Exit(() => new EditorScreen(OriginalEditorMap));
+            }
+
             TimesRequestedToPause++;
 
             // Force fail the user if they request to quit more than once.


### PR DESCRIPTION
Fixes #2017 by making Esc and quick exit do the same thing when test playing.