### PR TITLE
Add option to toggle notification display during gameplay

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -573,6 +573,10 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> EnableHighProcessPriority { get; private set; }
 
         /// <summary>
+        /// </summary>
+        internal static Bindable<bool> DisplayNotificationsInGameplay { get; private set; }
+
+        /// <summary>
         ///     Keybinding for leftward navigation.
         /// </summary>
         internal static Bindable<Keys> KeyNavigateLeft { get; private set; }
@@ -981,6 +985,7 @@ namespace Quaver.Shared.Config
             SkipSplashScreen = ReadValue(@"SkipSplashScreen", false, data);
             DisplayGameplayOverlay = ReadValue(@"DisplayGameplayOverlay", true, data);
             EnableHighProcessPriority = ReadValue(@"EnableHighProcessPriority", false, data);
+            DisplayNotificationsInGameplay = ReadValue(@"DisplayNotificationsInGameplay", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))

--- a/Quaver.Shared/Graphics/Notifications/NotificationInfo.cs
+++ b/Quaver.Shared/Graphics/Notifications/NotificationInfo.cs
@@ -25,18 +25,25 @@ namespace Quaver.Shared.Graphics.Notifications
         public bool AutomaticallySlide { get; }
 
         /// <summary>
+        ///     If the notification will be shown regardless of the state
+        /// </summary>
+        public bool ForceShow { get; }
+
+        /// <summary>
         /// </summary>
         /// <param name="level"></param>
         /// <param name="text"></param>
         /// <param name="automaticallySlide"></param>
         /// <param name="clickAction"></param>
-        public NotificationInfo(NotificationLevel level, string text, bool automaticallySlide, EventHandler clickAction = null)
+        /// <param name="forceShow"></param>
+        public NotificationInfo(NotificationLevel level, string text, bool automaticallySlide, EventHandler clickAction = null, bool forceShow = false)
         {
             Level = level;
             Text = text;
 
             AutomaticallySlide = automaticallySlide;
             ClickAction = clickAction;
+            ForceShow = forceShow;
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -760,7 +760,8 @@ namespace Quaver.Shared.Screens.Gameplay
                 }
 
                 // Show notification to the user that their score is invalid.
-                NotificationManager.Show(NotificationLevel.Warning, "WARNING! Your score will not be submitted due to pausing during gameplay!");
+                NotificationManager.Show(NotificationLevel.Warning,
+                    "WARNING! Your score will not be submitted due to pausing during gameplay!", null, true);
 
                 // Add the pause mod to their score.
                 if (!ModManager.IsActivated(ModIdentifier.Paused))
@@ -849,7 +850,7 @@ namespace Quaver.Shared.Screens.Gameplay
             switch (TimesRequestedToPause)
             {
                 case 1:
-                    NotificationManager.Show(NotificationLevel.Warning, "Press the exit button once more to quit.");
+                    NotificationManager.Show(NotificationLevel.Warning, "Press the exit button once more to quit.", null, true);
                     break;
                 default:
                     var game = GameBase.Game as QuaverGame;
@@ -1053,7 +1054,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
                 OnlineManager.Client?.RequestToSkipSong();
                 RequestedToSkipSong = true;
-                NotificationManager.Show(NotificationLevel.Info, "Requested to skip song. Waiting for all other players to skip!");
+                NotificationManager.Show(NotificationLevel.Info, "Requested to skip song. Waiting for all other players to skip!", null, true);
                 return;
             }
 
@@ -1217,7 +1218,7 @@ namespace Quaver.Shared.Screens.Gameplay
             if (Exiting)
                 return;
 
-            NotificationManager.Show(NotificationLevel.Error, "A global audio offset could not be suggested. Please try again!");
+            NotificationManager.Show(NotificationLevel.Error, "A global audio offset could not be suggested. Please try again!", null, true);
             OffsetConfirmDialog.Exit(this);
         }
 
@@ -1516,7 +1517,7 @@ namespace Quaver.Shared.Screens.Gameplay
                     inputManager.HandleInput(gameTime.ElapsedGameTime.TotalMilliseconds);
                 }
 
-                NotificationManager.Show(NotificationLevel.Info, $"Autoplay has been turned {(InReplayMode ? "on" : "off")}.");
+                NotificationManager.Show(NotificationLevel.Info, $"Autoplay has been turned {(InReplayMode ? "on" : "off")}.", null, true);
             }
 
             // Only allow offset changes if the map hasn't started or if we're on a break
