### PR TITLE
Fix Recently Played Filter

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -369,11 +369,6 @@ namespace Quaver.Shared.Screens.Gameplay
         {
             TimePlayed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
-            if (!isSongSelectPreview)
-            {
-                UpdateMapInDatabase();
-            }
-
             if (isPlayTesting && !isSongSelectPreview)
             {
                 var testingQua = ObjectHelper.DeepClone(map);
@@ -445,6 +440,7 @@ namespace Quaver.Shared.Screens.Gameplay
             // Create the current replay that will be captured.
             ReplayCapturer = new ReplayCapturer(this);
 
+            UpdateMapInDatabase();
             SetRuleset();
             SetRichPresence();
 
@@ -1404,6 +1400,9 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         private void UpdateMapInDatabase()
         {
+            if (IsSongSelectPreview)
+                return;
+
             var map = MapManager.Selected.Value;
 
             map.TimesPlayed++;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -368,7 +368,11 @@ namespace Quaver.Shared.Screens.Gameplay
             bool isTestPlayingInNewEditor = false)
         {
             TimePlayed = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            UpdateMapInDatabase();
+
+            if (!isSongSelectPreview)
+            {
+                UpdateMapInDatabase();
+            }
 
             if (isPlayTesting && !isSongSelectPreview)
             {
@@ -1400,9 +1404,6 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         private void UpdateMapInDatabase()
         {
-            if (IsSongSelectPreview)
-                return;
-            
             var map = MapManager.Selected.Value;
 
             map.TimesPlayed++;


### PR DESCRIPTION
As shown in this video, it work : https://streamable.com/mhnmrx

In the video i'm moving around in menu, even toggle the gameplay preview screen, then filter by recently played, and it is not added in it as previously, then i playtest a map, in which get set as played recently.

I'm not entirely sure, but after trying to log the result of "isSongSelectPreview" in the "UpdateMapInDatabase" function, it was always on false, so i guess the function was getting the default value of "isSongSelectPreview" instead of the value received by the "public GameplayScreen".