### PR TITLE
Disable retry hotkey in multiplayer/spectator results screen

### DIFF
--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -511,6 +511,9 @@ namespace Quaver.Shared.Screens.Results
             if (OnlineManager.IsSpectatingSomeone)
                 return;
 
+            if (OnlineManager.CurrentGame != null)
+                return;
+
             switch (ScreenType)
             {
                 case ResultsScreenType.Gameplay:


### PR DESCRIPTION
Fixes #2868 