### PR TITLE
Option to gray notes if hit early instead of despawning them

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -747,6 +747,10 @@ namespace Quaver.Shared.Config
         internal static Bindable<ResultGraphs> ResultGraph { get; private set; }
 
         /// <summary>
+        /// </summary>
+        internal static Bindable<bool> GrayOutEarlyHitNotes { get; private set; }
+
+        /// <summary>
         ///     Dictates whether or not this is the first write of the file for the current game session.
         ///     (Not saved in Config)
         /// </summary>
@@ -997,6 +1001,7 @@ namespace Quaver.Shared.Config
             DisplayNotificationsInGameplay = ReadValue(@"DisplayNotificationsInGameplay", false, data);
             TournamentPlayer2Skin = ReadValue(@"TournamentPlayer2Skin", "", data);
             ResultGraph = ReadValue(@"ResultGraph", ResultGraphs.Deviance, data);
+            GrayOutEarlyHitNotes = ReadValue(@"GrayOutEarlyHitNotes", true, data);
 
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -202,6 +202,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
             }
 
+            var isEarlyHit = hitDifference > 0;
+
             // Update Object Pooling
             switch (judgement)
             {
@@ -229,7 +231,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     break;
                 // Handle miss cases.
                 case Judgement.Miss:
-                    manager.RecyclePoolObject(gameplayHitObject);
+                    if (ConfigManager.GrayOutEarlyHitNotes.Value && isEarlyHit)
+                        manager.KillPoolObject(gameplayHitObject);
+                    else
+                        manager.RecyclePoolObject(gameplayHitObject);
                     break;
                 // Handle non-miss cases. Perform Hit Lighting Animation and Handle Object pooling.
                 default:
@@ -239,6 +244,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                         manager.ChangePoolObjectStatusToHeld(gameplayHitObject);
                         gameplayHitObject.StartLongNoteAnimation();
                     }
+                    else if (ConfigManager.GrayOutEarlyHitNotes.Value && isEarlyHit && judgement >= Judgement.Good)
+                        manager.KillPoolObject(gameplayHitObject);
                     else
                         manager.RecyclePoolObject(gameplayHitObject);
                     break;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -303,10 +303,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
                 }
 
-                // If the player recieved an early miss or "okay",
-                // show the player that they were inaccurate by killing the object instead of recycling it
-                if (judgement == Judgement.Miss || judgement == Judgement.Okay)
-                    manager.KillHoldPoolObject(gameplayHitObject, judgement == Judgement.Miss);
+                // If the player released early, show the player that they were
+                // inaccurate by killing the object instead of recycling it.
+                //
+                // The inclusion of the Good window when GrayOutEarlyHitNotes is enabled is
+                // to match the same window used in HandleKeyPress() when processing notes.
+                if ((ConfigManager.GrayOutEarlyHitNotes.Value && judgement == Judgement.Good) || judgement >= Judgement.Okay)
+                    manager.KillHoldPoolObject(gameplayHitObject);
                 else
                     manager.RecyclePoolObject(gameplayHitObject);
 

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -166,7 +166,11 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Experimental", new List<OptionsItem>()
                     {
-                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay)
+                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay),
+                        new OptionsItemCheckbox(containerRect, "Gray out early-hit notes instead of despawning them", ConfigManager.GrayOutEarlyHitNotes)
+                        {
+                            Tags = new List<string> { "hitmiss", "grey", "disappear" }
+                        }
                     }),
                 }),
                 new OptionsSection("Gameplay", UserInterface.OptionsGameplay, new List<OptionsSubcategory>


### PR DESCRIPTION
Addresses #2913 

Difference between old and new (dead color is barely visible because the tint in the default skin is low)
https://user-images.githubusercontent.com/22303902/112993502-9148e800-9169-11eb-9aa9-6d3e7d87c924.mp4

Only grays out notes hit outside of Marv-Great
https://user-images.githubusercontent.com/22303902/112993439-81c99f00-9169-11eb-8290-3c48a86f10cb.mp4