### PR TITLE
Fix editor being broken upon adding a timing point

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using ImGuiNET;
 using Microsoft.Xna.Framework.Input;
+using Quaver.API.Enums;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Screens.Edit.Actions.Timing.AddBatch;
 using TagLib.Matroska;
@@ -156,7 +157,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 var point = new TimingPointInfo
                 {
                     StartTime = (float)Screen.Track.Time,
-                    Bpm = bpm
+                    Bpm = bpm,
+                    Signature = TimeSignature.Quadruple
                 };
 
                 Screen.ActionManager.PlaceTimingPoint(point);


### PR DESCRIPTION
Now the timing point panel creates a timing point with Signature of TimeSignature.Quadruple instead of defaulting to 0

Fixes the bug introduced with #2760.