### PR TITLE
Fix DPI not being correct when using smaller resolution on fullscreen

### DIFF
--- a/Quaver/app.manifest
+++ b/Quaver/app.manifest
@@ -51,7 +51,8 @@
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
     </windowsSettings>
   </application>
 


### PR DESCRIPTION
After the adding of DPI awareness, this effect happened when using smaller resolution on fullscreen (using 1280x720, when you original resolution is 1920x1080 with windows's scaling at 125%)
![unknown](https://user-images.githubusercontent.com/68703144/120715384-d15b7c80-c4c4-11eb-967f-6170c50cdb37.png)

This PR make it so it actually work properly now (or so i hope, it did work for me at least, and i use high DPI)
Result : https://streamable.com/dp1k8c
~~Don't mind my screen being dirty~~
