### PR TITLE
Allow inserting an editor layer at a specified index

### DIFF
--- a/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
@@ -231,17 +231,16 @@ namespace Quaver.Shared.Graphics.Containers
                 var drawable = CreateObject(AvailableItems[index], index);
                 drawable.DestroyIfParentIsNull = false;
 
-                Pool.Insert(index, drawable);
+                Pool.Insert(index - PoolStartingIndex, drawable);
+
+                for (int i = index; i < Pool.Count; i++)
+                {
+                    var foo = Pool[i];
+                    foo.Y = (PoolStartingIndex + i) * foo.Height + PaddingTop;
+                }
 
                 if (updateContent)
-                {
-                    for (int i = index; i < Pool.Count; i++)
-                    {
-                        var foo = Pool[i];
-                        foo.Y = (PoolStartingIndex + i) * foo.Height + PaddingTop;
-                        foo.UpdateContent(AvailableItems[i], i);
-                    }
-                }
+                    drawable.UpdateContent(AvailableItems[index], index);
 
                 return drawable;
             }

--- a/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Containers/PoolableScrollContainer.cs
@@ -230,14 +230,39 @@ namespace Quaver.Shared.Graphics.Containers
             {
                 var drawable = CreateObject(AvailableItems[index], index);
                 drawable.DestroyIfParentIsNull = false;
-                drawable.Y = (PoolStartingIndex + index) * drawable.Height + PaddingTop;
+
+                Pool.Insert(index, drawable);
 
                 if (updateContent)
-                    drawable.UpdateContent(AvailableItems[index], index);
-
-                Pool.Add(drawable);
+                {
+                    for (int i = index; i < Pool.Count; i++)
+                    {
+                        var foo = Pool[i];
+                        foo.Y = (PoolStartingIndex + i) * foo.Height + PaddingTop;
+                        foo.UpdateContent(AvailableItems[i], i);
+                    }
+                }
 
                 return drawable;
+            }
+        }
+
+        protected void AddObjectAtIndex(int index, T obj, bool scrollTo, bool usePoolCount = false)
+        {
+            lock (AvailableItems)
+            lock (Pool)
+            {
+                if (!AvailableItems.Contains(obj))
+                    AvailableItems.Insert(index, obj);
+
+                // Need another drawable to use
+                if (Pool.Count < PoolSize)
+                    AddContainedDrawable(AddObject(index));
+
+                RecalculateContainerHeight(usePoolCount);
+
+                if (scrollTo)
+                    ScrollTo(-index * DrawableHeight, 1000);
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -426,7 +426,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Adds an editor layer to the map
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer) => Perform(new EditorActionCreateLayer(WorkingMap, this, EditScreen.SelectedHitObjects, layer));
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => Perform(new EditorActionCreateLayer(WorkingMap, this, EditScreen.SelectedHitObjects, layer, index));
 
         /// <summary>
         ///     Removes a non-default editor layer from the map

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -155,7 +155,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <summary>
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index - 1);
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -155,7 +155,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <summary>
         /// </summary>
         /// <param name="layer"></param>
-        public void CreateLayer(EditorLayerInfo layer) => ActionManager.CreateLayer(layer);
+        public void CreateLayer(EditorLayerInfo layer, int index = -1) => ActionManager.CreateLayer(layer, index - 1);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -36,7 +36,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
                 if (Index >= 1)
                 {
                     WorkingMap.EditorLayers.Insert(Index - 1, Layer);
-                    var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
+                    var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer >= Index);
                     hitObjects.ForEach(x => x.EditorLayer++);
                 }
                 else

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -17,21 +17,29 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
 
         private BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
