### PR TITLE
Various plugin additions

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -85,7 +85,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
 
             var state = (EditorPluginState)State;
 
-            state.SongTime = (int)Math.Round(Editor.Track.Time, MidpointRounding.AwayFromZero);
+            state.SongTime = Editor.Track.Time;
             state.UnixTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             state.SelectedHitObjects = Editor.SelectedHitObjects.Value;
             state.CurrentTimingPoint = Editor.WorkingMap.GetTimingPointAt(state.SongTime);

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using ImGuiNET;
 using MoonSharp.Interpreter;
 using Quaver.API.Enums;
+using Quaver.Shared.Config;
 using Quaver.Shared.Scripting;
 
 namespace Quaver.Shared.Screens.Edit.Plugins
@@ -89,8 +90,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             state.UnixTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             state.SelectedHitObjects = Editor.SelectedHitObjects.Value;
             state.CurrentTimingPoint = Editor.WorkingMap.GetTimingPointAt(state.SongTime);
+            state.CurrentSnap = Editor.BeatSnap.Value;
+            state.WindowSize = new Vector2(ConfigManager.WindowWidth.Value, ConfigManager.WindowHeight.Value);
 
             EditorPluginMap.Map = Editor.WorkingMap;
+            EditorPluginMap.Track = Editor.Track;
             EditorPluginMap.SetFrameState();
             WorkingScript.Globals["map"] = EditorPluginMap;
 

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginMap.cs
@@ -3,9 +3,12 @@ using MoonSharp.Interpreter.Interop;
 using Quaver.API.Enums;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Audio;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Wobble.Audio.Tracks;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.Edit.Plugins
 {
@@ -14,6 +17,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins
     {
         [MoonSharpVisible(false)]
         public Qua Map;
+
+        [MoonSharpVisible(false)]
+        public IAudioTrack Track;
 
         /// <summary>
         ///     The game mode of the map
@@ -35,6 +41,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// </summary>
         public List<TimingPointInfo> TimingPoints { get; [MoonSharpVisible(false)] set; }
 
+        /// <summary>
+        ///     Total mp3 length
+        /// </summary>
+        public double TrackLength { get; [MoonSharpVisible(false)] set; }
+
         [MoonSharpVisible(false)]
         public void SetFrameState()
         {
@@ -42,7 +53,17 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             TimingPoints = Map.TimingPoints;
             ScrollVelocities = Map.SliderVelocities; // Original name was SliderVelocities but that name doesn't really make sense
             HitObjects = Map.HitObjects;
+            TrackLength = Track.Length;
         }
+
+        public override string ToString() => Map.ToString();
+
+        /// <summary>
+        ///    In Quaver, the key count is defined by the game mode.
+        ///    This translates mode to key count.
+        /// </summary>
+        /// <returns></returns>
+        public int GetKeyCount(bool includeScratch = true) => Map.GetKeyCount(includeScratch);
 
         /// <summary>
         ///     Finds the most common BPM in the current map
@@ -70,6 +91,15 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="point"></param>
         /// <returns></returns>
         public double GetTimingPointLength(TimingPointInfo point) => Map.GetTimingPointLength(point);
+
+        /// <summary>
+        ///     Gets the nearest snap time at a time to a given direction.
+        /// </summary>
+        /// <param name="forwards"></param>
+        /// <param name="snap"></param>
+        /// <param name="time"></param>
+        /// <returns></returns>
+        public double GetNearestSnapTimeFromTime(bool forwards, int snap, float time) => AudioEngine.GetNearestSnapTimeFromTime(Map, forwards ? Direction.Forward : Direction.Backward, snap, time);
 
     }
 }

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <summary>
         ///     The current time in the song
         /// </summary>
-        public int SongTime { get; [MoonSharpVisible(false)] set; }
+        public double SongTime { get; [MoonSharpVisible(false)] set; }
 
         /// <summary>
         ///     The objects that are currently selected by the user

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
@@ -29,6 +29,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         public TimingPointInfo CurrentTimingPoint { get; [MoonSharpVisible(false)] set; }
 
         /// <summary>
+        ///     The currently selected beat snap
+        /// </summary>
+        public int CurrentSnap { get; [MoonSharpVisible(false)] set; }
+
+        /// <summary>
         ///     ImGui options used to set styles/fonts for the window
         /// </summary>
         [MoonSharpVisible(false)]

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -35,14 +35,15 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="endTime"></param>
         /// <param name="hitsounds"></param>
         /// <returns></returns>
-        public static HitObjectInfo CreateHitObject(int startTime, int lane, int endTime = 0, HitSounds hitsounds = 0)
+        public static HitObjectInfo CreateHitObject(int startTime, int lane, int endTime = 0, HitSounds hitsounds = 0, int editorLayer = 0)
         {
             var ho = new HitObjectInfo()
             {
                 StartTime = startTime,
                 Lane = lane,
                 EndTime = endTime,
-                HitSound = hitsounds
+                HitSound = hitsounds,
+                EditorLayer = editorLayer
             };
 
             return ho;

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -73,6 +73,9 @@ namespace Quaver.Shared.Scripting
             UserData.RegisterType<ImGuiCol>();
             UserData.RegisterType<ImGuiStyleVar>();
             UserData.RegisterType<ImDrawListPtr>();
+            UserData.RegisterType<ImGuiComboFlags>();
+            UserData.RegisterType<ImGuiFocusedFlags>();
+            UserData.RegisterType<ImGuiHoveredFlags>();
 
             // MonoGame
             UserData.RegisterType<Keys>();
@@ -149,6 +152,9 @@ namespace Quaver.Shared.Scripting
             WorkingScript.Globals["imgui_key"] = typeof(ImGuiKey);
             WorkingScript.Globals["imgui_col"] = typeof(ImGuiCol);
             WorkingScript.Globals["imgui_style_var"] = typeof(ImGuiStyleVar);
+            WorkingScript.Globals["imgui_combo_flags"] = typeof(ImGuiComboFlags);
+            WorkingScript.Globals["imgui_focused_flags"] = typeof(ImGuiFocusedFlags);
+            WorkingScript.Globals["imgui_hovered_flags"] = typeof(ImGuiHoveredFlags);
 
             WorkingScript.Globals["keys"] = typeof(Keys);
         }

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -72,6 +72,7 @@ namespace Quaver.Shared.Scripting
             UserData.RegisterType<ImGuiKey>();
             UserData.RegisterType<ImGuiCol>();
             UserData.RegisterType<ImGuiStyleVar>();
