### PR TITLE
Add skinning for the song select leaderboard panel

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
@@ -116,7 +116,16 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// <summary>
         ///     Returns the background color of the table
         /// </summary>
-        private Color BackgroundColor => Score.Index % 2 == 0 ? ColorHelper.HexToColor("#363636") : ColorHelper.HexToColor("#242424");
+        private Color BackgroundColor
+        {
+            get
+            {
+                if (Score.Index % 2 == 0)
+                    return SkinManager.Skin?.SongSelect?.LeaderboardScoreColorEven ?? ColorHelper.HexToColor("#363636");
+
+                return SkinManager.Skin?.SongSelect?.LeaderboardScoreColorOdd ?? ColorHelper.HexToColor("#242424");
+            }
+        }
 
         /// <summary>
         ///     Tooltip that displays when hovering over <see cref="CantBeatAlert"/>
@@ -214,7 +223,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                     Rank.Text = $"{Score.Index + 1}.";
 
                 Username.Text = $"{score.Item.Name}";
-                Username.Tint = score.Item.Name == ConfigManager.Username.Value ? Colors.MainAccent : ColorHelper.HexToColor("#FBFFB6");
+
+                if (score.Item.Name == ConfigManager.Username.Value)
+                    Username.Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreUsernameSelfColor ?? Colors.MainAccent;
+                else
+                    Username.Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreUsernameOtherColor ?? ColorHelper.HexToColor("#FBFFB6");
 
                 PerformanceRating.Text = StringHelper.RatingToString(score.Item.PerformanceRating);
                 AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float) score.Item.Accuracy)}";
@@ -290,7 +303,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Alignment = Alignment.MidLeft,
                 X = PaddingLeft,
                 UsePreviousSpriteBatchOptions = true,
-                Alpha = 0
+                Alpha = 0,
+                Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreRankColor ?? Color.White
             };
         }
 
@@ -369,7 +383,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Alignment = Alignment.TopRight,
                 Y = 6,
                 X = PerformanceRatingX,
-                Tint = ColorHelper.HexToColor("#E9B736"),
+                Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreRatingColor ?? ColorHelper.HexToColor("#E9B736"),
                 UsePreviousSpriteBatchOptions = true
             };
         }
@@ -385,7 +399,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Alignment = Alignment.BotRight,
                 X = PerformanceRating.X,
                 Y = -PerformanceRating.Y,
-                UsePreviousSpriteBatchOptions = true
+                UsePreviousSpriteBatchOptions = true,
+                Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreAccuracyColor ?? Color.White
             };
         }
 
@@ -475,7 +490,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Alignment = Alignment.TopLeft,
                 UsePreviousSpriteBatchOptions = true,
                 Image = UserInterface.Clock,
-                Size = new ScalableVector2(12, 12)
+                Size = new ScalableVector2(12, 12),
             };
 
             Time = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 18)

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardPersonalBestScore.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardPersonalBestScore.cs
@@ -1,3 +1,4 @@
+using Microsoft.Xna.Framework;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics;
@@ -117,7 +118,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 Parent = this,
                 Alignment = Alignment.MidCenter,
-                Alpha = 0
+                Alpha = 0,
+                Tint = SkinManager.Skin?.SongSelect?.NoPersonalBestColor ?? Color.White
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardPersonalBestScore.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardPersonalBestScore.cs
@@ -3,6 +3,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
+using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
@@ -40,7 +41,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             Container = container;
             Size = new ScalableVector2(Container.Width, 70);
 
-            Image = UserInterface.PersonalBestScorePanel;
+            Image = SkinManager.Skin?.SongSelect?.PersonalBestPanel ?? UserInterface.PersonalBestScorePanel;
 
             CreateLoadingWheel();
             CreateNoPersonalBestScoreText();

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
@@ -15,6 +15,7 @@ using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Menu.UI.Jukebox;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
+using Quaver.Shared.Skinning;
 using TagLib.Ape;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