+        private int Index { get; }
+
         public EditorActionCreateLayer(Qua workingMap, EditorActionManager actionManager, BindableList<HitObjectInfo> selectedHitObjects,
-            EditorLayerInfo layer)
+            EditorLayerInfo layer, int index = -1)
         {
             WorkingMap = workingMap;
             ActionManager = actionManager;
             Layer = layer;
             SelectedHitObjects = selectedHitObjects;
+            Index = index;
         }
 
         public void Perform()
         {
             if (!WorkingMap.EditorLayers.Contains(Layer))
-                WorkingMap.EditorLayers.Add(Layer);
+            {
+                if (Index >= 0)
+                    WorkingMap.EditorLayers.Insert(Index, Layer);
+                else
+                    WorkingMap.EditorLayers.Add(Layer);
+            }
 
-            ActionManager.TriggerEvent(EditorActionType.CreateLayer, new EditorLayerCreatedEventArgs(Layer));
+            ActionManager.TriggerEvent(EditorActionType.CreateLayer, new EditorLayerCreatedEventArgs(Layer, Index));
         }
 
         public void Undo() => new EditorActionRemoveLayer(ActionManager, WorkingMap, SelectedHitObjects, Layer).Perform();

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -33,9 +33,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
         {
             if (!WorkingMap.EditorLayers.Contains(Layer))
             {
-                if (Index >= 0)
+                if (Index >= 1)
                 {
-                    WorkingMap.EditorLayers.Insert(Index, Layer);
+                    WorkingMap.EditorLayers.Insert(Index - 1, Layer);
                     var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
                     hitObjects.ForEach(x => x.EditorLayer++);
                 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -34,7 +34,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
             if (!WorkingMap.EditorLayers.Contains(Layer))
             {
                 if (Index >= 0)
+                {
                     WorkingMap.EditorLayers.Insert(Index, Layer);
+                    var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
+                    hitObjects.ForEach(x => x.EditorLayer++);
+                }
                 else
                     WorkingMap.EditorLayers.Add(Layer);
             }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorLayerCreatedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorLayerCreatedEventArgs.cs
@@ -7,6 +7,12 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
     {
         public EditorLayerInfo Layer { get; }
 
-        public EditorLayerCreatedEventArgs(EditorLayerInfo l) => Layer = l;
+        public int Index { get; }
+
+        public EditorLayerCreatedEventArgs(EditorLayerInfo l, int index)
+        {
+            Layer = l;
+            Index = index;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
@@ -66,7 +66,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
         public void Undo()
         {
             new EditorActionPlaceHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
-            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index - 1).Perform();
+            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index).Perform();
             HitObjectsInLayer.ForEach(x => x.EditorLayer = Index);
         }
     }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
@@ -26,6 +26,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 
         private BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
+        private int Index { get; set; }
+
         /// <summary>
         /// </summary>
         /// <param name="manager"></param>
@@ -43,9 +45,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 
         public void Perform()
         {
-            var index = WorkingMap.EditorLayers.IndexOf(Layer) + 1;
+            Index = WorkingMap.EditorLayers.IndexOf(Layer) + 1;
 
-            HitObjectsInLayer = WorkingMap.HitObjects.FindAll(x => x.EditorLayer == index);
+            HitObjectsInLayer = WorkingMap.HitObjects.FindAll(x => x.EditorLayer == Index);
 
             // Remove the objects from being selected
             HitObjectsInLayer.ForEach(x => SelectedHitObjects.Remove(x));
@@ -55,7 +57,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
             new EditorActionRemoveHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
 
             // Find HitObjects at the indices above it and update them
-            var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > index);
+            var hitObjects = WorkingMap.HitObjects.FindAll(x => x.EditorLayer > Index);
             hitObjects.ForEach(x => x.EditorLayer--);
 
             ActionManager.TriggerEvent(EditorActionType.RemoveLayer, new EditorLayerRemovedEventArgs(Layer));
@@ -64,8 +66,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
         public void Undo()
         {
             new EditorActionPlaceHitObjectBatch(ActionManager, WorkingMap, HitObjectsInLayer).Perform();
-            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer).Perform();
-            HitObjectsInLayer.ForEach(x => x.EditorLayer = WorkingMap.EditorLayers.Count);
+            new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, Layer, Index - 1).Perform();
+            HitObjectsInLayer.ForEach(x => x.EditorLayer = Index);
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorLayerRemovedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorLayerRemovedEventArgs.cs
@@ -1,12 +1,12 @@
+using System;
 using Quaver.API.Maps.Structures;
-using Quaver.Shared.Screens.Edit.Actions.Layers.Create;
 
 namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 {
-    public class EditorLayerRemovedEventArgs : EditorLayerCreatedEventArgs
+    public class EditorLayerRemovedEventArgs : EventArgs
     {
-        public EditorLayerRemovedEventArgs(EditorLayerInfo l) : base(l)
-        {
-        }
+        public EditorLayerInfo Layer { get; }
+
+        public EditorLayerRemovedEventArgs(EditorLayerInfo l) => Layer = l;
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorLayerRenamedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorLayerRenamedEventArgs.cs
@@ -1,12 +1,18 @@
+using System;
 using Quaver.API.Maps.Structures;
-using Quaver.Shared.Screens.Edit.Actions.Layers.Create;
 
 namespace Quaver.Shared.Screens.Edit.Actions.Layers.Rename
 {
-    public class EditorLayerRenamedEventArgs : EditorLayerCreatedEventArgs
+    public class EditorLayerRenamedEventArgs : EventArgs
     {
+        public EditorLayerInfo Layer { get; }
+
         public string PreviousName { get; }
 
-        public EditorLayerRenamedEventArgs(EditorLayerInfo l, string previousName) : base(l) => PreviousName = previousName;
+        public EditorLayerRenamedEventArgs(EditorLayerInfo l, string previousName)
+        {
+            Layer = l;
+            PreviousName = previousName;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
@@ -102,7 +102,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     ColorRgb = "255,255,255"
                 };
 
-                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 2;
+                // FindIndex() returns -1 when the default layer is selected
+                int index = WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 2;
 
                 ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer, index));
             };

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
@@ -102,7 +102,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     ColorRgb = "255,255,255"
                 };
 
-                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 1;
+                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 2;
 
                 ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer, index));
             };

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayers.cs
@@ -102,7 +102,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
                     ColorRgb = "255,255,255"
                 };
 
