### PR TITLE
Editor: Allow num keys to change composition tool when livemapping is disabled

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -777,7 +777,7 @@ namespace Quaver.Shared.Screens.Edit
                 return;
 
             // Using i < 3 to prevent selecting the unimplemented Mine tool
-            for (var i = 0; i < 3; i++)
+            for (var i = 0; i < Enum.GetNames(typeof(EditorCompositionTool)).Length; i++)
             {
                 if (KeyboardManager.IsUniqueKeyPress(Keys.D1 + i))
                     CompositionTool.Value = (EditorCompositionTool)i;

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -445,6 +445,7 @@ namespace Quaver.Shared.Screens.Edit
             }
 
             HandleBeatSnapChanges();
+            HandleCompositionToolChanges();
             HandlePlaybackRateChanges();
             HandleTemporaryHitObjectPlacement();
             HandleCtrlInput();
@@ -763,6 +764,23 @@ namespace Quaver.Shared.Screens.Edit
                 }
                 else
                     ActionManager.PlaceHitObject(lane, time, 0, layer);
+            }
+        }
+
+        /// <summary>
+        ///     Switches the selected composition tool depending on the number key pressed
+        ///     Will only switch tools when live mapping is disabled
+        /// </summary>
+        private void HandleCompositionToolChanges()
+        {
+            if (LiveMapping.Value)
+                return;
+
+            // Using i < 3 to prevent selecting the unimplemented Mine tool
+            for (var i = 0; i < 3; i++)
+            {
+                if (KeyboardManager.IsUniqueKeyPress(Keys.D1 + i))
+                    CompositionTool.Value = (EditorCompositionTool)i;
             }
         }
 

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/EditorCompositionTool.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/EditorCompositionTool.cs
@@ -11,7 +11,6 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys
     {
         Select,
         Note,
-        LongNote,
-        Mine
+        LongNote
     }
 }

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/EditorRulesetKeys.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/EditorRulesetKeys.cs
@@ -211,7 +211,6 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys
                     break;
                 case EditorCompositionTool.Note:
                 case EditorCompositionTool.LongNote:
-                case EditorCompositionTool.Mine:
                     HandleHitObjectMouseInput();
                     break;
                 default:
@@ -666,7 +665,6 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys
             new EditorCompositionToolButton(View.CompositionToolbox, EditorCompositionTool.Select),
             new EditorCompositionToolButton(View.CompositionToolbox, EditorCompositionTool.Note),
             new EditorCompositionToolButton(View.CompositionToolbox, EditorCompositionTool.LongNote),
-            new EditorCompositionToolButton(View.CompositionToolbox, EditorCompositionTool.Mine)
         };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Editor/UI/Toolkit/EditorCompositionToolButton.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Toolkit/EditorCompositionToolButton.cs
@@ -79,10 +79,6 @@ namespace Quaver.Shared.Screens.Editor.UI.Toolkit
                     Icon.X += 2;
                     Name.Text = "Long Note";
                     break;
-                case EditorCompositionTool.Mine:
-                    Icon.Image = FontAwesome.Get(FontAwesomeIcon.fa_ban_circle_symbol);
-                    Name.Text = "Mine";
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }


### PR DESCRIPTION
Addresses #2073
Could also maybe remove using the up and down keys to change the tool