### PR TITLE
Add skinning for the results screen

### DIFF
--- a/Quaver.Shared/Screens/Results/ResultsScreenView.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreenView.cs
@@ -3,8 +3,10 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Menu.Border;
 using Quaver.Shared.Helpers;
+using Quaver.Shared.Screens.Results.UI;
 using Quaver.Shared.Screens.Results.UI.Footer;
 using Quaver.Shared.Screens.Results.UI.Header;
 using Quaver.Shared.Screens.Results.UI.Header.Contents.Tabs;
@@ -118,7 +120,8 @@ namespace Quaver.Shared.Screens.Results
 
         /// <summary>
         /// </summary>
-        private void CreateBackground() => Background = new BackgroundImage(SkinManager.Skin?.Results?.ResultsBackground ?? UserInterface.Triangles, 0,false)
+        private void CreateBackground() => Background = new BackgroundImage(SkinManager.Skin.Results.ResultsBackgroundType == ResultsBackgroundType.Background ?
+           BackgroundHelper.RawTexture : SkinManager.Skin?.Results?.ResultsBackground ?? UserInterface.Triangles, 0,false)
         {
             Parent = Container,
             Y = 0,

--- a/Quaver.Shared/Screens/Results/ResultsScreenView.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreenView.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Screens.Results.UI.Tabs;
 using Quaver.Shared.Screens.Results.UI.Tabs.Multiplayer;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview;
 using Quaver.Shared.Screens.Tests.UI.Borders;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -117,11 +118,11 @@ namespace Quaver.Shared.Screens.Results
 
         /// <summary>
         /// </summary>
-        private void CreateBackground() => Background = new BackgroundImage(UserInterface.Triangles, 0,false)
+        private void CreateBackground() => Background = new BackgroundImage(SkinManager.Skin?.Results?.ResultsBackground ?? UserInterface.Triangles, 0,false)
         {
             Parent = Container,
-            Y = -10,
-            X = -6
+            Y = 0,
+            X = 0
         };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
@@ -4,6 +4,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Skinning;
 using Steamworks;
 using Wobble.Assets;
 using Wobble.Bindables;
@@ -26,7 +27,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
         public ResultsScreenHeaderAvatar(float size, Bindable<ScoreProcessor> processor)
         {
             Size = new ScalableVector2(size, size);
-            Image = UserInterface.ResultsAvatarBorder;
+            Image = SkinManager.Skin?.Results?.ResultsAvatarBorder ?? UserInterface.ResultsAvatarBorder;
 
             var avatarSize = size - OFFSET * 2;
 
@@ -34,7 +35,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
             {
                 Parent = this,
                 Alignment = Alignment.MidCenter,
-                Image = UserInterface.ResultsAvatarMask
+                Image = SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask
             };
 
             if (SteamManager.UserAvatars != null)

--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/Tabs/ResultsTabSelector.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/Tabs/ResultsTabSelector.cs
@@ -6,6 +6,7 @@ using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Skinning;
 using Wobble.Assets;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -38,7 +39,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents.Tabs
             Processor = processor;
             Size = size;
 
-            Image = UserInterface.ResultsTabSelectorBackground;
+            Image = SkinManager.Skin?.Results?.ResultsTabSelectorBackground ?? UserInterface.ResultsTabSelectorBackground;
 
             CreateTabs();
             CreateModifiers();

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
@@ -51,7 +51,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header
 
             Size = new ScalableVector2(WindowManager.Width, HEIGHT);
 
-            if (SkinManager.Skin.Results.ResultsBackgroundType != "None")
+            if (SkinManager.Skin.Results.ResultsBackgroundType == ResultsBackgroundType.Header)
                 CreateBackground();
             CreateContentContainer();
         }
@@ -59,7 +59,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header
         /// <summary>
         /// </summary>
         private void CreateBackground() => Background = new ResultsScreenHeaderBackground(
-            new ScalableVector2(Width, SkinManager.Skin.Results.ResultsBackgroundType == "Background" ? 1080 : 208))
+            new ScalableVector2(Width, 208))
             { Parent = this };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
