### PR TITLE
Use the same resnap algorithm as editor click placement and resnap on paste

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -531,7 +531,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// </remarks>
         /// <param name="snaps">List of snaps to snap to</param>
         /// <param name="hitObjectsToResnap">List of hitobjects to resnap</param>
-        public void ResnapNotes(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap) => Perform(new EditorActionResnapHitObjects(this, WorkingMap, snaps, hitObjectsToResnap));
+        public void ResnapNotes(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap) => Perform(new EditorActionResnapHitObjects(this, WorkingMap, snaps, hitObjectsToResnap, true));
 
         /// <summary>
         ///     Detects the BPM of the map and returns the object instance

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionHitObjectsResnappedEventArgs.cs
@@ -14,10 +14,20 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         /// </summary>
         public List<HitObjectInfo> HitObjectsToResnap { get; }
 
-        public EditorActionHitObjectsResnappedEventArgs(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap)
+        /// <summary>
+        /// </summary>
+        public bool ShowNotif { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="snaps"></param>
+        /// <param name="hitObjectsToResnap"></param>
+        /// <param name="showNotif"></param>
+        public EditorActionHitObjectsResnappedEventArgs(List<int> snaps, List<HitObjectInfo> hitObjectsToResnap, bool showNotif)
         {
             Snaps = snaps;
             HitObjectsToResnap = hitObjectsToResnap;
+            ShowNotif = showNotif;
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -43,6 +43,10 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         private readonly Dictionary<HitObjectInfo, NoteAdjustment> noteTimeAdjustments =
             new Dictionary<HitObjectInfo, NoteAdjustment>();
 
+        /// <summary>
+        /// </summary>
+        public bool ShowNotif { get; }
+
         private struct NoteAdjustment
         {
             public int OriginalStartTime;
@@ -81,15 +85,17 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         /// <param name="actionManager"></param>
         /// <param name="workingMap"></param>
         /// <param name="snaps"></param>
-        /// /// <param name="hitObjectsToResnap"></param>
+        /// <param name="hitObjectsToResnap"></param>
+        /// <param name="showNotif"></param>
         [MoonSharpVisible(false)]
         public EditorActionResnapHitObjects(EditorActionManager actionManager, Qua workingMap, List<int> snaps,
-            List<HitObjectInfo> hitObjectsToResnap)
+            List<HitObjectInfo> hitObjectsToResnap, bool showNotif)
         {
             ActionManager = actionManager;
             HitObjectsToResnap = hitObjectsToResnap;
             WorkingMap = workingMap;
             Snaps = snaps;
+            ShowNotif = showNotif;
         }
 
         /// <inheritdoc />
@@ -119,14 +125,19 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
 
             if (resnapCount > 0)
             {
-                var notifMessage = $"Resnapped {resnapCount} note{(resnapCount == 1 ? "" : "s")}";
-                NotificationManager.Show(NotificationLevel.Info, notifMessage);
+                if (ShowNotif)
+                {
+                    var notifMessage = $"Resnapped {resnapCount} note{(resnapCount == 1 ? "" : "s")}";
+                    NotificationManager.Show(NotificationLevel.Info, notifMessage);
+                }
 
                 ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects,
-                    new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
+                    new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap, ShowNotif));
             }
-            else
+            else if (ShowNotif)
+            {
                 NotificationManager.Show(NotificationLevel.Info, $"No notes resnapped");
+            }
         }
 
         /// <summary>
@@ -198,11 +209,14 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
             }
 
             ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects,
-                new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
+                new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap, ShowNotif));
 
-            var offsnapCount = noteTimeAdjustments.Values.Count(x => x.StartTimeWasChanged || x.EndTimeWasChanged);
-            var notifMessage = $"Unsnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
-            NotificationManager.Show(NotificationLevel.Info, notifMessage);
+            if (ShowNotif)
+            {
+                var offsnapCount = noteTimeAdjustments.Values.Count(x => x.StartTimeWasChanged || x.EndTimeWasChanged);
+                var notifMessage = $"Unsnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
+                NotificationManager.Show(NotificationLevel.Info, notifMessage);
+            }
 
             noteTimeAdjustments.Clear();
         }

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -8,6 +8,8 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.PlaceBatch;
 using Wobble.Logging;
 using MoonSharp.Interpreter;
 using MoonSharp.Interpreter.Interop;
