### PR TITLE
Remove bpm limit when creating timing lines for gameplay

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -99,10 +99,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
                 var signature = (int)map.TimingPoints[i].Signature;
 
-                // Max possible sane value for timing lines
-                const float maxBpm = 9999f;
-
-                var msPerBeat = 60000 / Math.Min(Math.Abs(map.TimingPoints[i].Bpm), maxBpm);
+                var msPerBeat = 60000 / Math.Abs(map.TimingPoints[i].Bpm);
                 var increment = signature * msPerBeat;
 
                 // ReSharper disable once CompareOfFloatsByEqualityOperator


### PR DESCRIPTION
resolves #2982

Was worried that this would break some maps, so I wrote a thing to find maps in my songs folder with timing points that have >9999 bpm and that didn't have their lines hidden.

Generally for the maps I checked, they were either used for teleporting (when BPM affects SV) or for overriding beat snap colors, both of which this change didn't appear to negatively impact.

The maps I found that were negatively impacted were:
[Helblinde - The Solace of Oblivion [A Lie's Asgard]](https://osu.ppy.sh/beatmapsets/596105#mania/1274057): lags like crazy
[LeaF - Aleph-0 (extended ver.) [Boundless]](https://osu.ppy.sh/beatmapsets/1226110#mania/2549754): either doesn't start or takes a really really long time to start
Utata-P feat. Yuzuki Yukari - Shiawase ni Nareru Kakushi Command ga Arurashii [Cheat Code]: laggier

I did not find any ranked maps that were broken by this change.