-                ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer));
+                int index = SelectedLayer.Value == DefaultLayer ? 0 : WorkingMap.EditorLayers.FindIndex(l => l == SelectedLayer.Value) + 1;
+
+                ActionManager.Perform(new EditorActionCreateLayer(WorkingMap, ActionManager, SelectedHitObjects, layer, index));
             };
         }
 

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
@@ -141,10 +141,18 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
             if (Pool.Any(x => x.Item == e.Layer))
                 return;
 
-            AddObjectToBottom(e.Layer, true);
-
-            var item = Pool.Last() as DrawableEditorLayer;
-            SelectedLayer.Value = item?.Item;
+            if (e.Index >= 0)
+            {
+                AddObjectAtIndex(e.Index + 1, e.Layer, true);
+                var item = Pool[e.Index + 1] as DrawableEditorLayer;
+                SelectedLayer.Value = item?.Item;
+            }
+            else
+            {
+                AddObjectToBottom(e.Layer, true);
+                var item = Pool.Last() as DrawableEditorLayer;
+                SelectedLayer.Value = item?.Item;
+            }
         }
 
         private void OnLayerDeleted(object sender, EditorLayerRemovedEventArgs e)

--- a/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/Layers/EditorPanelLayersScrollContainer.cs
@@ -141,10 +141,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels.Layers
             if (Pool.Any(x => x.Item == e.Layer))
                 return;
 
-            if (e.Index >= 0)
+            if (e.Index >= 1)
             {
-                AddObjectAtIndex(e.Index + 1, e.Layer, true);
-                var item = Pool[e.Index + 1] as DrawableEditorLayer;
+                AddObjectAtIndex(e.Index, e.Layer, true);
+                var item = Pool[e.Index] as DrawableEditorLayer;
                 SelectedLayer.Value = item?.Item;
             }
             else


### PR DESCRIPTION
Additions 
- Implement inserting an editor layer at a given index
 - Creating a new layer using the editor now creates a new layer under the currently selected layer
 - Plugins can specify an index to insert a layer at

Code Stuff
 - Handling the index might be jank
 - Updating the DrawableEditorLayers might be jank