### PR TITLE
Implement Song Select Mapset Panel & Background Skinning

### DIFF
--- a/Quaver.Shared/Config/ConfigHelper.cs
+++ b/Quaver.Shared/Config/ConfigHelper.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Config
 {
@@ -234,6 +235,25 @@ namespace Quaver.Shared.Config
             {
                 var vectorSplit = newVal.Split(',');
                 return new Vector2(int.Parse(vectorSplit[0]), int.Parse(vectorSplit[1]));
+            }
+            catch (Exception)
+            {
+                return defaultVector2;
+            }
+        }
+
+        /// <summary>
+        ///     Reads a ScalableVector2 from a string
+        /// </summary>
+        /// <param name="defaultVector2"></param>
+        /// <param name="newVal"></param>
+        /// <returns></returns>
+        internal static ScalableVector2? ReadVector2(ScalableVector2 defaultVector2, string newVal)
+        {
+            try
+            {
+                var vectorSplit = newVal.Split(',');
+                return new ScalableVector2(int.Parse(vectorSplit[0]), int.Parse(vectorSplit[1]));
             }
             catch (Exception)
             {

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -581,6 +581,10 @@ namespace Quaver.Shared.Config
         internal static Bindable<string> TournamentPlayer2Skin { get; private set; }
 
         /// <summary>
+        /// </summary>
+        internal static Bindable<bool> DisplayMapBackgroundInSelect { get; private set; }
+
+        /// <summary>
         ///     Keybinding for leftward navigation.
         /// </summary>
         internal static Bindable<Keys> KeyNavigateLeft { get; private set; }
@@ -991,6 +995,7 @@ namespace Quaver.Shared.Config
             EnableHighProcessPriority = ReadValue(@"EnableHighProcessPriority", false, data);
             DisplayNotificationsInGameplay = ReadValue(@"DisplayNotificationsInGameplay", false, data);
             TournamentPlayer2Skin = ReadValue(@"TournamentPlayer2Skin", "", data);
+            DisplayMapBackgroundInSelect = ReadValue(@"DisplayMapBackgroundInSelect", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -581,10 +581,6 @@ namespace Quaver.Shared.Config
         internal static Bindable<string> TournamentPlayer2Skin { get; private set; }
 
         /// <summary>
-        /// </summary>
-        internal static Bindable<bool> DisplayMapBackgroundInSelect { get; private set; }
-
-        /// <summary>
         ///     Keybinding for leftward navigation.
         /// </summary>
         internal static Bindable<Keys> KeyNavigateLeft { get; private set; }
@@ -995,7 +991,6 @@ namespace Quaver.Shared.Config
             EnableHighProcessPriority = ReadValue(@"EnableHighProcessPriority", false, data);
             DisplayNotificationsInGameplay = ReadValue(@"DisplayNotificationsInGameplay", false, data);
             TournamentPlayer2Skin = ReadValue(@"TournamentPlayer2Skin", "", data);
-            DisplayMapBackgroundInSelect = ReadValue(@"DisplayMapBackgroundInSelect", false, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Scheduling;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Assets;
 using Wobble.Graphics;
@@ -394,7 +395,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 GameBase.Game.SpriteBatch.End();
 
                 // Cache a smaller version of the texture to a RenderTarget
-                var size = new ScalableVector2(421, 82);
+                var size = SkinManager.Skin?.SongSelect?.MapsetPanelBannerSize ?? new ScalableVector2(421, 82);
                 var scrollContainer = new ScrollContainer(size, size);
 
                 var maskedSprite = new Sprite

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -387,7 +387,8 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Song Select", new List<OptionsItem>()
                     {
-                        new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores)
+                        new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores),
+                        new OptionsItemCheckbox(containerRect, "Display Map Background In Song Select", ConfigManager.DisplayMapBackgroundInSelect)
                     }),
                     new OptionsSubcategory("Beta", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -388,7 +388,6 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("Song Select", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores),
-                        new OptionsItemCheckbox(containerRect, "Display Map Background In Song Select", ConfigManager.DisplayMapBackgroundInSelect)
                     }),
                     new OptionsSubcategory("Beta", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -184,7 +184,7 @@ namespace Quaver.Shared.Screens.Selection
         ///     Creates <see cref="Background"/>
         /// </summary>
         private void CreateBackground()
-            => Background = new BackgroundImage(UserInterface.Triangles, 0, false) { Parent = Container };
+            => Background = new BackgroundImage(UserInterface.TrianglesWallpaper, 0, false) { Parent = Container };
 
         /// <summary>
         ///     Creates <see cref="Header"/>

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -13,6 +13,7 @@ using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Menu.UI.Visualizer;
 using Quaver.Shared.Screens.Selection.Components;
 using Quaver.Shared.Screens.Selection.UI;
+using Quaver.Shared.Screens.Selection.UI.Background;
 using Quaver.Shared.Screens.Selection.UI.Borders.Footer;
 using Quaver.Shared.Screens.Selection.UI.FilterPanel;
 using Quaver.Shared.Screens.Selection.UI.Leaderboard;
@@ -184,7 +185,7 @@ namespace Quaver.Shared.Screens.Selection
         ///     Creates <see cref="Background"/>
         /// </summary>
         private void CreateBackground()
-            => Background = new BackgroundImage(UserInterface.TrianglesWallpaper, 0, false) { Parent = Container };
+            => Background = new SongSelectBackground() { Parent = Container };
 
         /// <summary>
         ///     Creates <see cref="Header"/>

--- a/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Backgrounds;
+using Wobble.Bindables;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.UI;
+
+namespace Quaver.Shared.Screens.Selection.UI.Background
+{
+    public class SongSelectBackground : BackgroundImage
+    {
+        public SongSelectBackground() : base(UserInterface.TrianglesWallpaper, 0, false)
+        {
+            MapManager.Selected.ValueChanged += OnMapChanged;
+            BackgroundHelper.Loaded += OnBackgroundLoaded;
+        }
+
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            MapManager.Selected.ValueChanged -= OnMapChanged;
+            BackgroundHelper.Loaded -= OnBackgroundLoaded;
+
+            base.Destroy();
+        }
+
+        private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
+        {
+            if (ConfigManager.DisplayMapBackgroundInSelect == null || !ConfigManager.DisplayMapBackgroundInSelect.Value)
+            {
+                Image = UserInterface.TrianglesWallpaper;
+                BrightnessSprite.ClearAnimations();
+                BrightnessSprite.FadeTo(0, Easing.Linear, 250);
+                return;
+            }
+
+            if (MapManager.GetBackgroundPath(e.Value) == MapManager.GetBackgroundPath(e.OldValue))
+                return;
+
+            BrightnessSprite.ClearAnimations();
+            BrightnessSprite.FadeTo(1, Easing.Linear, 250);
+        }
+
+        private void OnBackgroundLoaded(object sender, BackgroundLoadedEventArgs e)
+        {
+            if (ConfigManager.DisplayMapBackgroundInSelect == null || !ConfigManager.DisplayMapBackgroundInSelect.Value)
+                return;
+
+            if (e.Map != MapManager.Selected.Value)
+                return;
+
+            Image = e.Texture;
+            BrightnessSprite.ClearAnimations();
+            BrightnessSprite.FadeTo(0.80f, Easing.Linear, 250);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
@@ -3,6 +3,7 @@ using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics.Backgrounds;
+using Quaver.Shared.Skinning;
 using Wobble.Bindables;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.UI;
@@ -28,7 +29,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Background
 
         private void OnMapChanged(object sender, BindableValueChangedEventArgs<Map> e)
         {
-            if (ConfigManager.DisplayMapBackgroundInSelect == null || !ConfigManager.DisplayMapBackgroundInSelect.Value)
+            if (SkinManager.Skin == null || !SkinManager.Skin.SongSelect.DisplayMapBackground)
             {
                 Image = UserInterface.TrianglesWallpaper;
                 BrightnessSprite.ClearAnimations();
@@ -45,7 +46,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Background
 
         private void OnBackgroundLoaded(object sender, BackgroundLoadedEventArgs e)
         {
-            if (ConfigManager.DisplayMapBackgroundInSelect == null || !ConfigManager.DisplayMapBackgroundInSelect.Value)
+            if (SkinManager.Skin == null || !SkinManager.Skin.SongSelect.DisplayMapBackground)
                 return;
 
             if (e.Map != MapManager.Selected.Value)

--- a/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Background/SongSelectBackground.cs
@@ -54,7 +54,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Background
 
             Image = e.Texture;
             BrightnessSprite.ClearAnimations();
-            BrightnessSprite.FadeTo(0.80f, Easing.Linear, 250);
+
+            var brightness = SkinManager.Skin?.SongSelect?.MapBackgroundBrightness ?? 15;
+            BrightnessSprite.FadeTo((100 - brightness) / 100f, Easing.Linear, 250);
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
@@ -220,7 +220,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         {
             var container = (SongSelectContainer<Map>) ParentMap.Container;
 
-            Button = new SongSelectContainerButton(WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,

--- a/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
@@ -147,7 +147,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         /// </summary>
         public void Select(bool changeWidthInstantly = false)
         {
-            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.MapsetSelected ?? UserInterface.SelectedMapset;
 
             var fade = 1f;
             var time = 200;
@@ -182,7 +182,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.MapsetDeselected ?? UserInterface.DeselectedMapset;
 
             var fade = 0.85f;
             var time = 200;
@@ -220,7 +220,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         {
             var container = (SongSelectContainer<Map>) ParentMap.Container;
 
-            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHovered ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,

--- a/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
@@ -147,7 +147,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         /// </summary>
         public void Select(bool changeWidthInstantly = false)
         {
-            Image = UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
 
             var fade = 1f;
             var time = 200;
@@ -182,7 +182,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
 
             var fade = 0.85f;
             var time = 200;
@@ -296,7 +296,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
             {
                 Parent = this,
                 Position = new ScalableVector2(Name.X, Name.Y + Name.Height + 5),
-                Tint = ColorHelper.HexToColor("#757575"),
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelByColor ?? ColorHelper.HexToColor("#757575"),
                 UsePreviousSpriteBatchOptions = true
             };
 
@@ -304,7 +304,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
             {
                 Parent = this,
                 Position = new ScalableVector2(ByText.X + ByText.Width + 4, ByText.Y),
-                Tint = ColorHelper.HexToColor("#0587e5"),
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelCreatorColor ?? ColorHelper.HexToColor("#0587e5"),
                 UsePreviousSpriteBatchOptions = true
             };
         }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -222,7 +222,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         {
             var container = (SongSelectContainer<Mapset>) ParentMapset.Container;
 
-            Button = new SongSelectContainerButton(WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -269,7 +269,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {
                 Parent = this,
                 Position = new ScalableVector2(TitleX, 18),
-                UsePreviousSpriteBatchOptions = true
+                UsePreviousSpriteBatchOptions = true,
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelSongTitleColor ?? Color.White
             };
         }
 
@@ -282,7 +283,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
-                Tint = ColorHelper.HexToColor("#0587e5"),
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelSongArtistColor ?? ColorHelper.HexToColor("#0587e5"),
                 UsePreviousSpriteBatchOptions = true
             };
         }
@@ -310,7 +311,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {
                 Parent = this,
                 Position = new ScalableVector2(DividerLine.X + DividerLine.Width + ArtistCreatorSpacingX, Artist.Y),
-                Tint = ColorHelper.HexToColor("#757575"),
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelByColor ?? ColorHelper.HexToColor("#757575"),
                 UsePreviousSpriteBatchOptions = true
             };
 
@@ -318,8 +319,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {
                 Parent = this,
                 Position = new ScalableVector2(ByText.X + ByText.Width + ArtistCreatorSpacingX, Artist.Y),
-                Tint = Artist.Tint,
-                UsePreviousSpriteBatchOptions = true
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelCreatorColor ?? Artist.Tint,
+                UsePreviousSpriteBatchOptions = true,
             };
         }
 
@@ -462,7 +463,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Select(bool instantSizeChange = false)
         {
-            Image = UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
 
             var fade = 1f;
             var time = 200;
@@ -512,7 +513,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
 
             var fade = 0.85f;
             var time = 200;

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -440,11 +440,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             }
 
             if (has4k && !has7K)
-                return UserInterface.Keys4Panel;
+                return SkinManager.Skin?.SongSelect?.GameMode4K ?? UserInterface.Keys4Panel;
             if (has7K && !has4k)
-                return UserInterface.Keys7Panel;
+                return SkinManager.Skin?.SongSelect?.GameMode7K ?? UserInterface.Keys7Panel;
 
-            return UserInterface.BothModesPanel;
+            return SkinManager.Skin?.SongSelect?.GameMode4K7K ?? UserInterface.BothModesPanel;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -394,9 +394,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 switch (ParentMapset.Item.Maps.First().Game)
                 {
                     case MapGame.Osu:
-                        return UserInterface.StatusOtherGameOsu;
+                        return SkinManager.Skin?.SongSelect?.StatusOsu ?? UserInterface.StatusOtherGameOsu;
                     case MapGame.Etterna:
-                        return UserInterface.StatusOtherGameEtterna;
+                        return SkinManager.Skin?.SongSelect?.StatusStepmania ?? UserInterface.StatusOtherGameEtterna;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -405,13 +405,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             switch (ParentMapset.Item.Maps.Max(x => x.RankedStatus))
             {
                 case RankedStatus.NotSubmitted:
-                    return UserInterface.StatusNotSubmitted;
+                    return SkinManager.Skin?.SongSelect?.StatusNotSubmitted ??  UserInterface.StatusNotSubmitted;
                 case RankedStatus.Unranked:
-                    return UserInterface.StatusUnranked;
+                    return SkinManager.Skin?.SongSelect?.StatusUnranked ?? UserInterface.StatusUnranked;
                 case RankedStatus.Ranked:
-                    return UserInterface.StatusRanked;
+                    return SkinManager.Skin?.SongSelect?.StatusRanked ?? UserInterface.StatusRanked;
                 case RankedStatus.DanCourse:
-                    return UserInterface.StatusNotSubmitted;
+                    return SkinManager.Skin?.SongSelect?.StatusNotSubmitted ?? UserInterface.StatusNotSubmitted;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -254,7 +254,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             {
                 Parent = this,
                 Alignment = Alignment.MidRight,
-                Size = new ScalableVector2(421, 82),
+                Size = SkinManager.Skin?.SongSelect?.MapsetPanelBannerSize ?? new ScalableVector2(421, 82),
                 X = -2,
                 UsePreviousSpriteBatchOptions = true
             };

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -222,7 +222,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         {
             var container = (SongSelectContainer<Mapset>) ParentMapset.Container;
 
-            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHovered ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,
@@ -463,7 +463,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Select(bool instantSizeChange = false)
         {
-            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.MapsetSelected ?? UserInterface.SelectedMapset;
 
             var fade = 1f;
             var time = 200;
@@ -513,7 +513,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.MapsetDeselected ?? UserInterface.DeselectedMapset;
 
             var fade = 0.85f;
             var time = 200;

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -419,11 +419,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             }
 
             if (has4k && !has7K)
-                return UserInterface.Keys4Panel;
+                return SkinManager.Skin?.SongSelect?.GameMode4K ?? UserInterface.Keys4Panel;
             if (has7K && !has4k)
-                return UserInterface.Keys7Panel;
+                return SkinManager.Skin?.SongSelect?.GameMode7K ?? UserInterface.Keys7Panel;
 
-            return UserInterface.BothModesPanel;
+            return SkinManager.Skin?.SongSelect?.GameMode4K7K ?? UserInterface.BothModesPanel;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -245,7 +245,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             {
                 Parent = this,
                 Position = new ScalableVector2(TitleX, 18),
-                UsePreviousSpriteBatchOptions = true
+                UsePreviousSpriteBatchOptions = true,
+                Tint = SkinManager.Skin?.SongSelect?.MapsetPanelSongTitleColor ?? Color.White
             };
         }
 
@@ -258,7 +259,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             {
                 Parent = this,
                 Alignment = Alignment.MidRight,
-                Size = new ScalableVector2(421, 82),
+                Size = SkinManager.Skin?.SongSelect?.MapsetPanelBannerSize ?? new ScalableVector2(421, 82),
                 Image = UserInterface.DefaultBanner,
                 X = -2,
                 UsePreviousSpriteBatchOptions = true

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Modifiers;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;
 using Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Assets;
 using Wobble.Graphics;
@@ -209,7 +210,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         public void Select(bool changeWidthInstantly = false)
         {
-            Image = UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
 
             const int time = 200;
             AnimateSprites(1, 200);
@@ -224,7 +225,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
 
             const int time = 200;
             AnimateSprites(0.85f, 200);
@@ -272,6 +273,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
+                Key = { Tint = SkinManager.Skin?.SongSelect?.MapsetPanelByColor ?? ColorHelper.HexToColor("#808080") }
             };
         }
 
@@ -279,11 +281,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         private void CreateCreator()
         {
-            Creator = new PlaylistKeyValueDisplay("By:", "Me", ColorHelper.HexToColor("#0587E5"))
+            Creator = new PlaylistKeyValueDisplay("By:", "Me",
+                SkinManager.Skin?.SongSelect?.MapsetPanelCreatorColor ?? ColorHelper.HexToColor("#0587E5"))
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, MapCount.Y),
-                UsePreviousSpriteBatchOptions = true
+                UsePreviousSpriteBatchOptions = true,
+                Key = { Tint = SkinManager.Skin?.SongSelect?.MapsetPanelByColor ?? ColorHelper.HexToColor("#808080") }
             };
         }
 
@@ -296,7 +300,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             {
                 Parent = this,
                 UsePreviousSpriteBatchOptions = true,
-                Y = MapCount.Y
+                Y = MapCount.Y,
+                Key = { Tint = SkinManager.Skin?.SongSelect?.MapsetPanelByColor ?? ColorHelper.HexToColor("#808080") }
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -153,7 +153,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         {
             var container = (PlaylistContainer) Playlist.Container;
 
-            Button = new SongSelectContainerButton(WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -153,7 +153,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         {
             var container = (PlaylistContainer) Playlist.Container;
 
-            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHover ?? WobbleAssets.WhiteBox, container.ClickableArea)
+            Button = new SongSelectContainerButton(SkinManager.Skin?.SongSelect?.MapsetHovered ?? WobbleAssets.WhiteBox, container.ClickableArea)
             {
                 Parent = this,
                 Size = Size,
@@ -210,7 +210,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         public void Select(bool changeWidthInstantly = false)
         {
-            Image = SkinManager.Skin?.SongSelect?.SelectedMapset ?? UserInterface.SelectedMapset;
+            Image = SkinManager.Skin?.SongSelect?.MapsetSelected ?? UserInterface.SelectedMapset;
 
             const int time = 200;
             AnimateSprites(1, 200);
@@ -225,7 +225,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         public void Deselect(bool changeWidthInstantly = false)
         {
-            Image = SkinManager.Skin?.SongSelect.DeselectedMapset ?? UserInterface.DeselectedMapset;
+            Image = SkinManager.Skin?.SongSelect.MapsetDeselected ?? UserInterface.DeselectedMapset;
 
             const int time = 200;
             AnimateSprites(0.85f, 200);

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylistContainer.cs
@@ -367,9 +367,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 switch (Playlist.Item.PlaylistGame)
                 {
                     case MapGame.Osu:
-                        return UserInterface.StatusOtherGameOsu;
+                        return SkinManager.Skin?.SongSelect?.StatusOsu ?? UserInterface.StatusOtherGameOsu;
                     case MapGame.Etterna:
-                        return UserInterface.StatusOtherGameEtterna;
+                        return SkinManager.Skin?.SongSelect?.StatusStepmania ?? UserInterface.StatusOtherGameEtterna;
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -381,13 +381,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             switch (Playlist.Item.Maps.Max(x => x.RankedStatus))
             {
                 case RankedStatus.NotSubmitted:
-                    return UserInterface.StatusNotSubmitted;
+                    return SkinManager.Skin?.SongSelect?.StatusNotSubmitted ??  UserInterface.StatusNotSubmitted;
                 case RankedStatus.Unranked:
-                    return UserInterface.StatusUnranked;
+                    return SkinManager.Skin?.SongSelect?.StatusUnranked ?? UserInterface.StatusUnranked;
                 case RankedStatus.Ranked:
-                    return UserInterface.StatusRanked;
+                    return SkinManager.Skin?.SongSelect?.StatusRanked ?? UserInterface.StatusRanked;
                 case RankedStatus.DanCourse:
-                    return UserInterface.StatusNotSubmitted;
+                    return SkinManager.Skin?.SongSelect?.StatusNotSubmitted ?? UserInterface.StatusNotSubmitted;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -22,11 +22,11 @@ namespace Quaver.Shared.Skinning.Menus
 
         public ScalableVector2? MapsetPanelBannerSize { get; private set; }
 
-        public Texture2D SelectedMapset { get; private set; }
+        public Texture2D MapsetSelected { get; private set; }
 
-        public Texture2D DeselectedMapset { get; private set; }
+        public Texture2D MapsetDeselected { get; private set; }
 
-        public Texture2D MapsetHover { get; private set; }
+        public Texture2D MapsetHovered { get; private set; }
 
         public Texture2D GameMode4K { get; private set; }
 
@@ -78,9 +78,9 @@ namespace Quaver.Shared.Skinning.Menus
         {
             const string folder = "SongSelect";
 
-            SelectedMapset = LoadSkinElement(folder, "selected-mapset.png");
-            DeselectedMapset = LoadSkinElement(folder, "deselected-mapset.png");
-            MapsetHover = LoadSkinElement(folder, "mapset-hover.png");
+            MapsetSelected = LoadSkinElement(folder, "mapset-selected.png");
+            MapsetDeselected = LoadSkinElement(folder, "mapset-deselected.png");
+            MapsetHovered = LoadSkinElement(folder, "mapset-hovered.png");
             GameMode4K = LoadSkinElement(folder, "game-mode-4k.png");
             GameMode7K = LoadSkinElement(folder, "game-mode-7k.png");
             GameMode4K7K = LoadSkinElement(folder, "game-mode-4k7k.png");

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -1,0 +1,26 @@
+﻿using IniFileParser.Model;
+using Quaver.Shared.Config;
+
+namespace Quaver.Shared.Skinning.Menus
+{
+    public class SkinMenuSongSelect : SkinMenu
+    {
+        public bool DisplayMapBackground { get; private set; }
+
+        public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
+        {
+        }
+
+        protected override void ReadConfig()
+        {
+            var ini = Config["SongSelect"];
+
+            var displayMapBackground = ini["DisplayMapBackground"];
+            ReadIndividualConfig(displayMapBackground, () => DisplayMapBackground = ConfigHelper.ReadBool(false, displayMapBackground));
+        }
+
+        protected override void LoadElements()
+        {
+        }
+    }
+}

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -1,4 +1,6 @@
 ﻿using IniFileParser.Model;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Quaver.Shared.Config;
 
 namespace Quaver.Shared.Skinning.Menus
@@ -8,6 +10,18 @@ namespace Quaver.Shared.Skinning.Menus
         public bool DisplayMapBackground { get; private set; }
 
         public byte? MapBackgroundBrightness { get; private set; }
+
+        public Color? MapsetPanelSongTitleColor { get; private set; }
+
+        public Color? MapsetPanelSongArtistColor { get; private set; }
+
+        public Color? MapsetPanelCreatorColor { get; private set; }
+
+        public Color? MapsetPanelByColor { get; private set; }
+
+        public Texture2D SelectedMapset { get; private set; }
+
+        public Texture2D DeselectedMapset { get; private set; }
 
         public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
         {
@@ -22,10 +36,26 @@ namespace Quaver.Shared.Skinning.Menus
 
             var mapBackgroundBrightness = ini["MapBackgroundBrightness"];
             ReadIndividualConfig(mapBackgroundBrightness, () => MapBackgroundBrightness = ConfigHelper.ReadByte(0, mapBackgroundBrightness));
+
+            var mapsetPanelSongTitleColor = ini["MapsetPanelSongTitleColor"];
+            ReadIndividualConfig(mapsetPanelSongTitleColor, () => MapsetPanelSongTitleColor = ConfigHelper.ReadColor(Color.Transparent, mapsetPanelSongTitleColor));
+
+            var mapsetPanelSongArtistColor = ini["MapsetPanelSongArtistColor"];
+            ReadIndividualConfig(mapsetPanelSongArtistColor, () => MapsetPanelSongArtistColor = ConfigHelper.ReadColor(Color.Transparent, mapsetPanelSongArtistColor));
+
+            var mapsetPanelCreatorColor = ini["MapsetPanelCreatorColor"];
+            ReadIndividualConfig(mapsetPanelCreatorColor, () => MapsetPanelCreatorColor = ConfigHelper.ReadColor(Color.Transparent, mapsetPanelCreatorColor));
+
+            var mapsetPanelByColor = ini["MapsetPanelByColor"];
+            ReadIndividualConfig(mapsetPanelByColor, () => MapsetPanelByColor = ConfigHelper.ReadColor(Color.Transparent, mapsetPanelByColor));
         }
 
         protected override void LoadElements()
         {
+            const string folder = "SongSelect";
+
+            SelectedMapset = LoadSkinElement(folder, "selected-mapset.png");
+            DeselectedMapset = LoadSkinElement(folder, "deselected-mapset.png");
         }
     }
 }

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -29,6 +29,16 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Texture2D GameMode4K7K { get; private set; }
 
+        public Texture2D StatusNotSubmitted { get; private set; }
+
+        public Texture2D StatusUnranked { get; private set; }
+
+        public Texture2D StatusRanked { get; private set; }
+
+        public Texture2D StatusOsu { get; private set; }
+
+        public Texture2D StatusStepmania { get; private set; }
+
         public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
         {
         }
@@ -65,6 +75,11 @@ namespace Quaver.Shared.Skinning.Menus
             GameMode4K = LoadSkinElement(folder, "game-mode-4k.png");
             GameMode7K = LoadSkinElement(folder, "game-mode-7k.png");
             GameMode4K7K = LoadSkinElement(folder, "game-mode-4k7k.png");
+            StatusNotSubmitted = LoadSkinElement(folder, "status-notsubmitted.png");
+            StatusUnranked = LoadSkinElement(folder, "status-unranked.png");
+            StatusRanked = LoadSkinElement(folder, "status-ranked.png");
+            StatusOsu = LoadSkinElement(folder, "status-osu.png");
+            StatusStepmania = LoadSkinElement(folder, "status-sm.png");
         }
     }
 }

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -7,6 +7,8 @@ namespace Quaver.Shared.Skinning.Menus
     {
         public bool DisplayMapBackground { get; private set; }
 
+        public byte? MapBackgroundBrightness { get; private set; }
+
         public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
         {
         }
@@ -17,6 +19,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var displayMapBackground = ini["DisplayMapBackground"];
             ReadIndividualConfig(displayMapBackground, () => DisplayMapBackground = ConfigHelper.ReadBool(false, displayMapBackground));
+
+            var mapBackgroundBrightness = ini["MapBackgroundBrightness"];
+            ReadIndividualConfig(mapBackgroundBrightness, () => MapBackgroundBrightness = ConfigHelper.ReadByte(0, mapBackgroundBrightness));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.Shared.Config;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Skinning.Menus
 {
@@ -18,6 +19,8 @@ namespace Quaver.Shared.Skinning.Menus
         public Color? MapsetPanelCreatorColor { get; private set; }
 
         public Color? MapsetPanelByColor { get; private set; }
+
+        public ScalableVector2? MapsetPanelBannerSize { get; private set; }
 
         public Texture2D SelectedMapset { get; private set; }
 
@@ -64,6 +67,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var mapsetPanelByColor = ini["MapsetPanelByColor"];
             ReadIndividualConfig(mapsetPanelByColor, () => MapsetPanelByColor = ConfigHelper.ReadColor(Color.Transparent, mapsetPanelByColor));
+
+            var mapsetPanelBannerSize = ini["MapsetPanelBannerSize"];
+            ReadIndividualConfig(mapsetPanelBannerSize, () => MapsetPanelBannerSize = ConfigHelper.ReadVector2(new ScalableVector2(0, 0), mapsetPanelBannerSize));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -26,6 +26,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Texture2D DeselectedMapset { get; private set; }
 
+        public Texture2D MapsetHover { get; private set; }
+
         public Texture2D GameMode4K { get; private set; }
 
         public Texture2D GameMode7K { get; private set; }
@@ -78,6 +80,7 @@ namespace Quaver.Shared.Skinning.Menus
 
             SelectedMapset = LoadSkinElement(folder, "selected-mapset.png");
             DeselectedMapset = LoadSkinElement(folder, "deselected-mapset.png");
+            MapsetHover = LoadSkinElement(folder, "mapset-hover.png");
             GameMode4K = LoadSkinElement(folder, "game-mode-4k.png");
             GameMode7K = LoadSkinElement(folder, "game-mode-7k.png");
             GameMode4K7K = LoadSkinElement(folder, "game-mode-4k7k.png");

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -23,6 +23,12 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Texture2D DeselectedMapset { get; private set; }
 
+        public Texture2D GameMode4K { get; private set; }
+
+        public Texture2D GameMode7K { get; private set; }
+
+        public Texture2D GameMode4K7K { get; private set; }
+
         public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
         {
         }
@@ -56,6 +62,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             SelectedMapset = LoadSkinElement(folder, "selected-mapset.png");
             DeselectedMapset = LoadSkinElement(folder, "deselected-mapset.png");
+            GameMode4K = LoadSkinElement(folder, "game-mode-4k.png");
+            GameMode7K = LoadSkinElement(folder, "game-mode-7k.png");
+            GameMode4K7K = LoadSkinElement(folder, "game-mode-4k7k.png");
         }
     }
 }

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -71,6 +71,11 @@ namespace Quaver.Shared.Skinning
         internal SkinMenuMain MainMenu { get; }
 
         /// <summary>
+        ///     Skinning for the song select menu
+        /// </summary>
+        internal SkinMenuSongSelect SongSelect { get; }
+
+        /// <summary>
         ///     The name of the skin.
         /// </summary>
         internal string Name { get; private set; } = "Default Quaver Skin";
@@ -267,6 +272,7 @@ namespace Quaver.Shared.Skinning
 
             MenuBorder = new SkinMenuBorder(this, Config);
             MainMenu = new SkinMenuMain(this, Config);
+            SongSelect = new SkinMenuSongSelect(this, Config);
 
             LoadUniversalElements();
 


### PR DESCRIPTION
## Summary

* Adds skinning for the mapset/map/playlist panels in song select
* Adds skinning for the song select background.

## Song Select Background

The background texture of the screen.

**Ini Config**

| Key                     | Type                    | Description                                                                                                  |
|-------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------|
| DisplayMapBackground    | Boolean (True or False) | If true, the game will display the current map's background. If false, it'll display the default background. |
| MapBackgroundBrightness | Percentage (0-100)      | If `DisplayMapBackground` is true, this will be the brightness of the background.                            |

## Mapset Panel

The panels used for mapsets, maps, and playlists.

**Deselected Texture Location:** `/SongSelect/mapset-deselected.png`

**Selected Texture Location:** `/SongSelect/mapset-selected.png`

**Hovered Texture Location:** `/SongSelect/mapset-hovered.png` (1184x82)

**Optimal Texture Size:** 1188x86

**Ini Config**


| Key                        | Type                    | Description                                         |
|----------------------------|-------------------------|-----------------------------------------------------|
| MapsetPanelSongTitleColor  | RGB Color (255,255,255) | The color of the song title.                        |
| MapsetPanelSongArtistColor | RGB Color (255,255,255) | The color of the song artist.                       |
| MapsetPanelCreatorColor    | RGB Color (255,255,255) | The color of the map creator.                       |
| MapsetPanelByColor         | RGB Color (255,255,255) | The color of the "By:" text (and all similar texts) |
| MapsetPanelBannerSize      | Vector2 (0,0)           | The size of the map banner on the panel.            |

## Mapset Panel (Ranked Status)

The ranked statuses that appear on mapsets & playlists.

**Not Submitted Texture Location:** `/SongSelect/status-notsubmitted.png`

**Unranked Texture Location:** `/SongSelect/unranked-unranked.png`

**Ranked Texture Location:** `/SongSelect/status-ranked.png`

**osu! Texture Location:** `/SongSelect/status-osu.png`

**Stepmania Texture Location:** `/SongSelect/status-sm.png`

**Optimal Texture Size:** 115x28

## Mapset Panel (Game Mode)

The game mode of the mapset/map/playlist

**4K Texture Location:** `/SongSelect/game-mode-4k.png`

**7K Texture Location:** `/SongSelect/game-mode-7k.png`

**4K & 7K Texture Location:** `/SongSelect/game-mode-4k7k.png`

**Optimal Texture Size:** 71x28