### PR TITLE
Fix a crash when opening editor on a map of a mapset which contains an invalid osu! map

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -387,7 +387,7 @@ namespace Quaver.Shared.Database.Maps
                     break;
                 case MapGame.Osu:
                     var osu = new OsuBeatmap(MapManager.OsuSongsFolder + Directory + "/" + Path);
-                    qua = osu.ToQua();
+                    qua = osu.ToQua(checkValidity);
                     break;
                 case MapGame.Etterna:
                     var stepFile = new StepFile(Path).ToQuas();

--- a/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanelContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanelContainer.cs
@@ -110,7 +110,10 @@ namespace Quaver.Shared.Screens.Edit.UI.AutoMods
         public override void Dispose()
         {
             IsActive.Dispose();
-            Panel.IssueClicked -= OnIssueClicked;
+
+            // Can happen if an exception occurs before Panel is created.
+            if (Panel != null)
+                Panel.IssueClicked -= OnIssueClicked;
 
             base.Dispose();
         }

--- a/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanelContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanelContainer.cs
@@ -62,7 +62,16 @@ namespace Quaver.Shared.Screens.Edit.UI.AutoMods
                 if (x == Screen.Map)
                     return;
 
-                mapset.Add(x.LoadQua());
+                try
+                {
+                    mapset.Add(x.LoadQua());
+                }
+                catch (Exception e)
+                {
+                    // This can happen if e.g. a mapset in the database has a missing .qua file.
+                    // Just ignore these, don't prevent editor from loading.
+                    Logger.Warning($"Couldn't load difficulty `{x.DifficultyName}` for automod: {e}", LogType.Runtime);
+                }
             });
 
             Panel = new EditorAutoModPanel(Screen.WorkingMap, mapset)


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.API/pull/118