### PR TITLE
Add "Confirm Ready" dialog if host readies up without everyone ready

### DIFF
--- a/Quaver.Shared/Screens/Multi/UI/Dialogs/ConfirmReady.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Dialogs/ConfirmReady.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Online;
+
+namespace Quaver.Shared.Screens.Multi.UI.Dialogs
+{
+    public sealed class ConfirmReady : YesNoDialog
+    {
+        public ConfirmReady() : base("CONFIRM READY",
+            "Readying up as the host will start the round, are you\nsure you would like to start without all players ready?")
+        {
+            YesAction += () =>
+            {
+                OnlineManager.Client?.MultiplayerGameIsReady();
+                OnlineManager.Client?.MultiplayerGameStartCountdown();
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Multi/UI/Footer/IconTextButtonMultiplayerReady.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Footer/IconTextButtonMultiplayerReady.cs
@@ -7,8 +7,10 @@ using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Menu.Border.Components;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Multi.UI.Dialogs;
 using Wobble.Bindables;
 using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Dialogs;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Multi.UI.Footer
@@ -35,10 +37,15 @@ namespace Quaver.Shared.Screens.Multi.UI.Footer
                 }
                 else
                 {
-                    OnlineManager.Client?.MultiplayerGameIsReady();
-
-                    if (game.Value.HostId == OnlineManager.Self.OnlineUser.Id)
-                        OnlineManager.Client?.MultiplayerGameStartCountdown();
+                    if (game.Value.HostId == OnlineManager.Self.OnlineUser.Id &&
+                        game.Value.Players.Count - 1 != game.Value.PlayersReady.Count) // Not all players are ready
+                        DialogManager.Show(new ConfirmReady());
+                    else
+                    {
+                        OnlineManager.Client?.MultiplayerGameIsReady();
+                        if (game.Value.HostId == OnlineManager.Self.OnlineUser.Id)
+                            OnlineManager.Client?.MultiplayerGameStartCountdown();
+                    }
                 }
             })
         {


### PR DESCRIPTION
new player joins into room, gets host and readies up instantly, starting the game. uncomfortable for everyone as the new player either does not know how to end the game or does not check the chat at all. they're used to osu! behavior so this makes them aware of quaver being different.