### PR TITLE
implement steam's rich presence.

### DIFF
--- a/Quaver.Shared/Helpers/RichPresenceHelper.cs
+++ b/Quaver.Shared/Helpers/RichPresenceHelper.cs
@@ -1,0 +1,29 @@
+using Quaver.Shared.Discord;
+using Quaver.Shared.Online;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Quaver.Shared.Helpers
+{
+    public static class RichPresenceHelper
+    {
+        /// <summary>
+        ///     Sets both discord and steam (if applicable)'s rich presence.
+        ///
+        ///     note: it might be a good idea to set your images and other properties in DiscordHelper.Presence first before calling this function, instead of
+        ///     calling rpc twice.
+        /// </summary>
+        /// <param name="state">state of the game</param>
+        /// <param name="details">details of the game.</param>
+        public static void UpdateRichPresence(string state, string details) {
+            // might be a good idea to check k_cchMaxRichPresenceValueLength and the return value in the future.
+            SteamManager.SetRichPresence("State", state);
+            SteamManager.SetRichPresence("Details", details);
+
+            DiscordHelper.Presence.Details = details;
+            DiscordHelper.Presence.State = state;
+            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+        }
+    }
+}

--- a/Quaver.Shared/Online/SteamManager.cs
+++ b/Quaver.Shared/Online/SteamManager.cs
@@ -138,6 +138,9 @@ namespace Quaver.Shared.Online
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 RefreshWorkshopSkins();
 
+            // Set the rich presence.
+            SetRichPresence("steam_display", "Status");
+
             // DANGEROUS: Uncomment to reset all achievements
             // SteamUserStats.ResetAllStats(true);
         }
@@ -266,6 +269,34 @@ namespace Quaver.Shared.Online
             // Start updating to Steam
             var call = SteamUGC.SubmitItemUpdate(SteamWorkshopItem.Current.Handle, "");
             OnSubmitUpdateResponse.Set(call);
+        }
+
+        /// <summary>
+        ///     Sets a Rich Presence key/value for the current user that is automatically shared to all friends playing the same game.
+        /// </summary>
+        /// <param name="pchKey">The rich presence 'key' to set. This can not be longer than specified in k_cchMaxRichPresenceKeyLength.</param>
+        /// <param name="pchValue">The rich presence 'value' to associate with pchKey. This can not be longer than specified in k_cchMaxRichPresenceValueLength.
+        /// If this is set to an empty string ("") or NULL then the key is removed if it's set.</param>
+        /// <returns></returns>
+        public static bool SetRichPresence(string pchKey, string pchValue)
+        {
+            // don't bother trying to set rich presence if it's not a steam build.
+            if (!((QuaverGame)GameBase.Game).IsDeployedBuild)
+                return false;
+
+            return SteamFriends.SetRichPresence(pchKey, pchValue);
+        }
+
+        /// <summary>
+        ///     Clears all of the current user's Rich Presence key/values.
+        /// </summary>
+        public static void ClearRichPresence()
+        {
+            // don't bother if it's not a steam build.
+            if (!((QuaverGame)GameBase.Game).IsDeployedBuild)
+                return;
+
+            SteamFriends.ClearRichPresence();
         }
 
         /// <summary>

--- a/Quaver.Shared/Online/SteamManager.cs
+++ b/Quaver.Shared/Online/SteamManager.cs
@@ -139,7 +139,8 @@ namespace Quaver.Shared.Online
                 RefreshWorkshopSkins();
 
             // Set the rich presence.
-            SetRichPresence("steam_display", "Status");
+            // note that this depends on the localization file. 
+            SteamFriends.SetRichPresence("steam_display", "Status");
 
             // DANGEROUS: Uncomment to reset all achievements
             // SteamUserStats.ResetAllStats(true);
@@ -274,17 +275,23 @@ namespace Quaver.Shared.Online
         /// <summary>
         ///     Sets a Rich Presence key/value for the current user that is automatically shared to all friends playing the same game.
         /// </summary>