@@ -4,6 +4,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Results.UI.Header.Contents;
 using Quaver.Shared.Screens.Results.UI.Header.Contents.Tabs;
+using Quaver.Shared.Skinning;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -50,13 +51,15 @@ namespace Quaver.Shared.Screens.Results.UI.Header
 
             Size = new ScalableVector2(WindowManager.Width, HEIGHT);
 
-            CreateBackground();
+            if (SkinManager.Skin.Results.ResultsBackgroundType != "None")
+                CreateBackground();
             CreateContentContainer();
         }
 
         /// <summary>
         /// </summary>
-        private void CreateBackground() => Background = new ResultsScreenHeaderBackground(new ScalableVector2(Width, 208))
+        private void CreateBackground() => Background = new ResultsScreenHeaderBackground(
+            new ScalableVector2(Width, SkinManager.Skin.Results.ResultsBackgroundType == "Background" ? 1080 : 208))
             { Parent = this };
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
@@ -83,8 +83,8 @@ namespace Quaver.Shared.Screens.Results.UI.Header
             DarknessFilter = new Sprite
             {
                 Parent = this,
-                Size = new ScalableVector2(WindowManager.Width , WindowManager.Height),
-                Alpha = SkinManager.Skin?.Results?.ResultsBackgroundFilterAlpha ?? 0f,
+                Size = new ScalableVector2(WindowManager.Width, SkinManager.Skin.Results.ResultsBackgroundType != ResultsBackgroundType.Header ? WindowManager.Height : Background.Height),
+                Alpha = SkinManager.Skin?.Results?.ResultsBackgroundFilterAlpha ?? 1f,
                 Image = SkinManager.Skin?.Results?.ResultsBackgroundFilter ?? UserInterface.ResultsBackgroundFilter
             };
         }

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeader.cs
@@ -1,5 +1,6 @@
 using System;
 using Quaver.API.Maps.Processors.Scoring;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Results.UI.Header.Contents;
@@ -40,6 +41,10 @@ namespace Quaver.Shared.Screens.Results.UI.Header
 
         /// <summary>
         /// </summary>
+        private Sprite DarknessFilter { get; set; }
+
+        /// <summary>
+        /// </summary>
         /// <param name="map"></param>
         /// <param name="processor"></param>
         /// <param name="activeTab"></param>
@@ -53,6 +58,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header
 
             if (SkinManager.Skin.Results.ResultsBackgroundType == ResultsBackgroundType.Header)
                 CreateBackground();
+            CreateDarknessFilter();
             CreateContentContainer();
         }
 
@@ -69,5 +75,18 @@ namespace Quaver.Shared.Screens.Results.UI.Header
             Parent = this,
             Alignment = Alignment.BotCenter,
         };
+
+        /// <summary>
+        /// </summary>
+        private void CreateDarknessFilter()
+        {
+            DarknessFilter = new Sprite
+            {
+                Parent = this,
+                Size = new ScalableVector2(WindowManager.Width , WindowManager.Height),
+                Alpha = SkinManager.Skin?.Results?.ResultsBackgroundFilterAlpha ?? 0f,
+                Image = SkinManager.Skin?.Results?.ResultsBackgroundFilter ?? UserInterface.ResultsBackgroundFilter
+            };
+        }
     }
 }

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
@@ -2,6 +2,7 @@ using System;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Music.UI.Controller;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Assets;
 using Wobble.Graphics;
