### PR TITLE
Changes related to editor layers

### DIFF
--- a/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
@@ -230,14 +230,39 @@ namespace Quaver.Shared.Graphics.Containers
             {
                 var drawable = CreateObject(AvailableItems[index], index);
                 drawable.DestroyIfParentIsNull = false;
-                drawable.Y = (PoolStartingIndex + index) * drawable.Height + PaddingTop;
+
+                Pool.Insert(index, drawable);
 
                 if (updateContent)
-                    drawable.UpdateContent(AvailableItems[index], index);
-
-                Pool.Add(drawable);
+                {
+                    for (int i = index; i < Pool.Count; i++)
+                    {
+                        var foo = Pool[i];
+                        foo.Y = (PoolStartingIndex + i) * foo.Height + PaddingTop;
+                        foo.UpdateContent(AvailableItems[i], i);
+                    }
+                }
 
                 return drawable;
+            }
+        }
+
+        protected void AddObjectAtIndex(int index, T obj, bool scrollTo, bool usePoolCount = false)
+        {
+            lock (AvailableItems)
+            lock (Pool)
+            {
+                if (!AvailableItems.Contains(obj))
+                    AvailableItems.Insert(index, obj);
+
+                // Need another drawable to use
+                if (Pool.Count < PoolSize)
+                    AddContainedDrawable(AddObject(index));
+
+                RecalculateContainerHeight(usePoolCount);
+
+                if (scrollTo)
+                    ScrollTo(-index * DrawableHeight, 1000);
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -21,6 +21,7 @@ using Quaver.Shared.Screens.Edit.Actions.Hitsounds.Add;
 using Quaver.Shared.Screens.Edit.Actions.Hitsounds.Remove;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Colors;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Create;
+using Quaver.Shared.Screens.Edit.Actions.Layers.Merge;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Move;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Remove;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Rename;
@@ -455,6 +456,17 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <param name="layer"></param>
         /// <param name="hitObjects"></param>
         public void MoveHitObjectsToLayer(EditorLayerInfo layer, List<HitObjectInfo> hitObjects) => Perform(new EditorActionMoveObjectsToLayer(this, WorkingMap, layer, hitObjects));
+
+        /// <summary>
+        ///     Merges a non-default layer into another layer
+        /// </summary>
+        /// <param name="originLayer"></param>
+        /// <param name="destinationLayer"></param>
+        public void MergeLayers(EditorLayerInfo originLayer, EditorLayerInfo destinationLayer)
+        {
+            if (originLayer != EditScreen.DefaultLayer)
+                Perform(new EditorActionMergeLayers(this, WorkingMap, originLayer, destinationLayer, EditScreen.SelectedHitObjects));
+        }
 
         /// <summary>
         ///     Changes the color of a non-default editor layer

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -53,7 +53,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
     {
         /// <summary>
         /// </summary>
-        private EditScreen EditScreen { get; }
+        public EditScreen EditScreen { get; }
 
         /// <summary>
         /// </summary>
@@ -464,8 +464,13 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <param name="destinationLayer"></param>
         public void MergeLayers(EditorLayerInfo originLayer, EditorLayerInfo destinationLayer)
         {
-            if (originLayer != EditScreen.DefaultLayer)
-                Perform(new EditorActionMergeLayers(this, WorkingMap, originLayer, destinationLayer, EditScreen.SelectedHitObjects));
+            if (originLayer == destinationLayer)
+                return;
+
+            if (originLayer == EditScreen.DefaultLayer)
+                return;
+
+            Perform(new EditorActionMergeLayers(this, WorkingMap, originLayer, destinationLayer, EditScreen.SelectedHitObjects));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -426,7 +426,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Adds an editor layer to the map
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer) => Perform(new EditorActionCreateLayer(WorkingMap, this, EditScreen.SelectedHitObjects, layer));
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => Perform(new EditorActionCreateLayer(WorkingMap, this, EditScreen.SelectedHitObjects, layer, index));
 
         /// <summary>
         ///     Removes a non-default editor layer from the map

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
@@ -17,6 +17,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         RenameLayer,
         MoveToLayer,
         ColorLayer,
+        MergeLayers,
         ToggleLayerVisibility,
         AddScrollVelocity,
         RemoveScrollVelocity,

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -176,6 +176,12 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
+        /// <param name="originLayer"></param>
+        /// <param name="destinationLayer"></param>
+        public void MergeLayers(EditorLayerInfo originLayer, EditorLayerInfo destinationLayer) => ActionManager.MergeLayers(originLayer, destinationLayer);
+
+        /// <summary>
+        /// </summary>
         /// <param name="layer"></param>
         /// <param name="color"></param>
         public void ChangeLayerColor(EditorLayerInfo layer, int r, int g, int b) => ActionManager.ChangeLayerColor(layer, new Color(r, g, b));

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -155,7 +155,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <summary>
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index - 1);
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -155,7 +155,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <summary>
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer) => ActionManager.CreateLayer(layer);
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index - 1);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -17,21 +17,29 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
 
         private BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
