### PR TITLE
Revert "Take time signatures into account when rendering editor playfield lines"

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Quaver.API.Maps;
-using Quaver.API.Enums;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
@@ -185,7 +184,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
                 {
                     while (true)
                     {
-                        if (numBeatsOffsetted / BeatSnap.Value % (int)tp.Signature == 0
+                        if (numBeatsOffsetted / BeatSnap.Value % 4 == 0
                             && numBeatsOffsetted % BeatSnap.Value == 0 && startTime <= -2000)
                             break;
 
@@ -209,14 +208,14 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
                 {
                     var time = startTime + tp.MillisecondsPerBeat / BeatSnap.Value * i;
 
-                    var measureBeat = i / BeatSnap.Value % (int)tp.Signature == 0 && i % BeatSnap.Value == 0;
+                    var measureBeat = i / BeatSnap.Value % 4 == 0 && i % BeatSnap.Value == 0;
 
                     if (measureBeat && time >= tp.StartTime)
                         measureCount++;
 
                     var height = measureBeat ? 5 : 2;
 
-                    lines.Add(new EditorPlayfieldTimelineTick(Playfield, tp, time, i, measureCount, measureBeat && time >= tp.StartTime)
+                    lines.Add(new EditorPlayfieldTimelineTick(Playfield, tp, BeatSnap, time, i, measureCount)
                     {
                         Image = UserInterface.BlankBox,
                         Size = new ScalableVector2(Playfield.Width - 4, 0),
@@ -298,7 +297,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         }
 
         /// <summary>
-        ///     Gets an individual line color for the snap line.
+        ///     Gets an individual lioe color for the snap line.
         /// </summary>
         /// <param name="val"></param>
         /// <param name="i"></param>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
@@ -31,9 +31,14 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         public int Index { get; }
 
         /// <summary>
-        ///     Whether or not this line is for a measure.
+        ///     Determines if this line is for a measure.
         /// </summary>
-        public bool IsMeasureLine { get; }
+        public bool IsMeasureLine => Index / BeatSnap.Value % 4 == 0
+                                      && Index % BeatSnap.Value == 0 && Time >= TimingPoint.StartTime;
+
+        /// <summary>
+        /// </summary>
+        private BindableInt BeatSnap { get; }
 
         private SpriteTextPlus Measure { get; }
 
@@ -46,13 +51,13 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// <param name="time"></param>
         /// <param name="index"></param>
         /// <param name="measureCount"></param>
-        public EditorPlayfieldTimelineTick(EditorPlayfield playfield, TimingPointInfo tp, float time, int index, int measureCount, bool isMeasureLine)
+        public EditorPlayfieldTimelineTick(EditorPlayfield playfield, TimingPointInfo tp, BindableInt beatSnap, float time, int index, int measureCount)
         {
             Playfield = playfield;
             TimingPoint = tp;
             Index = index;
             Time = time;
-            IsMeasureLine = isMeasureLine;
+            BeatSnap = beatSnap;
 
             if (!IsMeasureLine)
                 return;


### PR DESCRIPTION
Reverts Quaver/Quaver#2760

Adding a timing point breaks the editor