@@ -22,9 +23,9 @@ namespace Quaver.Shared.Screens.Results.UI.Header
         /// <param name="size"></param>
         public ResultsScreenHeaderBackground(ScalableVector2 size) : base(size, false)
         {
-            Background.Y = 100;
+            Background.Y = SkinManager.Skin.Results.ResultsBackgroundType == "Background" ? 0 : 100;
             Background.Alignment = Alignment.MidCenter;
-            Darkness.Alpha = 0f;
+            Darkness.Alpha = (float)SkinManager.Skin.Results.ResultsBackgroundFilterAlpha;
 
             var game = GameBase.Game;
             var ratio = (float) game.Window.ClientBounds.Width / game.Window.ClientBounds.Height;
@@ -47,7 +48,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header
             {
                 Parent = this,
                 Size = Size,
-                Image = UserInterface.ResultsBackgroundFilter
+                Image = SkinManager.Skin?.Results?.ResultsBackgroundFilter ?? UserInterface.ResultsBackgroundFilter
             };
         }
     }

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
@@ -13,19 +13,15 @@ namespace Quaver.Shared.Screens.Results.UI.Header
 {
     public class ResultsScreenHeaderBackground : MusicControllerBackground
     {
-        /// <summary>
-        /// </summary>
-        private Sprite DarknessFilter { get; set; }
-
         /// <inheritdoc />
         /// <summary>
         /// </summary>
         /// <param name="size"></param>
         public ResultsScreenHeaderBackground(ScalableVector2 size) : base(size, false)
         {
-            Background.Y = SkinManager.Skin.Results.ResultsBackgroundType == ResultsBackgroundType.Background ? 0 : 100;
+            Background.Y = 100;
             Background.Alignment = Alignment.MidCenter;
-            Darkness.Alpha = SkinManager.Skin?.Results?.ResultsBackgroundFilterAlpha ?? 0f;
+            Darkness.Alpha = 0f;
 
             var game = GameBase.Game;
             var ratio = (float) game.Window.ClientBounds.Width / game.Window.ClientBounds.Height;
@@ -36,20 +32,6 @@ namespace Quaver.Shared.Screens.Results.UI.Header
                 Background.Size = new ScalableVector2(WindowManager.Width, WindowManager.Height);
                 Darkness.Size = Background.Size;
             }
-
-            CreateDarknessFilter();
-        }
-
-        /// <summary>
-        /// </summary>
-        private void CreateDarknessFilter()
-        {
-            DarknessFilter = new Sprite
-            {
-                Parent = this,
-                Size = Size,
-                Image = SkinManager.Skin?.Results?.ResultsBackgroundFilter ?? UserInterface.ResultsBackgroundFilter
-            };
         }
     }
 }

--- a/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/ResultsScreenHeaderBackground.cs
@@ -23,9 +23,9 @@ namespace Quaver.Shared.Screens.Results.UI.Header
         /// <param name="size"></param>
         public ResultsScreenHeaderBackground(ScalableVector2 size) : base(size, false)
         {
-            Background.Y = SkinManager.Skin.Results.ResultsBackgroundType == "Background" ? 0 : 100;
+            Background.Y = SkinManager.Skin.Results.ResultsBackgroundType == ResultsBackgroundType.Background ? 0 : 100;
             Background.Alignment = Alignment.MidCenter;
-            Darkness.Alpha = (float)SkinManager.Skin.Results.ResultsBackgroundFilterAlpha;
+            Darkness.Alpha = SkinManager.Skin?.Results?.ResultsBackgroundFilterAlpha ?? 0f;
 
             var game = GameBase.Game;
             var ratio = (float) game.Window.ClientBounds.Width / game.Window.ClientBounds.Height;

--- a/Quaver.Shared/Screens/Results/UI/ResultsBackgroundType.cs
+++ b/Quaver.Shared/Screens/Results/UI/ResultsBackgroundType.cs
@@ -1,0 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
+*/
+
+namespace Quaver.Shared.Screens.Results.UI
+{
+    public enum ResultsBackgroundType
+    {
+        Header,
+        Background,
+        None
+    }
+}

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Header/ResultsMultiplayerTeamHeader.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Header/ResultsMultiplayerTeamHeader.cs
@@ -7,6 +7,7 @@ using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Heading;
+using Quaver.Shared.Skinning;
 using Wobble.Assets;
 using Wobble.Bindables;
 
@@ -45,11 +46,11 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Multiplayer.Header
         {
             Items.AddRange(new []
             {
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelBlueTeam,
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelBlueTeam ?? UserInterface.ResultsLabelBlueTeam,
                     StringHelper.RatingToString(GetTeamAverageRating(Map, BlueTeam)), ColorHelper.HexToColor("#0587E5")),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelScore,
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelScore ?? UserInterface.ResultsLabelScore,
                     $"{Game.BlueTeamWins:n0} : {Game.RedTeamWins:n0}"),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelRedTeam,
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelRedTeam ?? UserInterface.ResultsLabelRedTeam,
                     StringHelper.RatingToString(GetTeamAverageRating(Map, RedTeam)), ColorHelper.HexToColor("#F9645D")),
             });
         }

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Table/ResultsMultiplayerTable.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Table/ResultsMultiplayerTable.cs
@@ -10,6 +10,7 @@ using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Screens.Results.UI.Header.Contents.Tabs;
 using Quaver.Shared.Screens.Results.UI.Tabs.Multiplayer.Table.Scrolling;