+        private int Index { get; }
+
         public EditorActionCreateLayer(Qua workingMap, EditorActionManager actionManager, BindableList<HitObjectInfo> selectedHitObjects,
-            EditorLayerInfo layer)
+            EditorLayerInfo layer, int index = -1)
         {
             WorkingMap = workingMap;
             ActionManager = actionManager;
             Layer = layer;
             SelectedHitObjects = selectedHitObjects;
+            Index = index;
         }
 
         public void Perform()
         {
             if (!WorkingMap.EditorLayers.Contains(Layer))
-                WorkingMap.EditorLayers.Add(Layer);
+            {
+                if (Index >= 0)
+                    WorkingMap.EditorLayers.Insert(Index, Layer);
+                else
+                    WorkingMap.EditorLayers.Add(Layer);
+            }
 
-            ActionManager.TriggerEvent(EditorActionType.CreateLayer, new EditorLayerCreatedEventArgs(Layer));
+            ActionManager.TriggerEvent(EditorActionType.CreateLayer, new EditorLayerCreatedEventArgs(Layer, Index));
         }
 
         public void Undo() => new EditorActionRemoveLayer(ActionManager, WorkingMap, SelectedHitObjects, Layer).Perform();

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -33,9 +33,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
         {
             if (!WorkingMap.EditorLayers.Contains(Layer))
             {
-                if (Index >= 0)
+                if (Index >= 1)
                 {
-                    WorkingMap.EditorLayers.Insert(Index, Layer);
+                    WorkingMap.EditorLayers.Insert(Index - 1, Layer);
                     var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
                     hitObjects.ForEach(x => x.EditorLayer++);
                 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -34,7 +34,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
             if (!WorkingMap.EditorLayers.Contains(Layer))
             {
                 if (Index >= 0)
+                {
                     WorkingMap.EditorLayers.Insert(Index, Layer);
+                    var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
+                    hitObjects.ForEach(x => x.EditorLayer++);
+                }
                 else
                     WorkingMap.EditorLayers.Add(Layer);
             }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorLayerCreatedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorLayerCreatedEventArgs.cs
@@ -7,6 +7,12 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
     {
         public EditorLayerInfo Layer { get; }
 
-        public EditorLayerCreatedEventArgs(EditorLayerInfo l) => Layer = l;
+        public int Index { get; }
+
+        public EditorLayerCreatedEventArgs(EditorLayerInfo l, int index)
+        {
+            Layer = l;
+            Index = index;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Merge/EditorActionMergeLayers.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Merge/EditorActionMergeLayers.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Screens.Edit.Actions.Layers.Move;
+using Quaver.Shared.Screens.Edit.Actions.Layers.Remove;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Edit.Actions.Layers.Merge
+{
+    public class EditorActionMergeLayers : IEditorAction
+    {
+        public EditorActionType Type { get; } = EditorActionType.MergeLayers;
+
+        private EditorActionManager ActionManager { get; }
+
+        private Qua WorkingMap { get; }
+
+        private EditorLayerInfo OriginLayer { get; }
+
+        private EditorLayerInfo DestinationLayer { get; }
+
+        private BindableList<HitObjectInfo> SelectedHitObjects { get; }
+
+        private EditorActionMoveObjectsToLayer MoveObjectsToLayerAction { get; }
+
+        private EditorActionRemoveLayer RemoveLayerAction { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="manager"></param>
+        /// <param name="workingMap"></param>
+        /// <param name="originLayer"></param>
+        /// <param name="destinationLayer"></param>
+        /// <param name="selectedHitObjects"></param>
+        public EditorActionMergeLayers(EditorActionManager manager, Qua workingMap, EditorLayerInfo originLayer,
+            EditorLayerInfo destinationLayer, BindableList<HitObjectInfo> selectedHitObjects)
+        {
+            ActionManager = manager;
+            WorkingMap = workingMap;
+            OriginLayer = originLayer;
+            DestinationLayer = destinationLayer;
+            SelectedHitObjects = selectedHitObjects;
+
+            var HitObjectsInLayer = WorkingMap.HitObjects.FindAll(x => x.EditorLayer == WorkingMap.EditorLayers.FindIndex(l => l == OriginLayer) + 1);
+
+            MoveObjectsToLayerAction = new EditorActionMoveObjectsToLayer(ActionManager, WorkingMap, DestinationLayer, HitObjectsInLayer);
+            RemoveLayerAction = new EditorActionRemoveLayer(ActionManager, WorkingMap, SelectedHitObjects, OriginLayer);
+        }
+
+        public void Perform()
+        {
+            MoveObjectsToLayerAction.Perform();
+            RemoveLayerAction.Perform();
+        }
+
+        public void Undo()
+        {
+            RemoveLayerAction.Undo();
+            MoveObjectsToLayerAction.Undo();
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
@@ -66,7 +66,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
         public void Undo()
         {
             new EditorActionPlaceHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
-            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index - 1).Perform();
+            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index).Perform();
             HitObjectsInLayer.ForEach(x => x.EditorLayer = Index);
         }
     }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
@@ -26,6 +26,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 
         private BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
+        private int Index { get; set; }
+
         /// <summary>
         /// </summary>
         /// <param name="manager"></param>
@@ -43,9 +45,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 
         public void Perform()
         {
-            var index = WorkingMap.EditorLayers.IndexOf(Layer) + 1;
+            Index = WorkingMap.EditorLayers.IndexOf(Layer) + 1;
 
-            HitObjectsInLayer = WorkingMap.HitObjects.FindAll(x => x.EditorLayer == index);
+            HitObjectsInLayer = WorkingMap.HitObjects.FindAll(x => x.EditorLayer == Index);
 
             // Remove the objects from being selected
             HitObjectsInLayer.ForEach(x => SelectedHitObjects.Remove(x));
@@ -55,7 +57,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
             new EditorActionRemoveHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
 
             // Find HitObjects at the indices above it and update them
-            var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > index);
+            var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
             hitObjects.ForEach(x => x.EditorLayer--);
 
             ActionManager.TriggerEvent(EditorActionType.RemoveLayer, new EditorLayerRemovedEventArgs(Layer));
@@ -64,8 +66,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
         public void Undo()
         {
             new EditorActionPlaceHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
-            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer).Perform();
-            HitObjectsInLayer.ForEach(x => x.EditorLayer = WorkingMap.EditorLayers.Count);
+            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index - 1).Perform();
+            HitObjectsInLayer.ForEach(x => x.EditorLayer = Index);
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorLayerRemovedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorLayerRemovedEventArgs.cs
@@ -1,12 +1,12 @@
+using System;
 using Quaver.API.Maps.Structures;
-using Quaver.Shared.Screens.Edit.Actions.Layers.Create;
 
 namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 {
-    public class EditorLayerRemovedEventArgs : EditorLayerCreatedEventArgs
+    public class EditorLayerRemovedEventArgs : EventArgs
     {
-        public EditorLayerRemovedEventArgs(EditorLayerInfo l) : base(l)
-        {
-        }
+        public EditorLayerInfo Layer { get; }
+
+        public EditorLayerRemovedEventArgs(EditorLayerInfo l) => Layer = l;
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorLayerRenamedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorLayerRenamedEventArgs.cs
@@ -1,12 +1,18 @@
+using System;
 using Quaver.API.Maps.Structures;
-using Quaver.Shared.Screens.Edit.Actions.Layers.Create;
 
 namespace Quaver.Shared.Screens.Edit.Actions.Layers.Rename
 {
-    public class EditorLayerRenamedEventArgs : EditorLayerCreatedEventArgs
+    public class EditorLayerRenamedEventArgs : EventArgs
     {
+        public EditorLayerInfo Layer { get; }
+
         public string PreviousName { get; }
 
-        public EditorLayerRenamedEventArgs(EditorLayerInfo l, string previousName) : base(l) => PreviousName = previousName;
+        public EditorLayerRenamedEventArgs(EditorLayerInfo l, string previousName)
+        {
+            Layer = l;
+            PreviousName = previousName;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -751,6 +751,8 @@ namespace Quaver.Shared.Screens.Edit
 
                 var lane = i + 1;
 
+                var layer = WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 1;
+
                 // Can be multiple if overlap
                 var hitObjectsAtTime = WorkingMap.HitObjects.Where(h => h.Lane == lane && h.StartTime == time).ToList();
 
@@ -760,7 +762,7 @@ namespace Quaver.Shared.Screens.Edit
                         ActionManager.RemoveHitObject(note);
                 }
                 else
-                    ActionManager.PlaceHitObject(lane, time);
+                    ActionManager.PlaceHitObject(lane, time, 0, layer);
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -719,6 +719,14 @@ namespace Quaver.Shared.Screens.Edit
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.I))
                 PlaceTimingPointOrScrollVelocity();
+
+            if (KeyboardManager.IsUniqueKeyPress(Keys.M))
+            {
+                if (KeyboardManager.IsAltDown())
+                    MergeOntoDefault();
+                else
+                    MergeUp();
+            }
         }
 
         /// <summary>
@@ -1443,6 +1451,37 @@ namespace Quaver.Shared.Screens.Edit
                     });
                 }
             }
+        }
+
+        /// <summary>
+        ///     Merges the currently selected layer onto the default layer.
+        /// </summary>
+        private void MergeOntoDefault()
+        {
+            if (SelectedLayer.Value == DefaultLayer)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "You cannot edit the default layer!");
+                return;
+            }
+
+            ActionManager.MergeLayers(SelectedLayer.Value, DefaultLayer);
+        }
+
+        /// <summary>
+        ///     Merges the currently selected layer onto the layer above it.
+        /// </summary>
+        private void MergeUp()
+        {
+            if (SelectedLayer.Value == DefaultLayer)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "You cannot edit the default layer!");
+                return;
+            }
+
+            var index = WorkingMap.EditorLayers.IndexOf(SelectedLayer.Value);
+            var destLayer = index == 0 ? DefaultLayer :WorkingMap.EditorLayers[index - 1];
+
+            ActionManager.MergeLayers(SelectedLayer.Value, destLayer);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/DrawableEditorLayerRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/DrawableEditorLayerRightClickOptions.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Edit.Actions;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Remove;
@@ -18,6 +19,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
 
         private const string ChangeColor = "Change Color";
 
