### PR TITLE
diff-scaling

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -101,7 +101,7 @@ namespace Quaver.Shared.Assets
         public static Texture2D StatusPanel => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/status-panel.png");
         public static Texture2D DefaultBanner => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/default-banner.png");
         public static Texture2D DifficultyBarBackground => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/difficultybar-bg.png");
-        public static Texture2D DifficultyBarColor => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/difficultybar-colour.png");
+        public static Texture2D DifficultyBarColor => TextureManager.Load("Quaver.Resources/Textures/UI/SongSelect/difficulty-bar-color.png");
         public static Texture2D LeaderboardScoresPanel => TextureManager.Load(@"Quaver.Resources/Textures/UI/SongSelect/leaderboard-scores-panel.png");
         public static Texture2D PersonalBestScorePanel => TextureManager.Load(@"Quaver.Resources/Textures/UI/SongSelect/personal-best-score-panel.png");
         public static Texture2D WarningRed => TextureManager.Load(@"Quaver.Resources/Textures/UI/SongSelect/warning-red.png");

--- a/Quaver.Shared/Helpers/ColorHelper.cs
+++ b/Quaver.Shared/Helpers/ColorHelper.cs
@@ -20,22 +20,24 @@ namespace Quaver.Shared.Helpers
         internal static Color DifficultyToColor(float rating)
         {
             // Beginner
-            if (rating < 1)
+            if (rating < 2)
                 return HexToColor("#D1FFFA");
             // Easy
-            if (rating < 3.5f)
+            if (rating < 7)
                 return HexToColor("#5EFF75");
             // Normal
-            if (rating < 8)
+            if (rating < 16)
                 return HexToColor("#5EC4FF");
             // Hard
-            if (rating < 19)
+            if (rating < 38)
                 return HexToColor("#F5B25B");
             // Insane
-            if (rating < 28)
+            if (rating < 56)
                 return HexToColor("#F9645D");
+            if (rating < 70)
+                return HexToColor("#D761EB");
             // Expert
-            return HexToColor("#D761EB");
+            return HexToColor("#7B61EB");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/DifficultyBarDisplay.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/DifficultyBarDisplay.cs
@@ -83,7 +83,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps.Components.Difficulty
         {
             var diff = Map.DifficultyFromMods(ModManager.Mods);
 
-            const int maxDiff = 35;
+            const int maxDiff = 100;
 
             var percent = diff / maxDiff;
 


### PR DESCRIPTION
scale qr to be a 0-100 system. Currently the bar goes from 0-35 and the highest threshold is at 28 qr, yet we have 3 maps ranked at 60 qr. For most players (myself included) upon hearing a map is "37 qr" the kneejerk reaction is "what does that mean". With this change, there is a very understandable and intuitive scale of 0-100, with a new extra threshold starting at 70 qr (35 now). the hypothetical 37 qr chart now becomes a 74 qr chart. Instantly we have a perfect idea of how difficult this chart is. its 75% of the way to the top of the bar! Not to mention how different the feeling is for a player when they get a 40 qr play vs an 80 qr play- 25 qr play vs 50 qr play and so on; its much more responsive and gives a better sense of progression, theres a legitimate max level to work towards (and then some with the few 100qr+ difficulty charts). Along with this change we will halve the players overall weighted performance rating. This is best explained by ice as it does also serve a purpose beyond allowing us to enact this change without updating achievement thresholds:

"so lets say all difficulty ratings were multiplied by 2
my overall rating would be 1560, the weighted average would be 78
your overall rating would be 1700, the weighted average would be 85
can you see how these relate to the current overall ratings?
because of the factor of 20, the current rating is the weighted average of the new diff numbers x10 

basically with my proposal, you would have 850 rating and that would be 85 weighted average
i would have 780 and that would be 78 weighted average
its super easy to relate the overall rating to the difficulty numbers now!
and it wouldnt require any achievement changes relating to overall rating!

in short: 
multiply all difficulty values by 2 as you proposed, use the weighted sum formula (play_1 * 0.95^0 + play_2 * 0.95^1 + ...) / 2"
- icedynamix


also ties into pr with https://github.com/Quaver/Quaver.API/pull/108