### PR TITLE
Replays use respective score's judgement windows

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1317,7 +1317,7 @@ namespace Quaver.Shared.Screens.Edit
                 var map = ObjectHelper.DeepClone(WorkingMap);
                 map.ApplyMods(ModManager.Mods);
 
-                return new GameplayScreen(map, "", new List<Score>(), null, true, Track.Time, false, null, null, false, true);
+                return new GameplayScreen(map, "", new List<Score>(), null, null, true, Track.Time, false, null, null, false, true);
             });
         }
 

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -970,7 +970,7 @@ namespace Quaver.Shared.Screens.Editor
             Exit(() =>
             {
                 Save();
-                return new GameplayScreen(WorkingMap, "", new List<Score>(), null, true, AudioEngine.Track.Time);
+                return new GameplayScreen(WorkingMap, "", new List<Score>(), null, null, true, AudioEngine.Track.Time);
             });
         }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -108,6 +108,11 @@ namespace Quaver.Shared.Screens.Gameplay
         public string MapHash { get; }
 
         /// <summary>
+        ///     The score of the current replay (if there is one.)
+        /// </summary>
+        public Score LoadedScore { get; private set; }
+
+        /// <summary>
         ///     The current replay being watched (if there is one.)
         /// </summary>
         public Replay LoadedReplay { get; private set; }
@@ -363,7 +368,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="options"></param>
         /// <param name="isSongSelectPreview"></param>
         /// <param name="isTestPlayingInNewEditor"></param>
-        public GameplayScreen(Qua map, string md5, List<Score> scores, Replay replay = null, bool isPlayTesting = false, double playTestTime = 0,
+        public GameplayScreen(Qua map, string md5, List<Score> scores, Replay replay = null, Score score = null, bool isPlayTesting = false, double playTestTime = 0,
             bool isCalibratingOffset = false, SpectatorClient spectatorClient = null, TournamentPlayerOptions options = null, bool isSongSelectPreview = false,
             bool isTestPlayingInNewEditor = false)
         {
@@ -383,6 +388,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             LocalScores = scores;
             MapHash = md5;
+            LoadedScore = score;
             LoadedReplay = replay;
             IsPlayTesting = isPlayTesting;
             IsTestPlayingInNewEditor = isTestPlayingInNewEditor;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -1041,9 +1041,9 @@ namespace Quaver.Shared.Screens.Gameplay
 
             // Use ChangeScreen here to give instant feedback. Can't be threaded
             if (IsPlayTesting)
-                QuaverScreenManager.ChangeScreen(new GameplayScreen(OriginalEditorMap, MapHash, LocalScores, null, true, PlayTestAudioTime, false, null, null, false, IsTestPlayingInNewEditor));
+                QuaverScreenManager.ChangeScreen(new GameplayScreen(OriginalEditorMap, MapHash, LocalScores, null, null, true, PlayTestAudioTime, false, null, null, false, IsTestPlayingInNewEditor));
             else if (InReplayMode)
-                QuaverScreenManager.ChangeScreen(new GameplayScreen(Map, MapHash, LocalScores, LoadedReplay));
+                QuaverScreenManager.ChangeScreen(new GameplayScreen(Map, MapHash, LocalScores, LoadedReplay, LoadedScore));
             else
                 QuaverScreenManager.ChangeScreen(new GameplayScreen(Map, MapHash, LocalScores));
         }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -83,7 +83,27 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             Screen = screen;
             Replay = Screen.LoadedReplay;
 
-            Windows = Screen.SpectatorClient != null ? JudgementWindowsDatabaseCache.Standard : JudgementWindowsDatabaseCache.Selected.Value;
+            // If spectating someone online OR watching an online replay,
+            // then we use standard judgement windows of the core
+            if (Screen.SpectatorClient != null || (Screen.LoadedScore != null && Screen.LoadedScore.IsOnline))
+                Windows = JudgementWindowsDatabaseCache.Standard;
+
+            // If we are watching a local replay, then we use the windows of the replay's score
+            else if (Screen.LoadedScore != null)
+                Windows = new JudgementWindows(){
+                    Id = 0,
+                    Name = Screen.LoadedScore.JudgementWindowPreset,
+                    IsDefault = false,
+                    Marvelous = Screen.LoadedScore.JudgementWindowMarv,
+                    Perfect = Screen.LoadedScore.JudgementWindowPerf,
+                    Great = Screen.LoadedScore.JudgementWindowGreat,
+                    Good = Screen.LoadedScore.JudgementWindowGood,
+                    Okay = Screen.LoadedScore.JudgementWindowOkay,
+                    Miss = Screen.LoadedScore.JudgementWindowMiss,
+                };
+            else // Otherwise use chosen (used by View Map on the select screen)
+                Windows = JudgementWindowsDatabaseCache.Selected.Value;
+
             VirtualPlayer = new VirtualReplayPlayer(Replay, Screen.Map, Windows, Screen.SpectatorClient != null);
 
             try

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -56,6 +56,11 @@ namespace Quaver.Shared.Screens.Loading
         private List<Score> Scores { get; }
 
         /// <summary>
+        ///     The local score (if loading a replay)
+        /// </summary>
+        private Score Score { get; }
+
+        /// <summary>
         ///     The replay to play back.
         /// </summary>
         private Replay Replay { get; }
@@ -67,11 +72,12 @@ namespace Quaver.Shared.Screens.Loading
 
         /// <summary>
         /// </summary>
-        public MapLoadingScreen(List<Score> scores, Replay replay = null, SpectatorClient spectatorClient = null)
+        public MapLoadingScreen(List<Score> scores, Replay replay = null, SpectatorClient spectatorClient = null, Score score = null)
         {
             Scores = scores;
             Replay = replay;
             SpectatorClient = spectatorClient;
+            Score = score;
 
             var game = GameBase.Game as QuaverGame;
             var cursor = game?.GlobalUserInterface.Cursor;
@@ -225,7 +231,7 @@ namespace Quaver.Shared.Screens.Loading
                     throw new ArgumentOutOfRangeException();
             }
 
-            Exit(() => new GameplayScreen(MapManager.Selected.Value.Qua, md5, Scores ?? new List<Score>(), Replay, false, 0, false, SpectatorClient));
+            Exit(() => new GameplayScreen(MapManager.Selected.Value.Qua, md5, Scores ?? new List<Score>(), Replay, Score, false, 0, false, SpectatorClient));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemCalibrateOffset.cs
+++ b/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemCalibrateOffset.cs
@@ -78,7 +78,7 @@ namespace Quaver.Shared.Screens.Options.Items.Custom
                     BackgroundHelper.Load(MapManager.Selected.Value);
                     DialogManager.Dismiss(DialogManager.Dialogs.Last());
 
-                    return new GameplayScreen(qua, "", new List<Score>(), null, false, 0, true);
+                    return new GameplayScreen(qua, "", new List<Score>(), null, null, false, 0, true);
                 });
             };
         }

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -301,7 +301,7 @@ namespace Quaver.Shared.Screens.Results
                 return;
             }
 