+        private const string Merge = "Merge";
+
         public DrawableEditorLayerRightClickOptions(EditorLayerInfo layer, EditorActionManager manager, Qua workingMap)
             : base(GetOptions(), new ScalableVector2(200, 40), 22)
         {
@@ -31,6 +34,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     case ChangeColor:
                         DialogManager.Show(new DialogChangeLayerColor(layer, manager, workingMap));
                         break;
+                    case Merge:
+                        var destLayer = manager.EditScreen.SelectedLayer.Value;
+                        if (layer == destLayer)
+                        {
+                            NotificationManager.Show(NotificationLevel.Warning, "You cannot merge a layer onto itself!");
+                            break;
+                        }
+                        manager.MergeLayers(layer, destLayer);
+                        break;
                 }
             };
         }
@@ -39,6 +51,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
         {
             {EditName, ColorHelper.HexToColor("#0787E3")},
             {ChangeColor, ColorHelper.HexToColor("#27B06E")},
+            {Merge, ColorHelper.HexToColor("#8622e3")},
         };
     }
 }

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
@@ -102,7 +102,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     ColorRgb = "255,255,255"
                 };
 
-                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 1;
+                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 2;
 
                 ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer, index));
             };

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
@@ -102,7 +102,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     ColorRgb = "255,255,255"
                 };
 