@@ -344,7 +345,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             StatusText = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 20)
             {
                 Parent = this,
-                Alignment = Alignment.MidCenter
+                Alignment = Alignment.MidCenter,
+                Tint = SkinManager.Skin?.SongSelect?.LeaderboardStatusTextColor ?? Color.White
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardTypeDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardTypeDropdown.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
     public class LeaderboardTypeDropdown : LabelledDropdown
     {
         public LeaderboardTypeDropdown() : base("RANKING: ", 24, new Dropdown(GetDropdownItems(),
-            new ScalableVector2(125, 30), 22, ColorHelper.HexToColor($"#10C8F6"),
+            new ScalableVector2(125, 30), 22, SkinManager.Skin?.SongSelect?.LeaderboardDropdownColor ?? ColorHelper.HexToColor($"#10C8F6"),
             GetSelectedIndex()))
         {
             Label.Tint = SkinManager.Skin.SongSelect?.LeaderboardRankingTitleColor ?? Color.White;

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardTypeDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardTypeDropdown.cs
@@ -7,6 +7,7 @@ using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Graphics.Form.Dropdowns.Custom;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
+using Quaver.Shared.Skinning;
 using Wobble.Bindables;
 using Wobble.Graphics;
 
@@ -15,8 +16,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
     public class LeaderboardTypeDropdown : LabelledDropdown
     {
         public LeaderboardTypeDropdown() : base("RANKING: ", 24, new Dropdown(GetDropdownItems(),
-            new ScalableVector2(125, 30), 22, ColorHelper.HexToColor($"#10C8F6"), GetSelectedIndex()))
+            new ScalableVector2(125, 30), 22, ColorHelper.HexToColor($"#10C8F6"),
+            GetSelectedIndex()))
         {
+            Label.Tint = SkinManager.Skin.SongSelect?.LeaderboardRankingTitleColor ?? Color.White;
+
             Dropdown.ItemSelected += OnItemSelected;
             ConfigManager.LeaderboardSection.ValueChanged += OnLeaderboardSectionChanged;
         }

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -154,6 +154,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
             {
                 Parent = this,
                 Alignment = Alignment.TopLeft,
+                Tint = SkinManager.Skin?.SongSelect?.LeaderboardTitleColor ?? Color.White
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -201,7 +201,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
             PersonalBestHeader = new SpriteTextPlus(Header.Font, "PERSONAL BEST", Header.FontSize)
             {
                 Parent = this,
-                Y = ScoresContainerBackground.Y + ScoresContainerBackground.Height + 28
+                Y = ScoresContainerBackground.Y + ScoresContainerBackground.Height + 28,
+                Tint = SkinManager.Skin?.SongSelect?.PersonalBestTitleColor ?? Color.White
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -15,6 +15,7 @@ using Quaver.Shared.Online;
 using Quaver.Shared.Screens.Select.UI.Leaderboard;
 using Quaver.Shared.Screens.Selection.UI.Leaderboard.Components;
 using Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings;
+using Quaver.Shared.Skinning;
 using WebSocketSharp;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -180,7 +181,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
                 Alignment = Alignment.TopLeft,
                 Y = Header.Y + Header.Height + 8,
                 Size = new ScalableVector2(Width,664),
-                Image = UserInterface.LeaderboardScoresPanel,
+                Image = SkinManager.Skin?.SongSelect?.LeaderboardPanel ?? UserInterface.LeaderboardScoresPanel,
                 AutoScaleHeight = true
             };
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -217,7 +217,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
                 Alignment = Alignment.TopRight,
                 Size = new ScalableVector2(25, 25),
                 Image = FontAwesome.Get(FontAwesomeIcon.fa_trophy),
-                Tint = ColorHelper.HexToColor("#E9B736"),
+                Tint = SkinManager.Skin?.SongSelect?.PersonalBestTrophyColor ?? ColorHelper.HexToColor("#E9B736"),
                 Alpha = 0
             };
         }
@@ -231,7 +231,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
                 Parent = this,
                 Y = PersonalBestTrophy.Y - 3,
                 Alignment = Alignment.TopRight,
-                Alpha = 0
+                Alpha = 0,
             };
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -232,6 +232,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
                 Y = PersonalBestTrophy.Y - 3,
                 Alignment = Alignment.TopRight,
                 Alpha = 0,
+                Tint = SkinManager.Skin?.SongSelect?.PersonalBestRankColor ?? Color.White
             };
         }
 

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -42,6 +42,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? LeaderboardDropdownColor { get; private set; }
 
