### PR TITLE
Fix osu! Directory Path

### DIFF
--- a/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/OtherGameMapDatabaseCache.cs
@@ -294,7 +294,7 @@ namespace Quaver.Shared.Database.Maps
 
                             var dir = line.Split("=")[1].Trim();
 
-                            MapManager.OsuSongsFolder = Directory.Exists(dir) ? dir + "/" : $"{osuFolder}/{dir}/";
+                            MapManager.OsuSongsFolder = dir == "Songs" ? $"{osuFolder}/{dir}/" : dir + "/";
                             break;
                         }
                     }


### PR DESCRIPTION
Because default path is "Songs" and " dir + "/" " will give the folder relative to Quaver. Now it check if the direction is simply "Songs", if it does, then it give the osu folder path by default, and if not, use the custom dir.