+using Quaver.Shared.Audio;
+using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
 {
@@ -36,20 +38,53 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         private List<HitObjectInfo> HitObjectsToResnap { get; }
 
         /// <summary>
-        ///  The distance of note start/end to the closest snap
+        ///     The original and new time(s) for each note
         /// </summary>
-        /// <typeparam name="HitObjectInfo">Note</typeparam>
-        /// <typeparam name="(int">Distance of StartTime to closest snap</typeparam>
-        /// <typeparam name="int)">Distance of EndTime to closest snap</typeparam>
-        private readonly Dictionary<HitObjectInfo, (int, int)> noteTimeAdjustments = new Dictionary<HitObjectInfo, (int, int)>();
+        private readonly Dictionary<HitObjectInfo, NoteAdjustment> noteTimeAdjustments =
+            new Dictionary<HitObjectInfo, NoteAdjustment>();
+
+        private struct NoteAdjustment
+        {
+            public int OriginalStartTime;
+            public int OriginalEndTime;
+            public int NewStartTime;
+            public int NewEndTime;
+            public bool IsLongNote;
+
+            public NoteAdjustment(int originalStartTime, int originalEndTime, HitObjectInfo note)
+            {
+                OriginalStartTime = originalStartTime;
+                OriginalEndTime = originalEndTime;
+                NewStartTime = note.StartTime;
+                NewEndTime = note.EndTime;
+                IsLongNote = note.IsLongNote;
+            }
+
+            /// <summary>
+            ///  Whether the start time was changed
+            /// </summary>
+            public bool StartTimeWasChanged => OriginalStartTime != NewStartTime;
+
+            /// <summary>
+            /// Whether the end time was changed
+            /// </summary>
+            public bool EndTimeWasChanged => IsLongNote && OriginalEndTime != NewEndTime;
+
+            /// <summary>
+            /// Whether the note was moved at all
+            /// </summary>
+            public bool NoteWasMoved => StartTimeWasChanged || EndTimeWasChanged;
+        }
 
         /// <summary>
         /// </summary>
         /// <param name="actionManager"></param>
         /// <param name="workingMap"></param>
-        /// <param name="hitObjects"></param>
+        /// <param name="snaps"></param>
+        /// /// <param name="hitObjectsToResnap"></param>
         [MoonSharpVisible(false)]
-        public EditorActionResnapHitObjects(EditorActionManager actionManager, Qua workingMap, List<int> snaps, List<HitObjectInfo> hitObjectsToResnap)
+        public EditorActionResnapHitObjects(EditorActionManager actionManager, Qua workingMap, List<int> snaps,
+            List<HitObjectInfo> hitObjectsToResnap)
         {
             ActionManager = actionManager;
             HitObjectsToResnap = hitObjectsToResnap;
@@ -63,64 +98,89 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         [MoonSharpVisible(false)]
         public void Perform()
         {
+            var resnapCount = 0;
+
             foreach (var note in HitObjectsToResnap)
             {
-                // Using AudioEngine.GetNearestSnapTimeFromTime is unreliable since it might not return the current snap
-                var startTimeDelta = DiffToClosestSnap(note.StartTime);
+                var originalStartTime = note.StartTime;
+                var originalEndTime = note.EndTime;
 
-                if (startTimeDelta != 0)
-                    note.StartTime -= startTimeDelta;
-
-                var endTimeDelta = 0;
-
+                note.StartTime = ClosestTickOverall(note.StartTime);
                 if (note.IsLongNote)
+                    note.EndTime = ClosestTickOverall(note.EndTime);
+
+                var adjustment = new NoteAdjustment(originalStartTime, originalEndTime, note);
+                if (adjustment.NoteWasMoved)
                 {
-                    endTimeDelta = DiffToClosestSnap(note.EndTime);
-
-                    if (endTimeDelta != 0f)
-                        note.EndTime -= endTimeDelta;
+                    noteTimeAdjustments.Add(note, adjustment);
+                    resnapCount++;
                 }
-
-                noteTimeAdjustments.Add(note, (startTimeDelta, endTimeDelta));
             }
 
-            var offsnapCount = noteTimeAdjustments.Values.Count(x => x.Item1 != 0 || x.Item2 != 0);
-
-            if (offsnapCount > 0)
+            if (resnapCount > 0)
             {
-                var notifMessage = $"Resnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
+                var notifMessage = $"Resnapped {resnapCount} note{(resnapCount == 1 ? "" : "s")}";
                 NotificationManager.Show(NotificationLevel.Info, notifMessage);
 
-                ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
+                ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects,
+                    new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
             }
             else
                 NotificationManager.Show(NotificationLevel.Info, $"No notes to resnap");
-
         }
 
         /// <summary>
-        ///
+        ///    Gets the closest time overall
         /// </summary>
         /// <param name="time"></param>
         /// <returns></returns>
-        private int DiffToClosestSnap(int time)
+        private int ClosestTickOverall(int time)
         {
-            var timingPoint = WorkingMap.GetTimingPointAt(time);
-            var msPerSnaps = Snaps.Select(s => timingPoint.MillisecondsPerBeat / s).ToList();
-
-            var smallestDelta = float.MaxValue;
-
-            foreach (var msPerSnap in msPerSnaps)
+            var closestTime = int.MaxValue;
+            foreach (var newTime in Snaps.Select(snap => ClosestTickToSnap(time, snap)))
             {
-                var deltaForward = (time - timingPoint.StartTime) % msPerSnap;
-                var deltaBackward = deltaForward - msPerSnap;
-                var delta = deltaForward < -deltaBackward ? deltaForward : deltaBackward;
-
-                if (Math.Abs(delta) < Math.Abs(smallestDelta))
-                    smallestDelta = delta;
+                if (Math.Abs(time - newTime) < Math.Abs(time - closestTime))
+                    closestTime = newTime;
             }
 
-            return (int)Math.Round(smallestDelta);
+            return closestTime;
+        }
+
+        /// <summary>
+        ///     Gets the closest time for a given snap, uses the same algorithm as EditorPlayfield.GetNearestTickFromTime()
+        /// </summary>
+        /// <param name="time"></param>
+        /// <param name="snap"></param>
+        /// <returns></returns>
+        private int ClosestTickToSnap(int time, int snap)
+        {
+            var timingPoint = WorkingMap.GetTimingPointAt(time);
+            if (timingPoint == null)
+                return time;
+
+            var timeFwd = (int) AudioEngine.GetNearestSnapTimeFromTime(WorkingMap, Direction.Forward, snap, time);
+            var timeBwd = (int) AudioEngine.GetNearestSnapTimeFromTime(WorkingMap, Direction.Backward, snap, time);
+
+            var fwdDiff = Math.Abs(time - timeFwd);
+            var bwdDiff = Math.Abs(time - timeBwd);
+
+            // When the forward and backwards differences are around the same (the user places directly on a line or in the middle)
+            // always go to the nearest backwards tick
+            if (Math.Abs(fwdDiff - bwdDiff) <= 2)
+            {
+                var snapTimePerBeat = 60000f / timingPoint.Bpm / snap;
+                return (int) AudioEngine.GetNearestSnapTimeFromTime(WorkingMap, Direction.Backward, snap,
+                    time + snapTimePerBeat);
+            }
+
+            var closestTime = time;
+
+            if (bwdDiff < fwdDiff)
+                closestTime = timeBwd;
+            else if (fwdDiff < bwdDiff)
+                closestTime = timeFwd;
+
+            return closestTime;
         }
 
         /// <inheritdoc />
@@ -129,16 +189,18 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
         [MoonSharpVisible(false)]
         public void Undo()
         {
-            foreach (var adjustment in noteTimeAdjustments)
+            foreach (var change in noteTimeAdjustments)
             {
-                var note = adjustment.Key;
-                note.StartTime += adjustment.Value.Item1;
-                note.EndTime += adjustment.Value.Item2;
+                var note = change.Key;
+                var adjustment = change.Value;
+                note.StartTime = adjustment.OriginalStartTime;
+                note.EndTime = adjustment.OriginalEndTime;
             }
 
-            ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects, new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
+            ActionManager.TriggerEvent(EditorActionType.ResnapHitObjects,
+                new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
 
-            var offsnapCount = noteTimeAdjustments.Values.Count(x => x.Item1 != 0 || x.Item2 != 0);
+            var offsnapCount = noteTimeAdjustments.Values.Count(x => x.StartTimeWasChanged || x.EndTimeWasChanged);
             var notifMessage = $"Unsnapped {offsnapCount} note{(offsnapCount == 1 ? "" : "s")}";
             NotificationManager.Show(NotificationLevel.Info, notifMessage);
 

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resnap/EditorActionResnapHitObjects.cs
@@ -126,7 +126,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap
                     new EditorActionHitObjectsResnappedEventArgs(Snaps, HitObjectsToResnap));
             }
             else
-                NotificationManager.Show(NotificationLevel.Info, $"No notes to resnap");
+                NotificationManager.Show(NotificationLevel.Info, $"No notes resnapped");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1064,7 +1064,7 @@ namespace Quaver.Shared.Screens.Edit
             if (resnapObjects)
             {
                 // Don't add to undo stack
-                var resnapAction = new EditorActionResnapHitObjects(ActionManager, WorkingMap, new List<int> { 16, 12 }, clonedObjects);
+                var resnapAction = new EditorActionResnapHitObjects(ActionManager, WorkingMap, new List<int> { 16, 12 }, clonedObjects, false);
                 resnapAction.Perform();
             }
 

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -31,6 +31,7 @@ using Quaver.Shared.Screens.Edit.Actions;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Flip;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.PlaceBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Components;
 using Quaver.Shared.Screens.Edit.Dialogs;
 using Quaver.Shared.Screens.Edit.Dialogs.Metadata;
@@ -690,8 +691,9 @@ namespace Quaver.Shared.Screens.Edit
             if (KeyboardManager.IsUniqueKeyPress(Keys.C))
                 CopySelectedObjects();
 
+            // Add shift to paste without automatic resnapping
             if (KeyboardManager.IsUniqueKeyPress(Keys.V))
-                PasteCopiedObjects();
+                PasteCopiedObjects(!KeyboardManager.IsShiftDown());
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.X))
                 CutSelectedObjects();
