### PR TITLE
Use tint depending on status for FFA/BR multiplayer player card

### DIFF
--- a/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayer.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Players/MultiplayerPlayer.cs
@@ -219,7 +219,24 @@ namespace Quaver.Shared.Screens.Multi.UI.Players
             }
             // FFA Color
             else
-                Border.Tint = ColorHelper.HexToColor("#0587E5");
+            {
+                if (Game.Value.HostId == User.OnlineUser.Id)
+                {
+                    Border.Tint = ColorHelper.HexToColor("#E8B636");
+                }
+                else if (Game.Value.PlayersWithoutMap.Contains(User.OnlineUser.Id))
+                {
+                    Border.Tint = ColorHelper.HexToColor("#F8645D");
+                }
+                else if (Game.Value.PlayersReady.Contains(User.OnlineUser.Id))
+                {
+                    Border.Tint = ColorHelper.HexToColor("#27AF6E");
+                }
+                else
+                {
+                    Border.Tint = ColorHelper.HexToColor("#0587E5");
+                }
+            }
 
             UpdateModifiers();
 


### PR DESCRIPTION
This aims at making it more visible when you are host of the game (primarily for host rotation lobbies)
Then also improves visibility of player statuses (idle/ready/missing map)
This is only for FFA and Battle Royale, since Team vs mode uses this as a team indicator.

![Quaver_sByiBqL1Mv](https://user-images.githubusercontent.com/16978299/130353937-8117afb4-22fe-41af-aa0b-25a19f0601bb.png)
![Quaver_scjbnDy2Ra](https://user-images.githubusercontent.com/16978299/130353939-383ba477-dbad-4f05-b589-99bc2a983af5.png)
![Quaver_9qzFTll4mm](https://user-images.githubusercontent.com/16978299/130353940-da8b46b5-8d97-40cf-b519-f38f7d641197.png)