+        public Color? PersonalBestTitleColor { get; private set; }
+
         #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
@@ -142,6 +144,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var leaderboardDropdownColor = ini["LeaderboardDropdownColor"];
             ReadIndividualConfig(leaderboardDropdownColor, () => LeaderboardDropdownColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardDropdownColor));
+
+            var personalBestTitleColor = ini["PersonalBestTitleColor"];
+            ReadIndividualConfig(personalBestTitleColor, () => PersonalBestTitleColor = ConfigHelper.ReadColor(Color.Transparent, personalBestTitleColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -50,6 +50,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? PersonalBestTrophyColor { get; private set; }
 
+        public Color? PersonalBestRankColor { get; private set; }
+
         #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
@@ -162,6 +164,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var personalBestTrophyColor = ini["PersonalBestTrophyColor"];
             ReadIndividualConfig(personalBestTrophyColor, () => PersonalBestTrophyColor = ConfigHelper.ReadColor(Color.Transparent, personalBestTrophyColor));
+
+            var personalBestRankColor = ini["PersonalBestRankColor"];
+            ReadIndividualConfig(personalBestRankColor, () => PersonalBestRankColor = ConfigHelper.ReadColor(Color.Transparent, personalBestRankColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -44,6 +44,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? PersonalBestTitleColor { get; private set; }
 
+        public Color? NoPersonalBestColor { get; private set; }
+
         #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
@@ -147,6 +149,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var personalBestTitleColor = ini["PersonalBestTitleColor"];
             ReadIndividualConfig(personalBestTitleColor, () => PersonalBestTitleColor = ConfigHelper.ReadColor(Color.Transparent, personalBestTitleColor));
+
+            var noPersonalBestColor = ini["NoPersonalBestColor"];
+            ReadIndividualConfig(noPersonalBestColor, () => NoPersonalBestColor = ConfigHelper.ReadColor(Color.Transparent, noPersonalBestColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -40,6 +40,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? LeaderboardRankingTitleColor { get; private set; }
 
+        public Color? LeaderboardDropdownColor { get; private set; }
+
         #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
@@ -137,6 +139,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var leaderboardRankingTitleColor = ini["LeaderboardRankingTitleColor"];
             ReadIndividualConfig(leaderboardRankingTitleColor, () => LeaderboardRankingTitleColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardRankingTitleColor));
+
+            var leaderboardDropdownColor = ini["LeaderboardDropdownColor"];
+            ReadIndividualConfig(leaderboardDropdownColor, () => LeaderboardDropdownColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardDropdownColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -42,6 +42,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? LeaderboardDropdownColor { get; private set; }
 
+        public Color? LeaderboardStatusTextColor { get; private set; }
+
         public Color? PersonalBestTitleColor { get; private set; }
 
         public Color? NoPersonalBestColor { get; private set; }
@@ -152,6 +154,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var noPersonalBestColor = ini["NoPersonalBestColor"];
             ReadIndividualConfig(noPersonalBestColor, () => NoPersonalBestColor = ConfigHelper.ReadColor(Color.Transparent, noPersonalBestColor));
+
+            var leaderboardStatusTextColor = ini["LeaderboardStatusTextColor"];
+            ReadIndividualConfig(leaderboardStatusTextColor, () => LeaderboardStatusTextColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardStatusTextColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -36,7 +36,11 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? LeaderboardScoreUsernameOtherColor { get; private set; }
 
-#region MAPSET
+        public Color? LeaderboardTitleColor { get; private set; }
+
+        public Color? LeaderboardRankingTitleColor { get; private set; }
+
+        #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
 
@@ -127,6 +131,12 @@ namespace Quaver.Shared.Skinning.Menus
 
             var leaderboardScoreUsernameOtherColor = ini["LeaderboardScoreUsernameOtherColor"];
             ReadIndividualConfig(leaderboardScoreUsernameOtherColor, () => LeaderboardScoreUsernameOtherColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreUsernameOtherColor));
+
+            var leaderboardTitleColor = ini["LeaderboardTitleColor"];
+            ReadIndividualConfig(leaderboardTitleColor, () => LeaderboardTitleColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardTitleColor));
+
+            var leaderboardRankingTitleColor = ini["LeaderboardRankingTitleColor"];
+            ReadIndividualConfig(leaderboardRankingTitleColor, () => LeaderboardRankingTitleColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardRankingTitleColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -48,6 +48,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Color? NoPersonalBestColor { get; private set; }
 
+        public Color? PersonalBestTrophyColor { get; private set; }
+
         #region MAPSET
 
         public Texture2D MapsetSelected { get; private set; }
@@ -157,6 +159,9 @@ namespace Quaver.Shared.Skinning.Menus
 
             var leaderboardStatusTextColor = ini["LeaderboardStatusTextColor"];
             ReadIndividualConfig(leaderboardStatusTextColor, () => LeaderboardStatusTextColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardStatusTextColor));
+
+            var personalBestTrophyColor = ini["PersonalBestTrophyColor"];
+            ReadIndividualConfig(personalBestTrophyColor, () => PersonalBestTrophyColor = ConfigHelper.ReadColor(Color.Transparent, personalBestTrophyColor));
         }
 
         protected override void LoadElements()

--- a/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuSongSelect.cs
@@ -22,17 +22,41 @@ namespace Quaver.Shared.Skinning.Menus
 
         public ScalableVector2? MapsetPanelBannerSize { get; private set; }
 
+        public Color? LeaderboardScoreColorEven { get; private set; }
+
+        public Color? LeaderboardScoreColorOdd { get; private set; }
+
+        public Color? LeaderboardScoreRankColor { get; private set; }
+
+        public Color? LeaderboardScoreRatingColor { get; private set; }
+
+        public Color? LeaderboardScoreAccuracyColor { get; private set; }
+
+        public Color? LeaderboardScoreUsernameSelfColor { get; private set; }
+
+        public Color? LeaderboardScoreUsernameOtherColor { get; private set; }
+
+#region MAPSET
+
         public Texture2D MapsetSelected { get; private set; }
 
         public Texture2D MapsetDeselected { get; private set; }
 
         public Texture2D MapsetHovered { get; private set; }
 
+#endregion
+
+#region GAME_MODE
+
         public Texture2D GameMode4K { get; private set; }
 
         public Texture2D GameMode7K { get; private set; }
 
         public Texture2D GameMode4K7K { get; private set; }
+
+#endregion
+
+#region  RANKED_STATUS
 
         public Texture2D StatusNotSubmitted { get; private set; }
 
@@ -43,6 +67,16 @@ namespace Quaver.Shared.Skinning.Menus
         public Texture2D StatusOsu { get; private set; }
 
         public Texture2D StatusStepmania { get; private set; }
+
+ #endregion
+
+#region LEADERBOARD
+
+        public Texture2D LeaderboardPanel { get; private set; }
+
+        public Texture2D PersonalBestPanel { get; private set; }
+
+#endregion
 
         public SkinMenuSongSelect(SkinStore store, IniData config) : base(store, config)
         {
@@ -72,6 +106,27 @@ namespace Quaver.Shared.Skinning.Menus
 
             var mapsetPanelBannerSize = ini["MapsetPanelBannerSize"];
             ReadIndividualConfig(mapsetPanelBannerSize, () => MapsetPanelBannerSize = ConfigHelper.ReadVector2(new ScalableVector2(0, 0), mapsetPanelBannerSize));
+
+            var leaderboardScoreColorEven = ini["LeaderboardScoreColorEven"];
+            ReadIndividualConfig(leaderboardScoreColorEven, () => LeaderboardScoreColorEven = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreColorEven));
+
+            var leaderboardScoreColorOdd = ini["LeaderboardScoreColorOdd"];
+            ReadIndividualConfig(leaderboardScoreColorOdd, () => LeaderboardScoreColorOdd = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreColorOdd));
+
+            var leaderboardScoreRankColor = ini["LeaderboardScoreRankColor"];
+            ReadIndividualConfig(leaderboardScoreRankColor, () => LeaderboardScoreRankColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreRankColor));
+
+            var leaderboardScoreRatingColor = ini["LeaderboardScoreRatingColor"];
+            ReadIndividualConfig(leaderboardScoreRatingColor, () => LeaderboardScoreRatingColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreRatingColor));
+
+            var leaderboardScoreAccuracyColor = ini["LeaderboardScoreAccuracyColor"];
+            ReadIndividualConfig(leaderboardScoreAccuracyColor, () => LeaderboardScoreAccuracyColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreAccuracyColor));
+
+            var leaderboardScoreUsernameSelfColor = ini["LeaderboardScoreUsernameSelfColor"];
+            ReadIndividualConfig(leaderboardScoreUsernameSelfColor, () => LeaderboardScoreUsernameSelfColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreUsernameSelfColor));
+
+            var leaderboardScoreUsernameOtherColor = ini["LeaderboardScoreUsernameOtherColor"];
+            ReadIndividualConfig(leaderboardScoreUsernameOtherColor, () => LeaderboardScoreUsernameOtherColor = ConfigHelper.ReadColor(Color.Transparent, leaderboardScoreUsernameOtherColor));
         }
 
         protected override void LoadElements()