@@ -1028,9 +1030,9 @@ namespace Quaver.Shared.Screens.Edit
         }
 
         /// <summary>
-        ///     Pastes any objects that are currently selected
+        ///     Pastes any objects that are currently selected and resnaps the pasted notes if desired
         /// </summary>
-        public void PasteCopiedObjects()
+        public void PasteCopiedObjects(bool resnapObjects)
         {
             if (Clipboard.Count == 0)
                 return;
@@ -1057,6 +1059,13 @@ namespace Quaver.Shared.Screens.Edit
                     continue;
 
                 clonedObjects.Add(hitObject);
+            }
+
+            if (resnapObjects)
+            {
+                // Don't add to undo stack
+                var resnapAction = new EditorActionResnapHitObjects(ActionManager, WorkingMap, new List<int> { 16, 12 }, clonedObjects);
+                resnapAction.Perform();
             }
 
             ActionManager.Perform(new EditorActionPlaceHitObjectBatch(ActionManager, WorkingMap, clonedObjects));

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginUtils.cs
@@ -185,7 +185,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
                 case EditorActionType.ChangeScrollVelocityMultiplierBatch:
                     return new EditorActionChangeScrollVelocityMultiplierBatch(EditScreen.ActionManager, EditScreen.WorkingMap, args[0].ToObject<List<SliderVelocityInfo>>(), args[1].ToObject<float>());
                 case EditorActionType.ResnapHitObjects:
