### PR TITLE
ConfigManager: use _gameDirectory when writing quaver.cfg

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -1118,7 +1118,7 @@ namespace Quaver.Shared.Config
             var attempts = 0;
 
             // Don't do anything if the file isn't ready.
-            while (!IsFileReady(GameDirectory.Value + "/quaver.cfg") && !FirstWrite)
+            while (!IsFileReady(_gameDirectory + "/quaver.cfg") && !FirstWrite)
             {
             }
 
@@ -1150,7 +1150,7 @@ namespace Quaver.Shared.Config
             try
             {
                 // Create a new stream
-                var sw = new StreamWriter(GameDirectory.Value + "/quaver.cfg")
+                var sw = new StreamWriter(_gameDirectory + "/quaver.cfg")
                 {
                     AutoFlush = true
                 };
@@ -1169,7 +1169,7 @@ namespace Quaver.Shared.Config
                     attempts++;
 
                     // Create a new stream
-                    var sw = new StreamWriter(GameDirectory.Value + "/quaver.cfg")
+                    var sw = new StreamWriter(_gameDirectory + "/quaver.cfg")
                     {
                         AutoFlush = true
                     };


### PR DESCRIPTION
Fixes #2520

`quaver.cfg` is read once at Quaver startup from `_gameDirectory`. Then `GameDirectory` might be overridden from the config property. This means, however, that setting changes would be written into `quaver.cfg` at the new `GameDirectory` location, which is never read from.

One possible fix is to change `quaver.cfg` reading code to check if `GameDirectory` is different from `_gameDirectory` and, if so, re-load the file from there. This, however, needs to be done recursively and with checks for `GameDirectory` loops, as one `quaver.cfg` can point to another `GameDirectory`, `quaver.cfg` there can point to a third `GameDirectory`, and so on. A simpler solution is to just write to `_gameDirectory`, which is what this PR does.