+        /// <remarks>https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence</remarks>
         /// <param name="pchKey">The rich presence 'key' to set. This can not be longer than specified in k_cchMaxRichPresenceKeyLength.</param>
         /// <param name="pchValue">The rich presence 'value' to associate with pchKey. This can not be longer than specified in k_cchMaxRichPresenceValueLength.
         /// If this is set to an empty string ("") or NULL then the key is removed if it's set.</param>
-        /// <returns></returns>
+        /// <returns>boolean
+        /// true - if the rich presence was set successfully.
+        /// false - if failed.
+        /// </returns>
         public static bool SetRichPresence(string pchKey, string pchValue)
         {
-            // don't bother trying to set rich presence if it's not a steam build.
-            if (!((QuaverGame)GameBase.Game).IsDeployedBuild)
-                return false;
+            var result = SteamFriends.SetRichPresence(pchKey, pchValue);
+            if (!result)
+            {
+                Logger.Error($"setting rich presence key ${pchKey} failed, please check the Rich Presence Tester for more details.", LogType.Runtime);
+            }
 
-            return SteamFriends.SetRichPresence(pchKey, pchValue);
+            return result;
         }
 
         /// <summary>
@@ -292,10 +299,6 @@ namespace Quaver.Shared.Online
         /// </summary>
         public static void ClearRichPresence()
         {
-            // don't bother if it's not a steam build.
-            if (!((QuaverGame)GameBase.Game).IsDeployedBuild)
-                return;
-
             SteamFriends.ClearRichPresence();
         }
 

--- a/Quaver.Shared/Online/SteamManager.cs
+++ b/Quaver.Shared/Online/SteamManager.cs
@@ -139,8 +139,14 @@ namespace Quaver.Shared.Online
                 RefreshWorkshopSkins();
 
             // Set the rich presence.
-            // note that this depends on the localization file. 
-            SteamFriends.SetRichPresence("steam_display", "Status");
+            // note that this depends on the localization file.
+
+            // have am initial value for State and details, so it doesn't just show "%state%: %details%" on Beta warning screen.
+            SteamFriends.SetRichPresence("State", "Loading");
+            SteamFriends.SetRichPresence("Details", "Launching the game");
+            // set our "displayed key" to #Status.  
+            SteamFriends.SetRichPresence("steam_display", "#Status");
+
 
             // DANGEROUS: Uncomment to reset all achievements
             // SteamUserStats.ResetAllStats(true);

