### PR TITLE
Result screen plot improvements

### DIFF
--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -113,6 +113,7 @@ namespace Quaver.Shared.Screens.Result.UI
                 FilterHitStats();
                 CreateDotsWithHitDifference();
                 CreateDotsWithoutHitDifference();
+                CreateMissLines();
             }
         }
 
@@ -266,6 +267,28 @@ namespace Quaver.Shared.Screens.Result.UI
                     StatsWithHitDifference.Add(hitStat);
                 else
                     StatsWithoutHitDifference.Add(hitStat);
+            }
+        }
+
+        /// <summary>
+        ///     Creates lines for misses to indicate combo breaks
+        /// </summary>
+        private void CreateMissLines()
+        {
+            foreach (var miss in Processor.Stats.FindAll(s => s.Judgement == Judgement.Miss))
+            {
+                Console.WriteLine(miss);
+                // ReSharper disable once ObjectCreationAsStatement
+                new Sprite
+                {
+                    Parent = this,
+                    Alpha = 0.35f,
+                    Tint = ResultsJudgementGraphBar.GetColor(Judgement.Miss),
+                    Alignment = Alignment.MidLeft,
+                    X = TimeToX(miss.SongPosition),
+                    Y = 0,
+                    Size = new ScalableVector2(MissLineWidth, Height)
+                };
             }
         }
 

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -206,7 +206,7 @@ namespace Quaver.Shared.Screens.Result.UI
                         Size = new ScalableVector2(Width, 2),
                     };
 
-                    LineData.Add(new HitDifferenceGraphLineData(judgement, line, difference * k));
+                    LineData.Add(new HitDifferenceGraphLineData(judgement, line, (difference - windowSize) * k));
                 }
             }
         }

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -14,8 +14,10 @@ using Quaver.API.Helpers;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.API.Maps.Processors.Scoring.Data;
 using Quaver.Shared.Assets;
+using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Deviance;
+using TagLib.Matroska;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
@@ -34,6 +36,11 @@ namespace Quaver.Shared.Screens.Result.UI
         ///     The size of each miss dot.
         /// </summary>
         private const float MissDotSize = 5;
+
+        /// <summary>
+        ///     The width of each miss line.
+        /// </summary>
+        private const float MissLineWidth = 2;
 
         /// <summary>
         ///     The largest of the dot sizes. Used for things like minimum graph width and dot positioning.
@@ -124,8 +131,7 @@ namespace Quaver.Shared.Screens.Result.UI
         /// <returns></returns>
         private float TimeToX(float time)
         {
-            var totalLength = LatestHitTime - EarliestHitTime;
-
+            var totalLength = Processor.Map.Length;
             if (totalLength == 0)
                 return Width / 2;
 

--- a/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultHitDifferenceGraph.cs
@@ -111,9 +111,9 @@ namespace Quaver.Shared.Screens.Result.UI
             if (Processor.Stats != null)
             {
                 FilterHitStats();
+                CreateMissLines();
                 CreateDotsWithHitDifference();
                 CreateDotsWithoutHitDifference();
-                CreateMissLines();
             }
         }
 

--- a/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
+++ b/Quaver.Shared/Screens/Result/UI/ResultScoreContainer.cs
@@ -146,7 +146,7 @@ namespace Quaver.Shared.Screens.Result.UI
             CreateOnlineStats();
 
             // Create the graph but don't set a constructor, as we need to draw it to a RenderTarget2D
-            HitDifferenceGraphRaw = new ResultHitDifferenceGraph(new ScalableVector2(Width - VerticalDividerLine.X - 30, 200), Processor);
+            HitDifferenceGraphRaw = new ResultHitDifferenceGraph(new ScalableVector2(Width - VerticalDividerLine.X - 30, 200), Processor, ResultScreen.Map);
         }
 
         public override void Update(GameTime gameTime)

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/HitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/HitDifferenceGraph.cs
@@ -50,7 +50,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Deviance
         /// <summary>
         /// </summary>
         private void CreateGraph() => Graph = new ResultHitDifferenceGraph(new ScalableVector2(Width - 50, Height),
-            Processor.Value)
+            Processor.Value, Map)
         {
             Parent = this,
             Alignment = Alignment.TopRight,


### PR DESCRIPTION
- Scale graph to full map length instead of only played notes
  - Makes failed plays or aborted plays show the total progress in the map
- Shift judgement labels by 1
  - Right now the labels are set for the upper bound, when it should actually be the lower bound of a judgement
- Add Miss Lines
  - Makes it easier to see combobreaks instead of relying on the center dots

![dotnet_2021-01-20_17-17-25](https://user-images.githubusercontent.com/22303902/105204396-67a98a00-5b44-11eb-89b1-a15e3c32fe74.png)