-            Exit(() => new MapLoadingScreen(MapManager.Selected.Value.Scores.Value, replay));
+            Exit(() => new MapLoadingScreen(MapManager.Selected.Value.Scores.Value, replay, null, Score));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoreRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoreRightClickOptions.cs
@@ -76,7 +76,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                                         return;
                                     }
 
-                                    game.CurrentScreen.Exit(() => new MapLoadingScreen(new List<Score>(), replay));
+                                    game.CurrentScreen.Exit(() => new MapLoadingScreen(new List<Score>(), replay, null, Score));
                                 });
 
                             DialogManager.Show(dialog);

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -207,7 +207,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
                 var autoplay = Replay.GeneratePerfectReplayKeys(new Replay(qua.Mode, "Autoplay", 0, map.Md5Checksum), qua);
 
-                var gameplay = new GameplayScreen(qua, map.Md5Checksum, new List<Score>(), autoplay, true, 0,
+                var gameplay = new GameplayScreen(qua, map.Md5Checksum, new List<Score>(), autoplay, null, true, 0,
                     false, null, null, true);
 
                 gameplay.HandleReplaySeeking();

--- a/Quaver.Shared/Screens/Settings/Elements/SettingsCalibrateOffset.cs
+++ b/Quaver.Shared/Screens/Settings/Elements/SettingsCalibrateOffset.cs
@@ -80,7 +80,7 @@ namespace Quaver.Shared.Screens.Settings.Elements
                     BackgroundHelper.Load(MapManager.Selected.Value);
                     DialogManager.Dismiss(Dialog);
 
-                    return new GameplayScreen(qua, "", new List<Score>(), null, false, 0, true);
+                    return new GameplayScreen(qua, "", new List<Score>(), null, null, false, 0, true);
                 });
             };
         }

--- a/Quaver.Shared/Screens/Tournament/Gameplay/TournamentGameplayScreen.cs
+++ b/Quaver.Shared/Screens/Tournament/Gameplay/TournamentGameplayScreen.cs
@@ -35,7 +35,7 @@ namespace Quaver.Shared.Screens.Tournament.Gameplay
         /// <param name="md5"></param>
         /// <param name="spectatorClient"></param>
         public TournamentGameplayScreen(Qua map, string md5, SpectatorClient spectatorClient) : base(map, md5,
-            new List<Score>(), null, false, 0, false, spectatorClient)
+            new List<Score>(), null, null, false, 0, false, spectatorClient)
         {
             Type = TournamentScreenType.Spectator;
         }
@@ -47,8 +47,8 @@ namespace Quaver.Shared.Screens.Tournament.Gameplay
         /// <param name="map"></param>
         /// <param name="md5"></param>
         /// <param name="options"></param>
-        public TournamentGameplayScreen(Qua map, string md5, TournamentPlayerOptions options) : base(map, md5, new List<Score>(), 
-            null, false, 0, false, null, options)
+        public TournamentGameplayScreen(Qua map, string md5, TournamentPlayerOptions options) : base(map, md5, new List<Score>(),
+            null, null, false, 0, false, null, options)
         {
             Type = TournamentScreenType.Coop;
         }


### PR DESCRIPTION
These changes will make replays use the judgement windows of their respective score, rather than using the selected judgement window preset of the user.