### PR TITLE
Implement a per timing point setting to hide timing lines

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -36,6 +36,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.Add;
 using Quaver.Shared.Screens.Edit.Actions.Timing.AddBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpm;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpmBatch;
+using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeHidden;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffset;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffsetBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.Remove;
@@ -207,6 +208,11 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Event invoked when the BPM of a timing point has been changed
         /// </summary>
         public event EventHandler<EditorTimingPointBpmChangedEventArgs> TimingPointBpmChanged;
+
+        /// <summary>
+        ///     Event invoked when the lines of a timing point have been hidden or unhidden
+        /// </summary>
+        public event EventHandler<EditorTimingPointHiddenChangedEventArgs> TimingPointHiddenChanged;
 
         /// <summary>
         ///     Event invoked when a batch of timing points have had their BPM changed
@@ -401,6 +407,13 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <param name="tp"></param>
         /// <param name="bpm"></param>
         public void ChangeTimingPointBpm(TimingPointInfo tp, float bpm) => Perform(new EditorActionChangeTimingPointBpm(this, WorkingMap, tp, bpm));
+
+        /// <summary>
+        ///     Changes whether an existing timing point's lines are hidden or not
+        /// </summary>
+        /// <param name="tp"></param>
+        /// <param name="hidden"></param>
+        public void ChangeTimingPointHidden(TimingPointInfo tp, bool hidden) => Perform(new EditorActionChangeTimingPointHidden(this, WorkingMap, tp, hidden));
 
         /// <summary>
         ///     Changes a batch of timing points to a new BPM
@@ -604,6 +617,9 @@ namespace Quaver.Shared.Screens.Edit.Actions
                 case EditorActionType.ChangeTimingPointBpm:
                     TimingPointBpmChanged?.Invoke(this, (EditorTimingPointBpmChangedEventArgs)args);
                     break;
+                case EditorActionType.ChangeTimingPointHidden:
+                    TimingPointHiddenChanged?.Invoke(this, (EditorTimingPointHiddenChangedEventArgs)args);
+                    break;
                 case EditorActionType.ChangeTimingPointBpmBatch:
                     TimingPointBpmBatchChanged?.Invoke(this, (EditorChangedTimingPointBpmBatchEventArgs)args);
                     break;
@@ -653,6 +669,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             PreviewTimeChanged = null;
             TimingPointOffsetChanged = null;
             TimingPointBpmChanged = null;
+            TimingPointHiddenChanged = null;
             TimingPointBpmBatchChanged = null;
             TimingPointOffsetBatchChanged = null;
             ScrollVelocityOffsetBatchChanged = null;

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
@@ -29,6 +29,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ChangePreviewTime,
         ChangeTimingPointOffset,
         ChangeTimingPointBpm,
