### PR TITLE
Fix MP difficulty parsing

### DIFF
--- a/Quaver.Shared/Online/MultiplayerGameExtensions.cs
+++ b/Quaver.Shared/Online/MultiplayerGameExtensions.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Xna.Framework;
 using Quaver.Server.Common.Objects.Multiplayer;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Online
 {
@@ -21,19 +22,35 @@ namespace Quaver.Shared.Online
         /// <returns></returns>
         public static string GetDifficultyName(this MultiplayerGame game)
         {
-            var diffName = "";
-            var pattern = @"\[(.*?)\]";
-            var matches = Regex.Matches(game.Map, pattern);
-
-            foreach (Match match in matches)
+            if (game.Map.LastOrDefault() != ']')
             {
-                if (match != matches.Last())
-                    continue;
-
-                diffName = match.Groups[1].ToString();
+                // Huh?
+                Logger.Warning($"Multiplayer map name not ending in ']': {game.Map}", LogType.Runtime);
+                return "";
             }
 
-            return diffName;
+            // The map string has a form of "artist - title [difficulty]". Look for the first " [" after the first " - ".
+            //
+            // This isn't quite perfect (it's possible trick it by having [, ] or - in a particular order in
+            // artist, name or difficulty name), but it works decently well and handles [something] inside
+            // a difficulty name.
+            var dash = game.Map.IndexOf(" - ");
+            if (dash == -1)
+            {
+                // Shouldn't happen.
+                Logger.Warning($"Multiplayer map name doesn't contain \" - \": {game.Map}", LogType.Runtime);
+                return "";
+            }
+
+            var spaceBracket = game.Map.IndexOf(" [", dash + 3);
+            if (spaceBracket == -1)
+            {
+                // Also shouldn't happen.
+                Logger.Warning($"Multiplayer map name doesn't contain \" [\" after \" - \": {game.Map}", LogType.Runtime);
+                return "";
+            }
+
+            return game.Map.Substring(spaceBracket + 2, game.Map.Length - spaceBracket - 3);
         }
     }
 }


### PR DESCRIPTION
The previous code failed on difficulty names containing `[something]`. This code isn't perfect either, but it's about the best we can do without sending artist, name and difficulty name as separate strings (which is the correct solution to this, but needs serverside changes, if you could add them please: https://github.com/Swan/Albatross/issues/53).