### PR TITLE
Render timing lines of custom time signatures in gameplay

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -94,16 +94,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
                 // Target position has tolerance of 1ms so timing points dont overlap by chance
                 var target = i + 1 < map.TimingPoints.Count ? map.TimingPoints[i + 1].StartTime - 1 : map.Length;
 
-                var signature = TimeSignature.Quadruple;
-
-                if (Enum.IsDefined(typeof(TimeSignature), map.TimingPoints[i].Signature))
-                    signature = map.TimingPoints[i].Signature;
+                var signature = (int)map.TimingPoints[i].Signature;
 
                 // Max possible sane value for timing lines
                 const float maxBpm = 9999f;
 
                 var msPerBeat = 60000 / Math.Min(Math.Abs(map.TimingPoints[i].Bpm), maxBpm);
-                var increment = (int) signature * msPerBeat;
+                var increment = signature * msPerBeat;
 
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if (increment <= 0)


### PR DESCRIPTION
Integers used when specifying the time signature of a timing point will be used when determining where timing lines are placed during gameplay. 

The editor already takes into account custom integer time signatures as a side effect of #2760.

This also kinda just makes the TimeSignature enum useless except for compatibility reasons (why does it exist in the first place?).