### PR TITLE
Handle Config File causing crash

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -18,6 +18,7 @@ using IniFileParser.Model;
 using ManagedBass;
 using Microsoft.Xna.Framework.Input;
 using Quaver.API.Enums;
+using Quaver.Server.Common.Helpers;
 using Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers;
 using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
@@ -813,6 +814,8 @@ namespace Quaver.Shared.Config
             catch (ParsingException)
             {
                 Logger.Important("Config file couldn't be read.", LogType.Runtime);
+                File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds()
+                + ".cfg");
                 File.Delete(_gameDirectory + "/quaver.cfg");
             }
 

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using IniFileParser;
+using IniFileParser.Exceptions;
 using IniFileParser.Model;
 using ManagedBass;
 using Microsoft.Xna.Framework.Input;
@@ -804,11 +805,25 @@ namespace Quaver.Shared.Config
         /// </summary>
         private static void ReadConfigFile()
         {
+            // Delete the config file if we catch an exception.
+            try
+            {
+                var Testdata = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
+            }
+            catch (ParsingException)
+            {
+                Logger.Important("Config file couldn't be read.", LogType.Runtime);
+                File.Delete(_gameDirectory + "/quaver.cfg");
+            }
+
             // We'll want to write a quaver.cfg file if it doesn't already exist.
             // There's no need to read the config file afterwards, since we already have
             // all of the default values.
             if (!File.Exists(_gameDirectory + "/quaver.cfg"))
+            {
                 File.WriteAllText(_gameDirectory + "/quaver.cfg", "; Quaver Configuration File");
+                Logger.Important("Creating a new config file...", LogType.Runtime);
+            }  
 
             var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
 

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -806,16 +806,15 @@ namespace Quaver.Shared.Config
         /// </summary>
         private static void ReadConfigFile()
         {
-            // Delete the config file if we catch an exception.
             try
             {
-                var Testdata = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
+                // Delete the config file if we catch an exception.
+                var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
             }
             catch (ParsingException)
             {
                 Logger.Important("Config file couldn't be read.", LogType.Runtime);
-                File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds()
-                + ".cfg");
+                File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
                 File.Delete(_gameDirectory + "/quaver.cfg");
             }
 
@@ -826,7 +825,7 @@ namespace Quaver.Shared.Config
             {
                 File.WriteAllText(_gameDirectory + "/quaver.cfg", "; Quaver Configuration File");
                 Logger.Important("Creating a new config file...", LogType.Runtime);
-            }  
+            }
 
             var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
 
@@ -835,14 +834,11 @@ namespace Quaver.Shared.Config
             // YOU CAN DO THIS DOWN BELOW, AFTER THE CONFIG HAS WRITTEN FOR THE FIRST TIME.
             GameDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"GameDirectory", _gameDirectory, data);
             SkinDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"SkinDirectory", _skinDirectory, data);
-            ScreenshotDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"ScreenshotDirectory",
-                _screenshotDirectory, data);
-            ReplayDirectory =
-                ReadSpecialConfigType(SpecialConfigType.Directory, @"ReplayDirectory", _replayDirectory, data);
+            ScreenshotDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"ScreenshotDirectory", _screenshotDirectory, data);
+            ReplayDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"ReplayDirectory", _replayDirectory, data);
             LogsDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"LogsDirectory", _logsDirectory, data);
             DataDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"DataDirectory", _dataDirectory, data);
             SongDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"SongDirectory", _songDirectory, data);
-
             _steamWorkshopDirectory = $"{GameDirectory.Value}/../../workshop/content/{SteamManager.ApplicationId}";
             SteamWorkshopDirectory = ReadSpecialConfigType(SpecialConfigType.Directory, @"SteamWorkshopDirectory", _steamWorkshopDirectory, data);
             SelectedGameMode = ReadValue(@"SelectedGameMode", GameMode.Keys4, data);


### PR DESCRIPTION
Simply delete the corrupted config file if an exception is catch, making quaver create a new one.