### PR TITLE
Check if a config file exist before attempting to read it

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -806,32 +806,33 @@ namespace Quaver.Shared.Config
         /// </summary>
         private static void ReadConfigFile()
         {
-            var _configFileDirectory = _gameDirectory + "/quaver.cfg";
-            if (File.Exists(_configFileDirectory))
+            var configFilePath = _gameDirectory + "/quaver.cfg";
+
+            if (File.Exists(configFilePath))
             {
                 try
                 {
                     // Delete the config file if we catch an exception.
-                    var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_configFileDirectory)["Config"];
+                    var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(configFilePath)["Config"];
                 }
                 catch (ParsingException)
                 {
                     Logger.Important("Config file couldn't be read.", LogType.Runtime);
-                    File.Copy(_configFileDirectory, _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
-                    File.Delete(_configFileDirectory);
+                    File.Copy(configFilePath, _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
+                    File.Delete(configFilePath);
                 }
             }
 
             // We'll want to write a quaver.cfg file if it doesn't already exist.
             // There's no need to read the config file afterwards, since we already have
             // all of the default values.
-            if (!File.Exists(_configFileDirectory))
+            if (!File.Exists(configFilePath))
             {
-                File.WriteAllText(_configFileDirectory, "; Quaver Configuration File");
+                File.WriteAllText(configFilePath, "; Quaver Configuration File");
                 Logger.Important("Creating a new config file...", LogType.Runtime);
             }
 
-            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_configFileDirectory)["Config"];
+            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(configFilePath)["Config"];
 
             // Read / Set Config Values
             // NOTE: MAKE SURE TO SET THE VALUE TO AUTO-SAVE WHEN CHANGING! THIS ISN'T DONE AUTOMATICALLY.

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -806,31 +806,32 @@ namespace Quaver.Shared.Config
         /// </summary>
         private static void ReadConfigFile()
         {
-            if (File.Exists(_gameDirectory + "/quaver.cfg"))
+            var _configFileDirectory = _gameDirectory + "/quaver.cfg";
+            if (File.Exists(_configFileDirectory))
             {
                 try
                 {
                     // Delete the config file if we catch an exception.
-                    var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
+                    var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_configFileDirectory)["Config"];
                 }
                 catch (ParsingException)
                 {
                     Logger.Important("Config file couldn't be read.", LogType.Runtime);
-                    File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
-                    File.Delete(_gameDirectory + "/quaver.cfg");
+                    File.Copy(_configFileDirectory, _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
+                    File.Delete(_configFileDirectory);
                 }
             }
 
             // We'll want to write a quaver.cfg file if it doesn't already exist.
             // There's no need to read the config file afterwards, since we already have
             // all of the default values.
-            if (!File.Exists(_gameDirectory + "/quaver.cfg"))
+            if (!File.Exists(_configFileDirectory))
             {
-                File.WriteAllText(_gameDirectory + "/quaver.cfg", "; Quaver Configuration File");
+                File.WriteAllText(_configFileDirectory, "; Quaver Configuration File");
                 Logger.Important("Creating a new config file...", LogType.Runtime);
             }
 
-            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
+            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_configFileDirectory)["Config"];
 
             // Read / Set Config Values
             // NOTE: MAKE SURE TO SET THE VALUE TO AUTO-SAVE WHEN CHANGING! THIS ISN'T DONE AUTOMATICALLY.

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -806,16 +806,19 @@ namespace Quaver.Shared.Config
         /// </summary>
         private static void ReadConfigFile()
         {
-            try
+            if (File.Exists(_gameDirectory + "/quaver.cfg"))
             {
-                // Delete the config file if we catch an exception.
-                var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
-            }
-            catch (ParsingException)
-            {
-                Logger.Important("Config file couldn't be read.", LogType.Runtime);
-                File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
-                File.Delete(_gameDirectory + "/quaver.cfg");
+                try
+                {
+                    // Delete the config file if we catch an exception.
+                    var _ = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(_gameDirectory + "/quaver.cfg")["Config"];
+                }
+                catch (ParsingException)
+                {
+                    Logger.Important("Config file couldn't be read.", LogType.Runtime);
+                    File.Copy(_gameDirectory + "/quaver.cfg", _gameDirectory + "/quaver.corrupted." + TimeHelper.GetUnixTimestampMilliseconds() + ".cfg");
+                    File.Delete(_gameDirectory + "/quaver.cfg");
+                }
             }
 
             // We'll want to write a quaver.cfg file if it doesn't already exist.


### PR DESCRIPTION
Because of an overlook on my end on my PR https://github.com/Quaver/Quaver/pull/2935 , i forgot to put a check if the file exist before attempting to read it, which mean the game will automatically crash on a fresh installation because no config file exist.