-                ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer));
+                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 1;
+
+                ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer, index));
             };
         }
 

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
@@ -141,10 +141,18 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
             if (Pool.Any(x => x.Item == e.Layer))
                 return;
 
-            AddObjectToBottom(e.Layer, true);
-
-            var item = Pool.Last() as DrawableEditorLayer;
-            SelectedLayer.Value = item?.Item;
+            if (e.Index >= 0)
+            {
+                AddObjectAtIndex(e.Index + 1, e.Layer, true);
+                var item = Pool[e.Index + 1] as DrawableEditorLayer;
+                SelectedLayer.Value = item?.Item;
+            }
+            else
+            {
+                AddObjectToBottom(e.Layer, true);
+                var item = Pool.Last() as DrawableEditorLayer;
+                SelectedLayer.Value = item?.Item;
+            }
         }
 
         private void OnLayerDeleted(object sender, EditorLayerRemovedEventArgs e)

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
@@ -141,10 +141,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
             if (Pool.Any(x => x.Item == e.Layer))
                 return;
 
-            if (e.Index >= 0)
+            if (e.Index >= 1)
             {
-                AddObjectAtIndex(e.Index + 1, e.Layer, true);
-                var item = Pool[e.Index + 1] as DrawableEditorLayer;
+                AddObjectAtIndex(e.Index, e.Layer, true);
+                var item = Pool[e.Index] as DrawableEditorLayer;
                 SelectedLayer.Value = item?.Item;
             }
             else


### PR DESCRIPTION
Additions/Changes
- Make toggling layer visibility not add to the undo stack
- Implement inserting an editor layer at a given index
- Creating a new layer using the editor now creates a new layer under the currently selected layer
- Plugins can specify an index to insert a layer at
- Top row number keys now add notes to selected layer (Fixes #2595)
- Implement layer merging (Fixes #620)
  - Ctrl+M to merge current layer into the one above
  - Ctrl+Alt+M to merge current layer into the default layer

Code Stuff
- Handling the index might be jank
- Updating the DrawableEditorLayers might be jank
- Made EditorLayerRemovedEventArgs and EditorLayerRenamedEventArgs not inherit from EditorLayerCreatedEventArgs
- ActionManager.EditScreen changed to public

Problems
- EditorActionMergeLayers unintuitively selects the layer above the one removed
- Merging through the right click menu is unintuitive
- Will need to add the layer merge action to the plugin utility function for creating actions eventually

To do
- [ ] Add move objects to layer to right click menu
- [ ] Change it so SelectedLayer.Value is set to DefaultLayer instead of null when Default Layer is selected