+using Quaver.Shared.Skinning;
 using Wobble.Assets;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -77,11 +78,11 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Multiplayer.Table
             {
                 case MultiplayerGameRuleset.Free_For_All:
                 case MultiplayerGameRuleset.Battle_Royale:
-                    Image = UserInterface.ResultsMultiplayerFFAPanel;
+                    Image = SkinManager.Skin?.Results?.ResultsMultiplayerFFAPanel ?? UserInterface.ResultsMultiplayerFFAPanel;
                     Height = Image.Height + 4;
                     break;
                 case MultiplayerGameRuleset.Team:
-                    Image = UserInterface.ResultsMultiplayerTeamPanel;
+                    Image = SkinManager.Skin?.Results?.ResultsMultiplayerTeamPanel ?? UserInterface.ResultsMultiplayerTeamPanel;
                     Height = Image.Height;
                     break;
                 default:

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/ResultsOverviewGraphContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/ResultsOverviewGraphContainer.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Footer;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Health;
 using Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Rating;
 using Quaver.Shared.Screens.Selection.UI.FilterPanel.MapInformation.Metadata;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Assets;
 using Wobble.Bindables;
@@ -126,7 +127,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs
             IsSubmittingScore = isSubmittingScore;
             ScoreSubmissionStats = scoreSubmissionStats;
 
-            Image = UserInterface.ResultsGraphContainerPanel;
+            Image = SkinManager.Skin?.Results?.ResultsGraphContainerPanel ?? UserInterface.ResultsGraphContainerPanel;
             Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, Image.Height);
 
             Statistics = Processor.Value.Stats != null ? Processor.Value.GetHitStatistics() : new HitStatistics();

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Heading/ResultsOverviewScoreContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Heading/ResultsOverviewScoreContainer.cs
@@ -5,6 +5,7 @@ using Quaver.API.Maps.Processors.Scoring;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Helpers;
+using Quaver.Shared.Skinning;
 using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -34,7 +35,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Heading
             Map = map;
             Processor = processor;
 
-            Image = UserInterface.ResultsScoreContainerPanel;
+            Image = SkinManager.Skin?.Results?.ResultsScoreContainerPanel ?? UserInterface.ResultsScoreContainerPanel;
             Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, Image.Height);
         }
 
@@ -47,12 +48,12 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Heading
 
             Items.AddRange(new []
             {
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelMaxCombo, $"{Processor.Value.MaxCombo:n0}x"),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelAccuracy, StringHelper.AccuracyToString(Processor.Value.Accuracy)),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelPerformanceRating,
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelMaxCombo ?? UserInterface.ResultsLabelMaxCombo, $"{Processor.Value.MaxCombo:n0}x"),
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelAccuracy ?? UserInterface.ResultsLabelAccuracy, StringHelper.AccuracyToString(Processor.Value.Accuracy)),
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelPerformanceRating ?? UserInterface.ResultsLabelPerformanceRating,
                     $"{StringHelper.RatingToString(rating.CalculateRating(accuracy))}", ColorHelper.HexToColor("#E9B736")),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelRankedAccuracy, StringHelper.AccuracyToString(accuracy)),
