### PR TITLE
Fix banners not exporting to .qp file

### DIFF
--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -117,14 +117,48 @@ namespace Quaver.Shared.Database.Maps
         }
 
         /// <summary>
+        ///     Gets the banner path for a given map.
+        /// </summary>
+        /// <param name="map"></param>
+        /// <returns></returns>
+        public static string GetBannerPath(Map map)
+        {
+            if (map == null)
+                return "";
+
+            switch (map.Game)
+            {
+                case MapGame.Osu:
+                    return "";
+                case MapGame.Quaver:
+                    return ConfigManager.SongDirectory + "/" + map.Directory + "/" + map.BannerPath;
+                case MapGame.Etterna:
+                    return map.BannerPath;
+                default:
+                    return "";
+            }
+        }
+
+        /// <summary>
         ///     Returns the path of the banner file provided a mapset
         /// </summary>
         /// <param name="mapset"></param>
         /// <returns></returns>
-        public static string GetBannerPath(Mapset mapset)
+        public static string GetMapsetBannerPath(Mapset mapset)
         {
             var map = mapset.Maps.First();
-            return (ConfigManager.SongDirectory + "/" + map.Directory + "/" + map.BannerPath).Replace("\\", "/");
+
+            switch (map.Game)
+            {
+                case MapGame.Osu:
+                    return "";
+                case MapGame.Quaver:
+                    return (ConfigManager.SongDirectory + "/" + map.Directory + "/" + map.BannerPath).Replace("\\", "/");
+                case MapGame.Etterna:
+                    return map.BannerPath;
+                default:
+                    return "";
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Database/Maps/Mapset.cs
+++ b/Quaver.Shared/Database/Maps/Mapset.cs
@@ -89,10 +89,8 @@ namespace Quaver.Shared.Database.Maps
                                 Logger.Debug($"Successfully converted osu beatmap: {osuPath}", LogType.Runtime);
                                 break;
                             case MapGame.Etterna:
-                                var stepFile = new StepFile(map.Path)
-                                {
-                                    Background = Path.GetFileName(map.BackgroundPath)
-                                };
+                                var stepFile = new StepFile(map.Path);
+
                                 var fileName = StringHelper.FileNameSafeString($"{map.Artist} - {map.Title} [{map.DifficultyName}].qua");
                                 var fileSavePath = $"{tempFolder}/{fileName}";
                                 stepFile.ToQuas().Find(x => x.DifficultyName == map.DifficultyName).Save(fileSavePath);

--- a/Quaver.Shared/Database/Maps/Mapset.cs
+++ b/Quaver.Shared/Database/Maps/Mapset.cs
@@ -89,7 +89,10 @@ namespace Quaver.Shared.Database.Maps
                                 Logger.Debug($"Successfully converted osu beatmap: {osuPath}", LogType.Runtime);
                                 break;
                             case MapGame.Etterna:
-                                var stepFile = new StepFile(map.Path);
+                                var stepFile = new StepFile(map.Path)
+                                {
+                                    Background = Path.GetFileName(map.BackgroundPath)
+                                };
                                 var fileName = StringHelper.FileNameSafeString($"{map.Artist} - {map.Title} [{map.DifficultyName}].qua");
                                 var fileSavePath = $"{tempFolder}/{fileName}";
                                 stepFile.ToQuas().Find(x => x.DifficultyName == map.DifficultyName).Save(fileSavePath);
@@ -113,6 +116,14 @@ namespace Quaver.Shared.Database.Maps
 
                         if (File.Exists(MapManager.GetBackgroundPath(map)) && !File.Exists(bgPath))
                             File.Copy(MapManager.GetBackgroundPath(map), bgPath);
+
+                        // Copy over banner file if necessary
+                        var bnPath = map.Game != MapGame.Etterna ?
+                            $"{tempFolder}/{map.BannerPath}" :
+                            $"{tempFolder}/{Path.GetFileName(map.BannerPath)}";
+
+                        if (File.Exists(MapManager.GetBannerPath(map)) && !File.Exists(bnPath))
+                            File.Copy(MapManager.GetBannerPath(map), bnPath);
                     }
                     catch (Exception e)
                     {

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -249,7 +249,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
                 // Give custom banners first priority
                 var bannerExists = true;
 
-                var path = MapManager.GetBannerPath(mapset);
+                var path = MapManager.GetMapsetBannerPath(mapset);
 
                 // Give map backgrounds second priority
                 if (!File.Exists(path))


### PR DESCRIPTION
Change : 
     - Rename old GetBannerPath to GetMapsetBannerPath so we can differentiate what is getting called and for what reason (GetMapsetBannerPath being called to get the mapset banner when loading menu screen, and GetBannerPath for when exporting file)
     - Add a proper GetBannerPath to be able to export the Banner file.
     - Make GetMapsetBannerPath work for etterna chart.
     - Fix Background not being named correctly in the .qua file when exporting an etterna chart from the etterna database. (Because sometime (quite often actually) the file name after the background case is not the same as the background file.) **REQUIRE CHANGE IN Quaver.API** https://github.com/Quaver/Quaver.API/pull/106