+        ChangeTimingPointHidden,
         ResetTimingPoint,
         ChangeTimingPointBpmBatch,
         ChangeTimingPointOffsetBatch,

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -117,6 +117,12 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
+        /// <param name="tp"></param>
+        /// <param name="hidden"></param>
+        public void ChangeTimingPointHidden(TimingPointInfo tp, bool hidden) => ActionManager.ChangeTimingPointHidden(tp, hidden);
+
+        /// <summary>
+        /// </summary>
         /// <param name="tps"></param>
         /// <param name="bpm"></param>
         public void ChangeTimingPointBpmBatch(List<TimingPointInfo> tps, float bpm) => ActionManager.ChangeTimingPointBpmBatch(tps, bpm);

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorActionChangeTimingPointHidden.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorActionChangeTimingPointHidden.cs
@@ -1,0 +1,38 @@
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+
+namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeHidden
+{
+    public class EditorActionChangeTimingPointHidden : IEditorAction
+    {
+        public EditorActionType Type { get; } = EditorActionType.ChangeTimingPointHidden;
+
+        private EditorActionManager ActionManager { get; }
+
+        private Qua WorkingMap { get; }
+
+        private TimingPointInfo TimingPoint { get; }
+
+        private bool OriginalHidden { get; }
+
+        private bool NewHidden { get; }
+
+        public EditorActionChangeTimingPointHidden(EditorActionManager manager, Qua workingMap, TimingPointInfo tp, bool newHidden)
+        {
+            ActionManager = manager;
+            WorkingMap = workingMap;
+            TimingPoint = tp;
+
+            OriginalHidden = tp.Hidden;
+            NewHidden = newHidden;
+        }
+
+        public void Perform()
+        {
+            TimingPoint.Hidden = NewHidden;
+            ActionManager.TriggerEvent(Type, new EditorTimingPointHiddenChangedEventArgs(OriginalHidden, NewHidden));
+        }
+
+        public void Undo() => new EditorActionChangeTimingPointHidden(ActionManager, WorkingMap, TimingPoint, OriginalHidden).Perform();
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorTimingPointHiddenChangedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorTimingPointHiddenChangedEventArgs.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeHidden
+{
+    public class EditorTimingPointHiddenChangedEventArgs : EventArgs
+    {
+        public bool OriginalHidden { get; }
+
+        public bool NewHidden { get; }
+
+        public EditorTimingPointHiddenChangedEventArgs(bool originalHidden, bool newHidden)
+        {
+            OriginalHidden = originalHidden;
+            NewHidden = newHidden;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -55,13 +55,14 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="bpm"></param>
         /// <param name="signature"></param>
         /// <returns></returns>
-        public static TimingPointInfo CreateTimingPoint(float startTime, float bpm, TimeSignature signature = TimeSignature.Quadruple)
+        public static TimingPointInfo CreateTimingPoint(float startTime, float bpm, TimeSignature signature = TimeSignature.Quadruple, bool hidden = false)
         {
             var tp = new TimingPointInfo()
             {
                 StartTime = startTime,
                 Bpm = bpm,
-                Signature = signature
+                Signature = signature,
+                Hidden = hidden
             };
 
             return tp;
@@ -91,7 +92,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="time"></param>
         /// <returns></returns>
         public static string MillisecondsToTime(float time) => TimeSpan.FromMilliseconds(time).ToString(@"mm\:ss\.fff");
-        
+
         public static bool IsKeyPressed(Keys k) => KeyboardManager.IsUniqueKeyPress(k);
 
         public static bool IsKeyReleased(Keys k) => KeyboardManager.IsUniqueKeyRelease(k);

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -339,11 +339,13 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// </summary>
         private void DrawTableHeader()
         {
-            ImGui.Columns(2);
+            ImGui.Columns(3);
             ImGui.SetColumnWidth(0, 160);
             ImGui.TextWrapped("Time");
             ImGui.NextColumn();
             ImGui.TextWrapped("BPM");
+            ImGui.NextColumn();
+            ImGui.TextWrapped("Hide Lines");
             ImGui.Columns();
             ImGui.Separator();
         }
@@ -354,7 +356,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         {
             ImGui.BeginChild("Timing Point Area");
 
-            ImGui.Columns(2);
+            ImGui.Columns(3);
             ImGui.SetColumnWidth(0, 160);
 
             if (
@@ -437,6 +439,12 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
                 ImGui.NextColumn();
                 ImGui.TextWrapped($"{point.Bpm:0.00}");
+                ImGui.NextColumn();
+
+                var hidden = point.Hidden;
+                // give each checkbox a unique ID based off timing point's StartTime so that they behave separately
+                if (ImGui.Checkbox($"##{point.StartTime}", ref hidden))
+                    Screen.ActionManager.ChangeTimingPointHidden(point, hidden);
                 ImGui.NextColumn();
             }
 

--- a/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
@@ -21,6 +21,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpm;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpmBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffset;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffsetBatch;
+using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeHidden;
 using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Selection.UI;
@@ -74,6 +75,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
             ActionManager.TimingPointBpmChanged += OnTimingPointBpmChanged;
             ActionManager.TimingPointBpmBatchChanged += OnTimingPointBpmBatchChanged;
             ActionManager.TimingPointOffsetBatchChanged += OnTimingPointOffsetBatchChanged;
+            ActionManager.TimingPointHiddenChanged += OnTimingPointHiddenChanged;
         }
 
         /// <inheritdoc />
@@ -103,6 +105,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
             ActionManager.TimingPointBpmChanged -= OnTimingPointBpmChanged;
             ActionManager.TimingPointBpmBatchChanged -= OnTimingPointBpmBatchChanged;
             ActionManager.TimingPointOffsetBatchChanged -= OnTimingPointOffsetBatchChanged;
+            ActionManager.TimingPointHiddenChanged -= OnTimingPointHiddenChanged;
 
             base.Destroy();
         }
@@ -157,6 +160,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
         private void OnTimingPointBpmChanged(object sender, EditorTimingPointBpmChangedEventArgs e) => Refresh();
 
         private void OnTimingPointOffsetBatchChanged(object sender, EditorChangedTimingPointOffsetBatchEventArgs e) => Refresh();
+
+        private void OnTimingPointHiddenChanged(object sender, EditorTimingPointHiddenChangedEventArgs e) => Refresh();
 
         private void OnScrollVelocityOffsetBatchChanged(object sender, EditorChangedScrollVelocityOffsetBatchEventArgs e) => Refresh();
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -90,6 +90,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
             for (var i = 0; i < map.TimingPoints.Count; i++)
             {
+                if (map.TimingPoints[i].Hidden)
+                    continue;
+
                 // Get target position and increment
                 // Target position has tolerance of 1ms so timing points dont overlap by chance
                 var target = i + 1 < map.TimingPoints.Count ? map.TimingPoints[i + 1].StartTime - 1 : map.Length;


### PR DESCRIPTION
Addresses #2518
Hides all timing lines instead of just the first one of a timing point because:
1. In the case of timing a song with variable tempo the two options are pretty much the same
2. Hiding all lines instead of the first is conceptually simpler
3. Hiding all timing lines allows more flexibility than hiding just the first

To Do:
- [x] Allow timing lines to be hidden from timing point panel
- [x] Implement editor action to set Hidden value of timing points