-                new DrawableResultsScoreMetric(UserInterface.ResultsLabelTotalScore,
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelRankedAccuracy ?? UserInterface.ResultsLabelRankedAccuracy, StringHelper.AccuracyToString(accuracy)),
+                new DrawableResultsScoreMetric(SkinManager.Skin?.Results?.ResultsLabelTotalScore ?? UserInterface.ResultsLabelTotalScore,
                     $"{Processor.Value.Score:n0}"),
             });
         }

--- a/Quaver.Shared/Skinning/Menus/SkinMenuResults.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuResults.cs
@@ -2,6 +2,7 @@ using IniFileParser.Model;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.Shared.Config;
+using Quaver.Shared.Screens.Results.UI;
 
 namespace Quaver.Shared.Skinning.Menus
 {
@@ -24,7 +25,7 @@ namespace Quaver.Shared.Skinning.Menus
         public Texture2D ResultsGraphContainerPanel { get; private set; }
         public Texture2D ResultsMultiplayerFFAPanel { get; private set; }
         public Texture2D ResultsBackground { get; private set; }
-        public string ResultsBackgroundType { get; private set; }
+        public ResultsBackgroundType ResultsBackgroundType { get; private set; }
         public float? ResultsBackgroundFilterAlpha { get; private set; }
 
         public SkinMenuResults(SkinStore store, IniData config) : base(store, config)
@@ -36,7 +37,7 @@ namespace Quaver.Shared.Skinning.Menus
             var ini = Config["Results"];
 
             var resultsBackgroundType = ini["ResultsBackgroundType"];
-            ReadIndividualConfig(resultsBackgroundType, () => ResultsBackgroundType = ConfigHelper.ReadString("Header", resultsBackgroundType));
+            ReadIndividualConfig(resultsBackgroundType, () => ResultsBackgroundType = ConfigHelper.ReadEnum(ResultsBackgroundType.Header, resultsBackgroundType));
 
             var resultsBackgroundFilterAlpha = ini["ResultsBackgroundFilterAlpha"];
             ReadIndividualConfig(resultsBackgroundFilterAlpha, () => ResultsBackgroundFilterAlpha = ConfigHelper.ReadFloat(0f, resultsBackgroundFilterAlpha));

--- a/Quaver.Shared/Skinning/Menus/SkinMenuResults.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuResults.cs
@@ -1,0 +1,68 @@
+using IniFileParser.Model;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Config;
+
+namespace Quaver.Shared.Skinning.Menus
+{
+    public class SkinMenuResults : SkinMenu
+    {
+        public Texture2D ResultsAvatarBorder { get; private set; }
+        public Texture2D ResultsAvatarMask { get; private set; }
+        public Texture2D ResultsBackgroundFilter { get; private set; }
+        public Texture2D ResultsTabSelectorBackground { get; private set; }
+        public Texture2D ResultsLabelAccuracy { get; private set; }
+        public Texture2D ResultsLabelMaxCombo { get; private set; }
+        public Texture2D ResultsLabelPerformanceRating { get; private set; }
+        public Texture2D ResultsLabelRankedAccuracy { get; private set; }
+        public Texture2D ResultsLabelTotalScore { get; private set; }
+        public Texture2D ResultsLabelScore { get; private set; }
+        public Texture2D ResultsLabelBlueTeam { get; private set; }
+        public Texture2D ResultsLabelRedTeam { get; private set; }
+        public Texture2D ResultsMultiplayerTeamPanel { get; private set; }
+        public Texture2D ResultsScoreContainerPanel { get; private set; }
+        public Texture2D ResultsGraphContainerPanel { get; private set; }
+        public Texture2D ResultsMultiplayerFFAPanel { get; private set; }
+        public Texture2D ResultsBackground { get; private set; }
+        public string ResultsBackgroundType { get; private set; }
+        public float? ResultsBackgroundFilterAlpha { get; private set; }
+
+        public SkinMenuResults(SkinStore store, IniData config) : base(store, config)
+        {
+        }
+
+        protected override void ReadConfig()
+        {
+            var ini = Config["Results"];
+
+            var resultsBackgroundType = ini["ResultsBackgroundType"];
+            ReadIndividualConfig(resultsBackgroundType, () => ResultsBackgroundType = ConfigHelper.ReadString("Header", resultsBackgroundType));
+
+            var resultsBackgroundFilterAlpha = ini["ResultsBackgroundFilterAlpha"];
+            ReadIndividualConfig(resultsBackgroundFilterAlpha, () => ResultsBackgroundFilterAlpha = ConfigHelper.ReadFloat(0f, resultsBackgroundFilterAlpha));
+        }
+
+        protected override void LoadElements()
+        {
+            const string folder = "Results";
+
+            ResultsAvatarBorder = LoadSkinElement(folder, "avatar-border.png");
+            ResultsAvatarMask = LoadSkinElement(folder, "avatar-mask.png");
+            ResultsBackgroundFilter = LoadSkinElement(folder, "background-filter.png");
+            ResultsTabSelectorBackground = LoadSkinElement(folder, "tab-selector-background.png");
+            ResultsLabelAccuracy = LoadSkinElement(folder, "label-accuracy.png");
+            ResultsLabelMaxCombo = LoadSkinElement(folder, "label-max-combo.png");
+            ResultsLabelPerformanceRating = LoadSkinElement(folder, "label-performance-rating.png");
+            ResultsLabelRankedAccuracy = LoadSkinElement(folder, "label-ranked-accuracy.png");
+            ResultsLabelTotalScore = LoadSkinElement(folder, "label-total-score.png");
+            ResultsLabelScore = LoadSkinElement(folder, "label-score.png");
+            ResultsLabelBlueTeam = LoadSkinElement(folder, "label-blue-team.png");
+            ResultsLabelRedTeam = LoadSkinElement(folder, "label-red-team.png");
+            ResultsMultiplayerTeamPanel = LoadSkinElement(folder, "multiplayer-team-panel.png");
+            ResultsScoreContainerPanel = LoadSkinElement(folder, "score-container-panel.png");
+            ResultsGraphContainerPanel = LoadSkinElement(folder, "graph-container-panel.png");
+            ResultsMultiplayerFFAPanel = LoadSkinElement(folder, "multiplayer-ffa-panel.png");
+            ResultsBackground = LoadSkinElement(folder, "background.png");
+        }
+    }
+}

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -71,6 +71,11 @@ namespace Quaver.Shared.Skinning
         internal SkinMenuMain MainMenu { get; }
 
         /// <summary>
+        ///     Skinning for the Results menu
+        /// </summary>
+        internal SkinMenuResults Results { get; }
+
+        /// <summary>
         ///     Skinning for the song select menu
         /// </summary>
         internal SkinMenuSongSelect SongSelect { get; }
@@ -275,6 +280,7 @@ namespace Quaver.Shared.Skinning
             {
                 MenuBorder = new SkinMenuBorder(this, Config);
                 MainMenu = new SkinMenuMain(this, Config);
+                Results = new SkinMenuResults(this, Config);
                 SongSelect = new SkinMenuSongSelect(this, Config);
             }
             catch (Exception e)


### PR DESCRIPTION
This will add basic skinning (simply changing images) for each element in the results screen (outside of number/judgements).

This also add ResultsBackgroundType which allow to change the header, the skinner can choose between "Header","Background","None".
Header will act as the current way. (this is also the default value)
Background will take the whole screen, so it will be the map background instead of the results screen background.
None is none.

This also make use of the background filter with the ResultsBackgroundFilterAlpha config.

Also not sure if this was intended, but the result screen background use different X and Y position, which mean there were a visible grey line on the right, as it's probably not wanted, i changed the value to 0.