### PR TITLE
Manage banner in editor and update banner in song select

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -114,6 +114,8 @@ namespace Quaver.Shared.Assets
         public static Texture2D ClosePanel => TextureManager.Load(@"Quaver.Resources/Textures/UI/SongSelect/close-panel.png");
         public static Texture2D CreateButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/create-button.png");
         public static Texture2D SureButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/sure-button.png");
+        public static Texture2D BackgroundButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/background-button.png");
+        public static Texture2D BannerButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/banner-button.png");
         public static Texture2D AcceptButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/accept-button.png");
         public static Texture2D DeclineButton => TextureManager.Load(@"Quaver.Resources/Textures/UI/decline-button.png");
         public static Texture2D LegalPanel => TextureManager.Load(@"Quaver.Resources/Textures/UI/legal-panel.png");

--- a/Quaver.Shared/Graphics/BackgroundBannerDialog.cs
+++ b/Quaver.Shared/Graphics/BackgroundBannerDialog.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Linq;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Helpers;
+using Quaver.Shared.Helpers.Input;
+using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Menu.UI.Jukebox;
+using Wobble.Assets;
+using Wobble.Graphics;
+using Wobble.Graphics.Animations;
+using Wobble.Graphics.Sprites;
+using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Input;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Graphics
+{
+    public class BackgroundBannerDialog : DialogScreen
+    {
+        /// <summary>
+        ///     The time it takes to fade in/out the dialog
+        /// </summary>
+        private const int FadeTime = 150;
+
+        /// <summary>
+        /// </summary>
+        private string HeaderText { get; }
+
+        /// <summary>
+        /// </summary>
+        private string ConfirmationText { get; }
+
+        /// <summary>
+        /// </summary>
+        public Sprite Panel { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        protected Sprite Banner { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private Sprite Blackness { get; set; }
+
+        /// <summary>
+        /// </summary>
+        public SpriteTextPlus Header { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public SpriteTextPlus Confirmation { get; private set; }
+
+        /// <summary>
+        /// </summary>
+        public IconButton BackgroundButton { get; protected set; }
+
+        /// <summary>
+        /// </summary>
+        public IconButton BannerButton { get; protected set; }
+
+        /// <summary>
+        /// </summary>
+        public IconButton NoneButton { get; protected set; }
+
+        /// <summary>
+        /// </summary>
+        protected Action BackgroundAction { get; set; }
+
+        /// <summary>
+        /// </summary>
+        protected Action BannerAction { get; set; }
+
+        /// <summary>
+        /// </summary>
+        protected Action NoneAction { get; set; }
+
+        /// <summary>
+        /// </summary>
+        protected Func<bool> ValidateBeforeClosing { get; set; }
+
+        /// <summary>
+        ///     If true, it'll call the yes action upon pressing enter and close the dialog.
+        /// </summary>
+        protected bool HandleEnterPress { get; set; } = true;
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public BackgroundBannerDialog(string header, string confirmationText, Action backgroundAction = null, Action bannerAction = null, Action noneAction = null) : base(0)
+        {
+            HeaderText = header;
+            ConfirmationText = confirmationText;
+            BackgroundAction = backgroundAction;
+            BannerAction = bannerAction;
+            NoneAction = noneAction;
+
+            FadeTo(0.85f, Easing.Linear, FadeTime);
+
+            // ReSharper disable once VirtualMemberCallInConstructor
+            CreateContent();
+
+            Clicked += (sender, args) =>
+            {
+                if (Panel.IsHovered()) 
+                    return;
+                
+                NoneAction?.Invoke();
+                Close();
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void CreateContent()
+        {
+            CreatePanel();
+            CreateBanner();
+            CreateHeader();
+            CreateConfirmation();
+            CreateButtons();
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void HandleInput(GameTime gameTime)
+        {
+            if (DialogManager.Dialogs.First() == this)
+            {
+                if (KeyboardManager.IsUniqueKeyPress(Keys.Escape))
+                {
+                    NoneAction?.Invoke();
+                    Close();
+                    return;
+                }
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        public virtual void Close()
+        {
+            FadeTo(0, Easing.Linear, FadeTime);
+
+            const int fadeTime = FadeTime - 50;
+
+            Panel.ClearAnimations();
+            Panel.FadeTo(0, Easing.Linear, fadeTime);
+
+            Blackness.ClearAnimations();
+            Blackness.FadeTo(0, Easing.Linear, fadeTime);
+
+            Confirmation.ClearAnimations();
+            Confirmation.FadeTo(0, Easing.Linear, fadeTime);
+
+            NoneButton.IsPerformingFadeAnimations = false;
+            NoneButton.IsClickable = false;
+
+            BackgroundButton.IsPerformingFadeAnimations = false;
+            BackgroundButton.IsClickable = false;
+
+            BannerButton.IsPerformingFadeAnimations = false;
+            BannerButton.IsClickable = false;
+
+            ThreadScheduler.RunAfter(() => DialogManager.Dismiss(this), FadeTime);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreatePanel()
+        {
+            Panel = new Sprite
+            {
+                Parent = this,
+                Alignment = Alignment.MidCenter,
+                Size = new ScalableVector2(770, 286),
+                Image = UserInterface.YesNoPanel,
+                Alpha = 0,
+                SetChildrenAlpha = true
+            };
+
+            Panel.FadeTo(1, Easing.Linear, FadeTime + 50);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateBanner()
+        {
+            Banner = new Sprite
+            {
+                Parent = Panel,
+                Alignment = Alignment.TopCenter,
+                Size = new ScalableVector2(766, 151),
+                Image = UserInterface.DefaultBanner,
+                Alpha = 0,
+                Y = 2,
+            };
+
+            Blackness = new Sprite()
+            {
+                Parent = Banner,
+                Size = Banner.Size,
+                Tint = Color.Black,
+                Alpha = 0
+            };
+
+            Blackness.FadeTo(0.7f, Easing.Linear, FadeTime + 50);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateHeader()
+        {
+            Header = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), HeaderText.ToUpper(), 26)
+            {
+                Parent = Panel,
+                Alignment = Alignment.TopLeft,
+            };
+
+            Header.Y = -Header.Height - 6;
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateConfirmation()
+        {
+            Confirmation = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), ConfirmationText, 26)
+            {
+                Parent = Banner,
+                Alignment = Alignment.MidCenter,
+                TextAlignment = TextAlignment.Center,
+                Alpha = 0
+            };
+
+            Confirmation.FadeTo(1, Easing.Linear, FadeTime + 50);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateButtons()
+        {
+            BackgroundButton = new IconButton(UserInterface.BackgroundButton, (o, e) =>
+            {
+                BackgroundAction?.Invoke();
+
+                if (ValidateBeforeClosing == null)
+                {
+                    Close();
+                    return;
+                }
+
+                var canClose = ValidateBeforeClosing?.Invoke();
+
+                if (canClose.Value)
+                    Close();
+            })
+            {
+                Parent = Panel,
+                Alignment = Alignment.BotLeft,
+                Size = new ScalableVector2(221, 40),
+                Y = -50,
+                X = 31
+            };
+
+            BannerButton = new IconButton(UserInterface.BannerButton, (o, e) =>
+            {
+                BannerAction?.Invoke();
+
+                if (ValidateBeforeClosing == null)
+                {
+                    Close();
+                    return;
+                }
+
+                var canClose = ValidateBeforeClosing?.Invoke();
+
+                if (canClose.Value)
+                    Close();
+            })
+            {
+                Parent = Panel,
+                Alignment = Alignment.BotCenter,
+                Size = new ScalableVector2(221, 40),
+                Y = -50,
+                X = 0
+            };
+
+            NoneButton = new IconButton(UserInterface.CancelButton, (o, e) =>
+            {
+                NoneAction?.Invoke();
+                Close();
+            })
+            {
+                Parent = Panel,
+                Alignment = Alignment.BotRight,
+                Size = BackgroundButton.Size,
+                Y = BackgroundButton.Y,
+                X = -BackgroundButton.X
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Graphics/BackgroundBannerDialog.cs
+++ b/Quaver.Shared/Graphics/BackgroundBannerDialog.cs
@@ -75,6 +75,10 @@ namespace Quaver.Shared.Graphics
 
         /// <summary>
         /// </summary>
+        protected Action BackgroundBannerAction { get; set; }
+
+        /// <summary>
+        /// </summary>
         protected Action NoneAction { get; set; }
 
         /// <summary>
@@ -89,12 +93,14 @@ namespace Quaver.Shared.Graphics
         /// <inheritdoc />
         /// <summary>
         /// </summary>
-        public BackgroundBannerDialog(string header, string confirmationText, Action backgroundAction = null, Action bannerAction = null, Action noneAction = null) : base(0)
+        public BackgroundBannerDialog(string header, string confirmationText, Action backgroundAction = null,
+            Action bannerAction = null, Action backgroundBannerAction = null, Action noneAction = null) : base(0)
         {
             HeaderText = header;
             ConfirmationText = confirmationText;
             BackgroundAction = backgroundAction;
             BannerAction = bannerAction;
+            BackgroundBannerAction = backgroundBannerAction;
             NoneAction = noneAction;
 
             FadeTo(0.85f, Easing.Linear, FadeTime);
@@ -246,6 +252,7 @@ namespace Quaver.Shared.Graphics
         {
             BackgroundButton = new IconButton(UserInterface.BackgroundButton, (o, e) =>
             {
+                BackgroundBannerAction?.Invoke();
                 BackgroundAction?.Invoke();
 
                 if (ValidateBeforeClosing == null)
@@ -269,6 +276,7 @@ namespace Quaver.Shared.Graphics
 
             BannerButton = new IconButton(UserInterface.BannerButton, (o, e) =>
             {
+                BackgroundBannerAction?.Invoke();
                 BannerAction?.Invoke();
 
                 if (ValidateBeforeClosing == null)

--- a/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
+++ b/Quaver.Shared/Graphics/Backgrounds/BackgroundHelper.cs
@@ -72,7 +72,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
         /// <summary>
         ///     A list of banners that are queued to be loaded on the load thread
         /// </summary>
-        private static List<Mapset> MapsetBannersToLoad { get; } = new List<Mapset>();
+        public static List<Mapset> MapsetBannersToLoad { get; } = new List<Mapset>();
 
         /// <summary>
         ///     A list of playlist banners to load
@@ -239,7 +239,7 @@ namespace Quaver.Shared.Graphics.Backgrounds
         /// <summary>
         ///     Responsible for making sure all mapset banners are loaded in
         /// </summary>
-        private static void LoadAllMapsetBanners()
+        public static void LoadAllMapsetBanners(bool updateBanner = false)
         {
             if (MapsetBannersToLoad.Count == 0)
                 return;
@@ -273,6 +273,8 @@ namespace Quaver.Shared.Graphics.Backgrounds
                     mapTexture = DefaultBanner;
                     Logger.Error(e, LogType.Runtime);
                 }
+
+                if (updateBanner) MapsetBanners.Remove(mapset.Directory);
 
                 // The banner is the default, so there's no need to cache it to a RenderTarget
                 if (mapTexture == DefaultBanner || bannerExists)

--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorChangeBackgroundBannerDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorChangeBackgroundBannerDialog.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Backgrounds;
+using Quaver.Shared.Graphics.Notifications;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Screens.Edit.Dialogs
+{
+    public class EditorChangeBackgroundBannerDialog : BackgroundBannerDialog
+    {
+        public EditorChangeBackgroundBannerDialog(EditScreen screen, string file) : base("CHANGE BACKGROUND / BANNER",
+            $"Would you like to change the background or the banner?")
+        {
+            BackgroundAction += () =>
+            {
+                var name = Path.GetFileName(file);
+
+                try
+                {
+                    if (ConfigManager.SongDirectory == null)
+                        throw new InvalidOperationException("Song directory is null. Visual testing?");
+
+                    try
+                    {
+                        File.Copy(file, $"{ConfigManager.SongDirectory.Value}/{screen.Map.Directory}/{name}", true);
+                    }
+                    catch (Exception)
+                    {
+                        // ignored
+                    }
+
+                    screen.WorkingMap.BackgroundFile = name;
+                    screen.Map.BackgroundPath = name;
+                    screen.Save(true, true);
+
+                    NotificationManager.Show(NotificationLevel.Success, "Your background has been successfully changed!");
+                    BackgroundHelper.Load(screen.Map);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                    NotificationManager.Show(NotificationLevel.Error, "There was an issue while changing your background");
+                }
+            };
+
+            BannerAction += () =>
+            {
+                var name = Path.GetFileName(file);
+
+                try
+                {
+                    if (ConfigManager.SongDirectory == null)
+                        throw new InvalidOperationException("Song directory is null. Visual testing?");
+
+                    try
+                    {
+                        File.Copy(file, $"{ConfigManager.SongDirectory.Value}/{screen.Map.Directory}/{name}", true);
+                    }
+                    catch (Exception)
+                    {
+                        // ignored
+                    }
+
+                    screen.WorkingMap.BannerFile = name;
+                    screen.Map.BannerPath = name;
+                    screen.Save(true, true);
+
+                    NotificationManager.Show(NotificationLevel.Success, "Your banner has been successfully changed!");
+                    BackgroundHelper.Load(screen.Map);
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                    NotificationManager.Show(NotificationLevel.Error, "There was an issue while changing your banner");
+                }
+            };
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1677,7 +1677,7 @@ namespace Quaver.Shared.Screens.Edit
                 return;
             }
 
-            DialogManager.Show(new EditorChangeBackgroundDialog(this, e));
+            DialogManager.Show(new EditorChangeBackgroundBannerDialog(this, e));
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1225,7 +1225,8 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         /// <param name="synchronous"></param>
         /// <param name="forceSave"></param>
-        public void Save(bool synchronous = false, bool forceSave = false)
+        /// <param name="wholeSet"></param>
+        public void Save(bool synchronous = false, bool forceSave = false, bool wholeSet = false)
         {
             if (!ActionManager.HasUnsavedChanges && !forceSave)
                 return;
@@ -1252,11 +1253,26 @@ namespace Quaver.Shared.Screens.Edit
                 if (ActionManager.UndoStack.Count != 0)
                     ActionManager.LastSaveAction = ActionManager.UndoStack.Peek();
 
-                Map.DifficultyProcessorVersion = "Needs Update";
-                MapDatabaseCache.UpdateMap(Map);
+                if (wholeSet)
+                {
+                    foreach (var UpdateMap in Map.Mapset.Maps)
+                    {
+                        UpdateMap.DifficultyProcessorVersion = "Needs Update";
+                        MapDatabaseCache.UpdateMap(UpdateMap);
 
-                if (!MapDatabaseCache.MapsToUpdate.Contains(MapManager.Selected.Value))
-                    MapDatabaseCache.MapsToUpdate.Add(MapManager.Selected.Value);
+                        if (!MapDatabaseCache.MapsToUpdate.Contains(UpdateMap))
+                            MapDatabaseCache.MapsToUpdate.Add(UpdateMap);
+                    }
+                }
+                else
+                {
+                    Map.DifficultyProcessorVersion = "Needs Update";
+                    MapDatabaseCache.UpdateMap(Map);
+
+                    if (!MapDatabaseCache.MapsToUpdate.Contains(MapManager.Selected.Value))
+                        MapDatabaseCache.MapsToUpdate.Add(MapManager.Selected.Value);
+                }
+
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Use a 3 options dialog instead so that the user can choose if they want to change the background or the banner.
When adding banner it will get added to all diff of the mapset.
Reload banner so it get instantly updated to the new one when coming back in the song select screen.

New button image added here : https://github.com/Quaver/Quaver.Resources/pull/11

https://github.com/Quaver/Quaver/issues/3192