--- a/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
+++ b/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
@@ -853,6 +853,9 @@ namespace Quaver.Shared.Screens.Downloading
         {
             try
             {
+                SteamManager.SetRichPresence("State", "In the menus");
+                SteamManager.SetRichPresence("Details", "Downloading Maps");
+
                 DiscordHelper.Presence.Details = "Downloading Maps";
                 DiscordHelper.Presence.State = "In the menus";
                 DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);

--- a/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
+++ b/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
@@ -853,15 +853,11 @@ namespace Quaver.Shared.Screens.Downloading
         {
             try
             {
-                SteamManager.SetRichPresence("State", "In the menus");
-                SteamManager.SetRichPresence("Details", "Downloading Maps");
-
-                DiscordHelper.Presence.Details = "Downloading Maps";
-                DiscordHelper.Presence.State = "In the menus";
                 DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
                 DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
                 DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-                DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+                RichPresenceHelper.UpdateRichPresence("In the menus", "Downloading Maps");
             }
             catch (Exception e)
             {

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1593,6 +1593,9 @@ namespace Quaver.Shared.Screens.Edit
         {
             try
             {
+                SteamManager.SetRichPresence("State", "Editing");
+                SteamManager.SetRichPresence("Details", WorkingMap.ToString());
+
                 DiscordHelper.Presence.Details = WorkingMap.ToString();
                 DiscordHelper.Presence.State = "Editing";
                 DiscordHelper.Presence.StartTimestamp = (long)(TimeHelper.GetUnixTimestampMilliseconds() / 1000);

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1593,17 +1593,13 @@ namespace Quaver.Shared.Screens.Edit
         {
             try
             {
-                SteamManager.SetRichPresence("State", "Editing");
-                SteamManager.SetRichPresence("Details", WorkingMap.ToString());
-
-                DiscordHelper.Presence.Details = WorkingMap.ToString();
-                DiscordHelper.Presence.State = "Editing";
                 DiscordHelper.Presence.StartTimestamp = (long)(TimeHelper.GetUnixTimestampMilliseconds() / 1000);
                 DiscordHelper.Presence.EndTimestamp = 0;
                 DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
                 DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(WorkingMap.Mode).ToLower();
                 DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(WorkingMap.Mode);
-                DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+                RichPresenceHelper.UpdateRichPresence("Editing", WorkingMap.ToString());
             }
             catch (Exception e)
             {

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -165,19 +165,15 @@ namespace Quaver.Shared.Screens.Editor
 
             MapManager.Selected.Value.Qua = WorkingMap;
 
-            // Discord Rich Presence
-            DiscordHelper.Presence.Details = WorkingMap.ToString();
-            DiscordHelper.Presence.State = "Editing";
+            // Discord Rich Presence specific stuff
             DiscordHelper.Presence.StartTimestamp = (long) (TimeHelper.GetUnixTimestampMilliseconds() / 1000);
             DiscordHelper.Presence.EndTimestamp = 0;
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(WorkingMap.Mode).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(WorkingMap.Mode);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
 
-            // Steam Rich Presence
-            SteamManager.SetRichPresence("State", "Editing");
-            SteamManager.SetRichPresence("Details", WorkingMap.ToString());
+            // Steam + Discord Rich Presence
+            RichPresenceHelper.UpdateRichPresence("Editing", WorkingMap.ToString());
 
             ActiveLayerInterface = new Bindable<EditorLayerInterface>(EditorLayerInterface.Composition) { Value = EditorLayerInterface.Composition };
 

--- a/Quaver.Shared/Screens/Editor/EditorScreen.cs
+++ b/Quaver.Shared/Screens/Editor/EditorScreen.cs
@@ -175,6 +175,10 @@ namespace Quaver.Shared.Screens.Editor
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(WorkingMap.Mode);
             DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
 
+            // Steam Rich Presence
+            SteamManager.SetRichPresence("State", "Editing");
+            SteamManager.SetRichPresence("Details", WorkingMap.ToString());
+
             ActiveLayerInterface = new Bindable<EditorLayerInterface>(EditorLayerInterface.Composition) { Value = EditorLayerInterface.Composition };
 
             ModManager.RemoveSpeedMods();

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -1159,6 +1159,9 @@ namespace Quaver.Shared.Screens.Gameplay
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(Ruleset.Mode).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(Ruleset.Mode);
             DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            SteamManager.SetRichPresence("State", DiscordHelper.Presence.State);
+            SteamManager.SetRichPresence("Details", Map.ToString());
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -247,18 +247,17 @@ namespace Quaver.Shared.Screens.Main
         /// </summary>
         private void SetRichPresence()
         {
-            SteamManager.SetRichPresence("Details", "Main Menu");
-            SteamManager.SetRichPresence("State", "In the menus");
-
-            DiscordHelper.Presence.Details = "Main Menu";
-            DiscordHelper.Presence.State = "In the menus";
             DiscordHelper.Presence.PartySize = 0;
             DiscordHelper.Presence.PartyMax = 0;
             DiscordHelper.Presence.EndTimestamp = 0;
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            SteamManager.SetRichPresence("steam_player_group", null);
+            SteamManager.SetRichPresence("steam_player_group_size", null);
+
+            Helpers.RichPresenceHelper.UpdateRichPresence("In the menus", "Main Menu");
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -59,7 +59,7 @@ namespace Quaver.Shared.Screens.Main
         public MainMenuScreen()
         {
 #if  !VISUAL_TESTS
-            SetDiscordRichPresence();
+            SetRichPresence();
 #endif
             ModManager.RemoveSpeedMods();
 
@@ -245,8 +245,11 @@ namespace Quaver.Shared.Screens.Main
 
         /// <summary>
         /// </summary>
-        private void SetDiscordRichPresence()
+        private void SetRichPresence()
         {
+            SteamManager.SetRichPresence("Details", "Main Menu");
+            SteamManager.SetRichPresence("State", "In the menus");
+
             DiscordHelper.Presence.Details = "Main Menu";
             DiscordHelper.Presence.State = "In the menus";
             DiscordHelper.Presence.PartySize = 0;

--- a/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Jukebox/Jukebox.cs
@@ -587,9 +587,7 @@ namespace Quaver.Shared.Screens.Menu.UI.Jukebox
             if (IgnoreRichPresence)
                 return;
 
-            DiscordHelper.Presence.Details = $"{MapManager.Selected.Value.Artist} - {MapManager.Selected.Value.Title}";
-            DiscordHelper.Presence.State = "In the Menus - Listening";
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+            Helpers.RichPresenceHelper.UpdateRichPresence("In the Menus - Listening", $"{MapManager.Selected.Value.Artist} - {MapManager.Selected.Value.Title}");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -315,18 +315,15 @@ namespace Quaver.Shared.Screens.Multi
         /// </summary>
         private void SetRichPresence()
         {
+            // Friend Grouping of Steam's Enhanced Rich Presence
             SteamManager.SetRichPresence("steam_player_group", Game.Value.GameId.ToString());
             SteamManager.SetRichPresence("steam_player_group_size", Game.Value.PlayerIds.Count.ToString());
 
-            SteamManager.SetRichPresence("State", $"Multiplayer [{Game.Value.Name}]");
-            SteamManager.SetRichPresence("Details", "Waiting to Start");
-
-            DiscordHelper.Presence.Details = "Waiting to Start";
-            DiscordHelper.Presence.State = $"{Game.Value.Name} ({Game.Value.PlayerIds.Count} of {Game.Value.MaxPlayers})";
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            RichPresenceHelper.UpdateRichPresence($"{Game.Value.Name} ({Game.Value.PlayerIds.Count} of {Game.Value.MaxPlayers})", "Waiting to Start");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -75,6 +75,9 @@ namespace Quaver.Shared.Screens.Multi
                 if (DontLeaveGameUponScreenSwitch)
                     return;
 
+                SteamManager.SetRichPresence("steam_player_group", null);
+                SteamManager.SetRichPresence("steam_player_group_size", null);
+
                 OnlineManager.LeaveGame();
             };
 
@@ -312,6 +315,12 @@ namespace Quaver.Shared.Screens.Multi
         /// </summary>
         private void SetRichPresence()
         {
+            SteamManager.SetRichPresence("steam_player_group", Game.Value.GameId.ToString());
+            SteamManager.SetRichPresence("steam_player_group_size", Game.Value.PlayerIds.Count.ToString());
+
+            SteamManager.SetRichPresence("State", $"Multiplayer [{Game.Value.Name}]");
+            SteamManager.SetRichPresence("Details", "Waiting to Start");
+
             DiscordHelper.Presence.Details = "Waiting to Start";
             DiscordHelper.Presence.State = $"{Game.Value.Name} ({Game.Value.PlayerIds.Count} of {Game.Value.MaxPlayers})";
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);

--- a/Quaver.Shared/Screens/Multiplayer/MultiplayerScreen.cs
+++ b/Quaver.Shared/Screens/Multiplayer/MultiplayerScreen.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -196,6 +196,12 @@ namespace Quaver.Shared.Screens.Multiplayer
         /// </summary>
         public void SetRichPresence()
         {
+            SteamManager.SetRichPresence("steam_player_group", Game.GameId.ToString());
+            SteamManager.SetRichPresence("steam_player_group_size", Game.PlayerIds.Count.ToString());
+
+            SteamManager.SetRichPresence("State", $"Multiplayer [{Game.Name}]");
+            SteamManager.SetRichPresence("Details", "Waiting to Start");
+
             DiscordHelper.Presence.Details = "Waiting to Start";
             DiscordHelper.Presence.State = $"{Game.Name} ({Game.PlayerIds.Count} of {Game.MaxPlayers})";
             DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
@@ -205,6 +211,9 @@ namespace Quaver.Shared.Screens.Multiplayer
         /// </summary>
         public void LeaveGame() => Exit(() =>
         {
+            SteamManager.SetRichPresence("steam_player_group", null);
+            SteamManager.SetRichPresence("steam_player_group_size", null);
+
             OnlineManager.LeaveGame();
             ThreadScheduler.RunAfter(Destroy, 1000);
             return new MultiplayerLobbyScreen();

--- a/Quaver.Shared/Screens/Multiplayer/MultiplayerScreen.cs
+++ b/Quaver.Shared/Screens/Multiplayer/MultiplayerScreen.cs
@@ -196,15 +196,11 @@ namespace Quaver.Shared.Screens.Multiplayer
         /// </summary>
         public void SetRichPresence()
         {
+            // Friend Grouping of Steam's Enhanced Rich Presence
             SteamManager.SetRichPresence("steam_player_group", Game.GameId.ToString());
             SteamManager.SetRichPresence("steam_player_group_size", Game.PlayerIds.Count.ToString());
 
-            SteamManager.SetRichPresence("State", $"Multiplayer [{Game.Name}]");
-            SteamManager.SetRichPresence("Details", "Waiting to Start");
-
-            DiscordHelper.Presence.Details = "Waiting to Start";
-            DiscordHelper.Presence.State = $"{Game.Name} ({Game.PlayerIds.Count} of {Game.MaxPlayers})";
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+            RichPresenceHelper.UpdateRichPresence($"{Game.Name} ({Game.PlayerIds.Count} of {Game.MaxPlayers})", "Waiting to Start");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/MultiplayerLobby/MultiplayerLobbyScreen.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/MultiplayerLobbyScreen.cs
@@ -108,15 +108,11 @@ namespace Quaver.Shared.Screens.MultiplayerLobby
         /// </summary>
         private void SetRichPresence()
         {
-            SteamManager.SetRichPresence("State", $"In the menus");
-            SteamManager.SetRichPresence("Details", "Multiplayer Lobby");
-
-            DiscordHelper.Presence.Details = "Multiplayer Lobby";
-            DiscordHelper.Presence.State = $"In the menus";
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            Helpers.RichPresenceHelper.UpdateRichPresence("In the menus", "Multiplayer Lobby");
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/MultiplayerLobby/MultiplayerLobbyScreen.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/MultiplayerLobbyScreen.cs
@@ -108,6 +108,9 @@ namespace Quaver.Shared.Screens.MultiplayerLobby
         /// </summary>
         private void SetRichPresence()
         {
+            SteamManager.SetRichPresence("State", $"In the menus");
+            SteamManager.SetRichPresence("Details", "Multiplayer Lobby");
+
             DiscordHelper.Presence.Details = "Multiplayer Lobby";
             DiscordHelper.Presence.State = $"In the menus";
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);

--- a/Quaver.Shared/Screens/Music/Components/MusicPlayerJukebox.cs
+++ b/Quaver.Shared/Screens/Music/Components/MusicPlayerJukebox.cs
@@ -379,6 +379,9 @@ namespace Quaver.Shared.Screens.Music.Components
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
             DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            SteamManager.SetRichPresence("State", DiscordHelper.Presence.State);
+            SteamManager.SetRichPresence("Details", DiscordHelper.Presence.Details);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -936,6 +936,9 @@ namespace Quaver.Shared.Screens.Results
         {
             try
             {
+                SteamManager.SetRichPresence("State", "In the menus");
+                SteamManager.SetRichPresence("Details", "Results Screen");
+
                 DiscordHelper.Presence.Details = "Results Screen";
                 DiscordHelper.Presence.State = "In the menus";
                 DiscordHelper.Presence.PartySize = 0;

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -936,11 +936,6 @@ namespace Quaver.Shared.Screens.Results
         {
             try
             {
-                SteamManager.SetRichPresence("State", "In the menus");
-                SteamManager.SetRichPresence("Details", "Results Screen");
-
-                DiscordHelper.Presence.Details = "Results Screen";
-                DiscordHelper.Presence.State = "In the menus";
                 DiscordHelper.Presence.PartySize = 0;
                 DiscordHelper.Presence.PartyMax = 0;
                 DiscordHelper.Presence.StartTimestamp = 0;
@@ -948,7 +943,8 @@ namespace Quaver.Shared.Screens.Results
                 DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
                 DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
                 DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-                DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+                RichPresenceHelper.UpdateRichPresence("In the Menus", "Results Screen");
             }
             catch (Exception e)
             {

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -858,11 +858,6 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         private void SetRichPresence()
         {
-            SteamManager.SetRichPresence("State", "In the menus");
-            SteamManager.SetRichPresence("Details", "Selecting a song");
-
-            DiscordHelper.Presence.Details = "Selecting a song";
-            DiscordHelper.Presence.State = "In the menus";
             DiscordHelper.Presence.PartySize = 0;
             DiscordHelper.Presence.PartyMax = 0;
             DiscordHelper.Presence.StartTimestamp = 0;
@@ -870,7 +865,8 @@ namespace Quaver.Shared.Screens.Selection
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            Helpers.RichPresenceHelper.UpdateRichPresence("In the menus", "Selecting a song");
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -858,6 +858,9 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         private void SetRichPresence()
         {
+            SteamManager.SetRichPresence("State", "In the menus");
+            SteamManager.SetRichPresence("Details", "Selecting a song");
+
             DiscordHelper.Presence.Details = "Selecting a song";
             DiscordHelper.Presence.State = "In the menus";
             DiscordHelper.Presence.PartySize = 0;

--- a/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
@@ -458,18 +458,14 @@ namespace Quaver.Shared.Screens.Tournament
         /// </summary>
         private void SetRichPresenceForTournamentViewer()
         {
-            SteamManager.SetRichPresence("State", "Tournament Viewer");
-            SteamManager.SetRichPresence("Details", MapManager.Selected.Value.ToString());
-
-            DiscordHelper.Presence.Details = MapManager.Selected.Value.ToString();
-            DiscordHelper.Presence.State = "Tournament Viewer";
             DiscordHelper.Presence.PartySize = GameplayScreens.Count;
             DiscordHelper.Presence.PartyMax = 4;
             DiscordHelper.Presence.EndTimestamp = 0;
             DiscordHelper.Presence.LargeImageText = OnlineManager.GetRichPresenceLargeKeyText(ConfigManager.SelectedGameMode.Value);
             DiscordHelper.Presence.SmallImageKey = ModeHelper.ToShortHand(ConfigManager.SelectedGameMode.Value).ToLower();
             DiscordHelper.Presence.SmallImageText = ModeHelper.ToLongHand(ConfigManager.SelectedGameMode.Value);
-            DiscordRpc.UpdatePresence(ref DiscordHelper.Presence);
+
+            Helpers.RichPresenceHelper.UpdateRichPresence("Tournament Viewer", MapManager.Selected.Value.ToString());
         }
     }
 }

--- a/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreen.cs
@@ -458,6 +458,9 @@ namespace Quaver.Shared.Screens.Tournament
         /// </summary>
         private void SetRichPresenceForTournamentViewer()
         {
+            SteamManager.SetRichPresence("State", "Tournament Viewer");
+            SteamManager.SetRichPresence("Details", MapManager.Selected.Value.ToString());
+
             DiscordHelper.Presence.Details = MapManager.Selected.Value.ToString();
             DiscordHelper.Presence.State = "Tournament Viewer";
             DiscordHelper.Presence.PartySize = GameplayScreens.Count;


### PR DESCRIPTION
This PR aims to implement Steam's [Enhanced Rich Presence](https://partner.steamgames.com/doc/features/enhancedrichpresence) onto Quaver. 

which adds the benefit of friend grouping if in the same multiplayer lobby, and not having to respond "what are you playing" in steam messages. ~~not really, people message anyways.~~

~~important note: This needs separate testing as I cannot test it because I don't have access to Steamworks. lol. that's why this is a draft..~~ see below
this is the localization file that I would like to commit.

```
"lang"
{
	"english"
	{
		"tokens"
		{
			"#State"	"%state%"
			"#Details"	"%details%"
			"#Status"	"{#State}: {#Details}"
		}
	}
}
```