-                    return new EditorActionResnapHitObjects(EditScreen.ActionManager, EditScreen.WorkingMap, args[0].ToObject<List<int>>(), args[1].ToObject<List<HitObjectInfo>>());
+                    return new EditorActionResnapHitObjects(EditScreen.ActionManager, EditScreen.WorkingMap, args[0].ToObject<List<int>>(), args[1].ToObject<List<HitObjectInfo>>(), args[2].ToObject<bool>());
                 case EditorActionType.Batch:
                     return new EditorActionBatch(EditScreen.ActionManager, args[0].ToObject<List<IEditorAction>>());
                 default:

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -191,8 +191,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.MenuItem("Cut", "CTRL + X", false, Screen.SelectedHitObjects.Value.Count > 0))
                 Screen.CutSelectedObjects();
 
-            if (ImGui.MenuItem("Paste", "CTRL + V", false, Screen.Clipboard.Count > 0))
-                Screen.PasteCopiedObjects();
+            if (ImGui.MenuItem("Paste (snapped)", "CTRL + V", false, Screen.Clipboard.Count > 0))
+                Screen.PasteCopiedObjects(true);
+
+            if (ImGui.MenuItem("Paste (unsnapped)", "CTRL + SHIFT + V", false, Screen.Clipboard.Count > 0))
+                Screen.PasteCopiedObjects(false);
 
             if (ImGui.MenuItem("Delete", "DEL", false, Screen.SelectedHitObjects.Value.Count > 0))
                 Screen.DeleteSelectedObjects();

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -770,13 +770,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             // always go to the nearest backwards tick
             if (Math.Abs(fwdDiff - bwdDiff) <= 2)
             {
-                // Get the current timing point
-                var point = Map.GetTimingPointAt(time);
-
-                if (point == null)
-                    return time;
-
-                var snapTimePerBeat = 60000f / point.Bpm / beatSnap;
+                var snapTimePerBeat = 60000f / timingPoint.Bpm / beatSnap;
 
                 if (PlaceObjectsOnNearestTick.Value)
                     return (int) AudioEngine.GetNearestSnapTimeFromTime(Map, Direction.Backward, beatSnap, time + snapTimePerBeat);


### PR DESCRIPTION
- The previous, simpler algorithm worked with floats and rounding, so 1ms inaccuracies happened frequently. This one uses the same one as the editor click.
- Resnap on paste! Add shift to paste without resnapping