+            UserData.RegisterType<ImDrawListPtr>();
 
             // MonoGame
             UserData.RegisterType<Keys>();

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -71,6 +71,7 @@ namespace Quaver.Shared.Scripting
             UserData.RegisterType<ImGuiColorEditFlags>();
             UserData.RegisterType<ImGuiKey>();
             UserData.RegisterType<ImGuiCol>();
+            UserData.RegisterType<ImGuiStyleVar>();
 
             // MonoGame
             UserData.RegisterType<Keys>();
@@ -146,6 +147,7 @@ namespace Quaver.Shared.Scripting
             WorkingScript.Globals["imgui_color_edit_flags"] = typeof(ImGuiColorEditFlags);
             WorkingScript.Globals["imgui_key"] = typeof(ImGuiKey);
             WorkingScript.Globals["imgui_col"] = typeof(ImGuiCol);
+            WorkingScript.Globals["imgui_style_var"] = typeof(ImGuiStyleVar);
 
             WorkingScript.Globals["keys"] = typeof(Keys);
         }

--- a/Quaver.Shared/Scripting/LuaPluginState.cs
+++ b/Quaver.Shared/Scripting/LuaPluginState.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 using MoonSharp.Interpreter;
 
 namespace Quaver.Shared.Scripting
@@ -45,5 +46,10 @@ namespace Quaver.Shared.Scripting
         /// <param name="key"></param>
         /// <param name="value"></param>
         public void SetValue(string key, object value) => Values[key] = value;
+
+        /// <summary>
+        ///     Width and height of the current Quaver window
+        /// </summary>
+        public Vector2 WindowSize { get; set; }
     }
 }


### PR DESCRIPTION
- **Register ImGuiDrawListPtr to allow for drawing of basic shapes** with imgui.GetOverlayDrawList() or imgui.GetWindowDrawList()
  - A small list of available shapes are: lines, circles, rectangles, quads, regular polygons, bezier curves
- Make state.SongTime a double for more accurate times
- Register following missing ImGui enums and make them globally accessible
  - ImGuiComboFlags as imgui_combo_flags
  - ImGuiFocusedFlags as imgui_focused_flags
  - ImGuiHoveredFlags as imgui_hovered_flags
  - ImGuiStyleVar as imgui_style_var
- Add GetNearestSnapTimeFromTime() from AudioManager as a map method
  - Add CurrentSnap to state variables to go along with that
- Add WindowSize to state variables
  - Useful for screen-relative coordinates, for which applications can be found with the DrawLists since they rely on absolute coordinates.
- Add following to EditorPluginMap
  - TrackLength (total mp3 length)
  - GetKeyCount()
  - ToString()
- Add editor layer to utils.CreateHitObject()

The most exciting change is probably the DrawList, because it allows for features like this with very little code. This example shows BPM changes with red lines at the bottom and SV changes as purple lines that scale with the value. It makes use of the newly introduced WindowSize and TrackLength as well.
![9122020 0-53-44-56](https://user-images.githubusercontent.com/22303902/92979307-890db180-f492-11ea-8efd-922e937431e0.jpg)

Source code
```lua
BPM_COLOR = 4267071231 -- #FE5656 = 0xFE5656FF (edit: format is actually rgba reversed [aaggbbrr instead of rrggbbaa] so thats the reason why the sv color isnt green like i intended it to be)
SV_COLOR = 1459515016 -- 0x56FE6E88
MENU_BAR_HEIGHT = 35
BOTTOM_MENU_HEIGHT = 52
LINE_LENGTH = 0.05
LINE_THICKNESS = 2

function draw()
    -- Toggle SV lines with F4 (causes lag if too many)
    local showSvLines = state.GetValue("showSvLines") or false
    if utils.IsKeyPressed(keys.F4) then showSvLines = not showSvLines end
    state.SetValue("showSvLines", showSvLines)

    if showSvLines then
        for _, sv in pairs(map.ScrollVelocities) do
            drawLine(sv.StartTime, SV_COLOR, sv.Multiplier)
        end
    end

    for _, tp in pairs(map.TimingPoints) do
        drawLine(tp.StartTime, BPM_COLOR, 1)
    end
end

function drawLine(time, color, lineScale)
    local progress = time / map.TrackLength

    local startPoint = relToAbsCoord(progress, 1 - LINE_LENGTH * lineScale)
    local endPoint = relToAbsCoord(progress, 1)
    imgui.GetOverlayDrawList().AddLine(startPoint, endPoint, color,
                                       LINE_THICKNESS)
end

function relToAbsCoord(x, y)
    return {
        x * state.WindowSize[1],
        y * (state.WindowSize[2] - MENU_BAR_HEIGHT - BOTTOM_MENU_HEIGHT) +
            MENU_BAR_HEIGHT
    }
end
```