@@ -1535,12 +1536,15 @@ namespace Quaver.Shared.Screens.Gameplay
                     if (KeyboardManager.IsAltDown())
                     {
                         ConfigManager.VisualOffset.Value += change;
-                        NotificationManager.Show(NotificationLevel.Success, $"Visual offset has been changed to: {ConfigManager.VisualOffset.Value} ms");
+                        NotificationManager.Show(NotificationLevel.Success,
+                            $"Visual offset has been changed to: {ConfigManager.VisualOffset.Value} ms", null, true);
                     }
                     else
                     {
                         MapManager.Selected.Value.LocalOffset += change;
-                        NotificationManager.Show(NotificationLevel.Success, $"Local map audio offset is now: {MapManager.Selected.Value.LocalOffset} ms");
+                        NotificationManager.Show(NotificationLevel.Success,
+                            $"Local map audio offset is now: {MapManager.Selected.Value.LocalOffset} ms", null, true);
+
                         ThreadScheduler.Run(() => MapDatabaseCache.UpdateMap(MapManager.Selected.Value));
                     }
                 }
@@ -1551,12 +1555,15 @@ namespace Quaver.Shared.Screens.Gameplay
                     if (KeyboardManager.IsAltDown())
                     {
                         ConfigManager.VisualOffset.Value -= change;
-                        NotificationManager.Show(NotificationLevel.Success, $"Visual offset has been changed to: {ConfigManager.VisualOffset.Value} ms");
+                        NotificationManager.Show(NotificationLevel.Success,
+                            $"Visual offset has been changed to: {ConfigManager.VisualOffset.Value} ms", null, true);
                     }
                     else
                     {
                         MapManager.Selected.Value.LocalOffset -= change;
-                        NotificationManager.Show(NotificationLevel.Success, $"Local map audio offset is now: {MapManager.Selected.Value.LocalOffset} ms");
+                        NotificationManager.Show(NotificationLevel.Success,
+                            $"Local map audio offset is now: {MapManager.Selected.Value.LocalOffset} ms", null, true);
+
                         ThreadScheduler.Run(() => MapDatabaseCache.UpdateMap(MapManager.Selected.Value));
                     }
                 }
@@ -1574,7 +1581,8 @@ namespace Quaver.Shared.Screens.Gameplay
             ConfigManager.DisplayGameplayOverlay.Value = !ConfigManager.DisplayGameplayOverlay.Value;
             var on = ConfigManager.DisplayGameplayOverlay.Value ? "on" : "off";
 
-            NotificationManager.Show(NotificationLevel.Info, $"Gameplay overlay is now {on}. Press Shift+F6 to toggle the display.");
+            NotificationManager.Show(NotificationLevel.Info,
+                $"Gameplay overlay is now {on}. Press Shift+F6 to toggle the display.", null, true);
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -305,7 +305,10 @@ namespace Quaver.Shared.Screens.Gameplay
 
             // Notify the user if their local offset is actually set for this map.
             if (!Screen.IsSongSelectPreview && MapManager.Selected.Value.LocalOffset != 0)
-                NotificationManager.Show(NotificationLevel.Info, $"The local audio offset for this map is: {MapManager.Selected.Value.LocalOffset} ms");
+            {
+                NotificationManager.Show(NotificationLevel.Info, $"The local audio offset for this map is: {MapManager.Selected.Value.LocalOffset} ms",
+                    null, true);
+            }
 
             if (Screen.IsCalibratingOffset)
             {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -371,7 +371,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))
                 scrollSpeed.Value -= speedIncrease;
 
-            NotificationManager.Show(NotificationLevel.Info, $"Scroll speed has been changed to: {scrollSpeed.Value / 10f:0.0}");
+            NotificationManager.Show(NotificationLevel.Info, $"Scroll speed has been changed to: {scrollSpeed.Value / 10f:0.0}",
+                null, true);
+
             ((HitObjectManagerKeys)Ruleset.HitObjectManager).ForceUpdateLNSize();
         }
 

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -199,6 +199,7 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("User Interface", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Display Gameplay Overlay (Shift + F6)", ConfigManager.DisplayGameplayOverlay),
+                        new OptionsItemCheckbox(containerRect, "Display Notifications During Gameplay", ConfigManager.DisplayNotificationsInGameplay),
                         new OptionsItemCheckbox(containerRect, "Show Spectators", ConfigManager.ShowSpectators),
                         new OptionsItemCheckbox(containerRect, "Display Timing Lines", ConfigManager.DisplayTimingLines),
                         new OptionsItemCheckbox(containerRect, "Display Judgement Counter", ConfigManager.DisplayJudgementCounter),


### PR DESCRIPTION
Still force displays important notifications related to gameplay such as scroll speed, offset, etc.