### PR TITLE
Require a timing point to test play map

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1300,6 +1300,12 @@ namespace Quaver.Shared.Screens.Edit
                 return;
             }
 
+            if (WorkingMap.TimingPoints.Count == 0)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "A timing point must be added to your map before test playing!");
+                return;
+            }
+
             if (DialogManager.Dialogs.Count != 0)
             {
                 NotificationManager.Show(NotificationLevel.Warning, "Finish what you're doing before test playing!");


### PR DESCRIPTION
Fixes a softlock when people somehow create a map without timing points and try to test play it.