### PR TITLE
Add more streamer files

### DIFF
--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -169,7 +169,7 @@ namespace Quaver.Shared.Screens.Loading
             var streamerValues = new[]
             {
                 ("difficulty", $"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}"),
-                ("map", MapManager.Selected.Value.Qua.ToString()),
+                ("map", MapManager.Selected.Value.Qua + " "),
                 ("mods", ModHelper.GetModsString(ModManager.Mods)),
                 ("mapid", MapManager.Selected.Value.MapId.ToString())
             };

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -8,7 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Quaver.API.Enums;
+using Quaver.API.Helpers;
 using Quaver.API.Maps;
 using Quaver.API.Replays;
 using Quaver.Server.Client.Handlers;
@@ -89,6 +91,7 @@ namespace Quaver.Shared.Screens.Loading
                 try
                 {
                     ParseAndLoadMap();
+                    WriteStreamerFiles();
                     LoadGameplayScreen();
                 }
                 catch (Exception e)
@@ -156,13 +159,26 @@ namespace Quaver.Shared.Screens.Loading
 
                 MapManager.Selected.Value.Qua.RandomizeLanes(seed);
             }
+        }
 
-            // Asynchronously write to a file for livestreamers the difficulty rating
-            using (var writer = File.CreateText(ConfigManager.TempDirectory + "/Now Playing/difficulty.txt"))
-                writer.Write($"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}");
+        /// <summary>
+        ///    Asynchronously writes files for livestreamers
+        /// </summary>
+        private static void WriteStreamerFiles()
+        {
+            var streamerValues = new[]
+            {
+                ("difficulty", $"{MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods):0.00}"),
+                ("map", MapManager.Selected.Value.Qua.ToString()),
+                ("mods", ModHelper.GetModsString(ModManager.Mods)),
+                ("mapid", MapManager.Selected.Value.MapId.ToString())
+            };
 
-            using (var writer = File.CreateText(ConfigManager.TempDirectory + "/Now Playing/map.txt"))
-                writer.Write($"{MapManager.Selected.Value.Qua.Artist} - {MapManager.Selected.Value.Qua.Title} [{MapManager.Selected.Value.Qua.DifficultyName}] ");
+            foreach (var (fileName, value) in streamerValues)
+            {
+                using (var writer = File.CreateText($"{ConfigManager.TempDirectory}/Now Playing/{fileName}.txt"))
+                    writer.Write(value);
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -176,8 +176,15 @@ namespace Quaver.Shared.Screens.Loading
 
             foreach (var (fileName, value) in streamerValues)
             {
-                using (var writer = File.CreateText($"{ConfigManager.TempDirectory}/Now Playing/{fileName}.txt"))
-                    writer.Write(value);
+                try
+                {
+                    using (var writer = File.CreateText($"{ConfigManager.TempDirectory}/Now Playing/{fileName}.txt"))
+                        writer.Write(value);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                }
             }
         }
 


### PR DESCRIPTION
Mods and map ID are now written to files to use for streamers as well

Map ID can prove useful for displaying the map link on screen or with self-hosted twitch bots with !np commands etc.