### PR TITLE
Remove 2 uses of lowercased filesystem paths

### DIFF
--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorAddDifficultyFromQuaDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorAddDifficultyFromQuaDialog.cs
@@ -42,9 +42,9 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
 
         private void OnFileDropped(object sender, string e)
         {
-            e = e.ToLower();
+            var file = e.ToLower();
 
-            if (!e.EndsWith(".qua"))
+            if (!file.EndsWith(".qua"))
                 return;
 
             Logger.Important($"Importing file: {e} into the mapset.", LogType.Runtime);

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1642,7 +1642,7 @@ namespace Quaver.Shared.Screens.Edit
                 return;
             }
 
-            DialogManager.Show(new EditorChangeBackgroundDialog(this, file));
+            DialogManager.Show(new EditorChangeBackgroundDialog(this, e));
         }
     }
 }


### PR DESCRIPTION
Linux filesystems are generally case-sensitive, so using lowercased paths breaks the operation for any path that has an uppercase letter.