@@ -89,6 +144,8 @@ namespace Quaver.Shared.Skinning.Menus
             StatusRanked = LoadSkinElement(folder, "status-ranked.png");
             StatusOsu = LoadSkinElement(folder, "status-osu.png");
             StatusStepmania = LoadSkinElement(folder, "status-sm.png");
+            LeaderboardPanel = LoadSkinElement(folder, "leaderboard-panel.png");
+            PersonalBestPanel = LoadSkinElement(folder, "personalbest-panel.png");
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds skinning for the song select leaderboard panel.

### Leaderboard Panel

The panel that displays the top 50 leaderboard scores.

**Texture Location:** `/SongSelect/leaderboard-panel.png`

**Optimal Texture Size: 564x664**

**Ini Config: [SongSelect]**

| Key                                | Type                    | Description                                                                            |
|------------------------------------|-------------------------|----------------------------------------------------------------------------------------|
| LeaderboardTitleColor              | RGB Color (255,255,255) | The color of the "LEADERBOARD" text                                                    |
| LeaderboardRankingTitleColor       | RGB Color (255,255,255) | The color of the "RANKING" text                                                        |
| LeaderboardDropdownColor           | RGB Color (255,255,255) | The color of the leaderboard ranking dropdown text                                     |
| LeaderboardStatusTextColor         | RGB Color (255,255,255) | The color of the status text in the leaderboard when no scores are available.          |
| LeaderboardScoreColorEven          | RGB Color (255,255,255) | The background color of the leaderboard scores for even number panels.                 |
| LeaderboardScoreColorOdd           | RGB Color (255,255,255) | The background color of the leaderboard scores for odd number panels.                  |
| LeaderboardScoreRankColor          | RGB Color (255,255,255) | The color of the text which displays a leaderboard score's rank.                       |
| LeaderboardScoreRatingColor        | RGB Color (255,255,255) | The color of the text which displays a leaderboard score's performance rating.         |
| LeaderboardScoreAccuracyColor      | RGB Color (255,255,255) | The color of the text which displays a leaderboard score's accuracy.                   |
| LeaderboardScoreUsernameSelfColor  | RGB Color (255,255,255) | The color of the text which displays the current player's username on the leaderboard. |
| LeaderboardScoreUsernameOtherColor | RGB Color (255,255,255) | The color of the text which displays other players' usernames on the leaderboard.      |

### Personal Best Panel

The panel that displays the player's personal best/top score.

**Texture Location:** `/SongSelect/personalbest-panel.png`

**Optimal Texture Size: 564x70**

**Ini Config: [SongSelect]**

| Key                     | Type                    | Description                                                                                  |
|-------------------------|-------------------------|----------------------------------------------------------------------------------------------|
| PersonalBestTitleColor  | RGB Color (255,255,255) | The color of the "PERSONAL BEST" text                                                        |
| PersonalBestTrophyColor | RGB Color (255,255,255) | The color of the trophy icon.                                                                |
| PersonalBestRankColor   | RGB Color (255,255,255) | The color of the text which displays the rank the personal best score is on the leaderboard. |
| NoPersonalBestColor     | RGB Color (255,255,255) | The color of the text which displays that there is no personal best score.                   |