### PR TITLE
Make metronome use timing point's time signature

### DIFF
--- a/Quaver.Shared/Screens/Editor/Timing/Metronome.cs
+++ b/Quaver.Shared/Screens/Editor/Timing/Metronome.cs
@@ -107,7 +107,7 @@ namespace Quaver.Shared.Screens.Editor.Timing
             var totalBeats = (time - point.StartTime) / (point.MillisecondsPerBeat / (PlayHalfBeats.Value ? 2 : 1));
 
             CurrentTotalBeats = (int) Math.Floor(totalBeats);
-            CurrentBeat = (int) totalBeats % 4;
+            CurrentBeat = (int) totalBeats % (int) point.Signature;
 
             // Play samples
             if (CurrentTotalBeats == 0 && LastTotalBeats < 0 || CurrentBeat != LastBeat)


### PR DESCRIPTION
I forgot the metronome exists

Now the metronome should be playing 3/4 time signature properly