### PR TITLE
Fix not being able to select duplicate SVs or timing points

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -371,8 +371,14 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 NeedsToScrollToLastSelectedSv = false;
             }
 
-            foreach (var sv in Screen.WorkingMap.SliderVelocities)
+            for (int i = 0; i < Screen.WorkingMap.SliderVelocities.Count; i++)
             {
+                // https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-why-is-my-widget-not-reacting-when-i-click-on-it
+                // allows all SVs with same truncated time to be selected, instead of just the first in list
+                ImGui.PushID(i);
+
+                var sv = Screen.WorkingMap.SliderVelocities[i];
+
                 var isSelected = SelectedScrollVelocities.Contains(sv);
 
                 if (!isSelected)
@@ -442,6 +448,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 ImGui.NextColumn();
                 ImGui.TextWrapped($"{sv.Multiplier:0.00}x");
                 ImGui.NextColumn();
+
+                ImGui.PopID();
             }
 
             IsWindowHovered = ImGui.IsWindowHovered() || ImGui.IsAnyItemFocused();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -373,8 +373,14 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 NeedsToScrollToLastSelectedPoint = false;
             }
 
-            foreach (var point in Screen.WorkingMap.TimingPoints)
+            for (int i = 0; i < Screen.WorkingMap.TimingPoints.Count; i++)
             {
+                // https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-why-is-my-widget-not-reacting-when-i-click-on-it
+                // allows all timing points with same truncated time to be selected, instead of just the first in list
+                ImGui.PushID(i);
+
+                var point = Screen.WorkingMap.TimingPoints[i];
+
                 var isSelected = SelectedTimingPoints.Contains(point);
 
                 if (!isSelected)
@@ -446,10 +452,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 ImGui.NextColumn();
 
                 var hidden = point.Hidden;
-                // give each checkbox a unique ID based off timing point's StartTime so that they behave separately
                 if (ImGui.Checkbox($"##{point.StartTime}", ref hidden))
                     Screen.ActionManager.ChangeTimingPointHidden(point, hidden);
+
                 ImGui.NextColumn();
+                ImGui.PopID();
             }
 
             IsWindowHovered = ImGui.IsWindowHovered() || ImGui.IsAnyItemFocused();


### PR DESCRIPTION
Give each button in the columns of the SV and timing point panels their own unique ids so that mapper is not limited to selecting only the first of a group of SVs or timing points that have the same truncated timestamps

Fixes #2031 and #2471