### PR TITLE
Fix LN rendering past the receptor if hit late

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -449,9 +449,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             LongNoteEndSprite.Y = GetEndSpritePosition(offset, EndTrackPosition);
 
-            // Stop drawing LN body + end if the ln reaches half the height of the hitobject
+            // Stop drawing LN body + end if the ln reaches 0 height or below
             // (prevents body + end extending below this point)
-            if (CurrentLongNoteBodySize + LongNoteSizeDifference <= HitObjectSprite.Height / 2f || CurrentLongNoteBodySize <= 0)
+            if (CurrentLongNoteBodySize <= 0 || curTime >= Info.EndTime && CurrentlyBeingHeld)
             {
                 LongNoteEndSprite.Visible = false;
                 LongNoteBodySprite.Visible = false;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -449,9 +449,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             LongNoteEndSprite.Y = GetEndSpritePosition(offset, EndTrackPosition);
 
-            // Stop drawing LN body + end if the ln reaches 0 height or below
+            // Stop drawing LN body + end if the ln reaches half the height of the hitobject
             // (prevents body + end extending below this point)
-            if (CurrentLongNoteBodySize <= 0 || curTime >= Info.EndTime && CurrentlyBeingHeld)
+            if (CurrentLongNoteBodySize + LongNoteSizeDifference <= HitObjectSprite.Height / 2f || CurrentLongNoteBodySize <= 0 || curTime >= Info.EndTime && CurrentlyBeingHeld)
             {
                 LongNoteEndSprite.Visible = false;
                 LongNoteBodySprite.Visible = false;


### PR DESCRIPTION
Remove the "**[CurrentLongNoteBodySize + LongNoteSizeDifference <= HitObjectSprite.Height / 2f]**" line, which block the LN Body/Head from being rendered if the height was below half the hitobject's height. As this is an unnatural behavior i don't think this is necessary to keep.

Add "**[curTime >= Info.EndTime && CurrentlyBeingHeld]**", whose purpose is to fix the LN going beyond the hitposition if hit after the endtime AND only happen when trying to hit the object (otherwise every LN would dissapear once the current time is the endtime)

For example, currently LN act as such : https://streamable.com/0orq25 in which you can notice the LN body goes beyond the receptor cause hit too late.

And with the fix : https://streamable.com/qu1tln the LN doesn't go past the receptor if hit late

Also i'm not sure by what to change the comment so feel free to fix that one