### PR TITLE
Remove hitobjects from selection when removed by plugin or livemapping

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -55,7 +55,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
     {
         /// <summary>
         /// </summary>
-        private EditScreen EditScreen { get; }
+        public EditScreen EditScreen { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Remove/EditorActionRemoveHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Remove/EditorActionRemoveHitObject.cs
@@ -48,6 +48,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Remove
             WorkingMap.HitObjects.Remove(HitObject);
             WorkingMap.Sort();
 
+            ActionManager.EditScreen.SelectedHitObjects.Remove(HitObject);
+
             ActionManager.TriggerEvent(EditorActionType.RemoveHitObject, new EditorHitObjectRemovedEventArgs(HitObject));
         }
 

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/RemoveBatch/EditorActionRemoveHitObjectBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/RemoveBatch/EditorActionRemoveHitObjectBatch.cs
@@ -37,7 +37,10 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
         {
             ActionManager = actionManager;
             WorkingMap = workingMap;
-            HitObjects = hitObjects;
+
+            // create a copy since it is highly likely the original list is
+            // the list of selected hitobjects that will be modified when this action is performed
+            HitObjects = new List<HitObjectInfo>(hitObjects);
         }
 
         /// <inheritdoc />
@@ -48,6 +51,8 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
         {
             HitObjects.ForEach(x => WorkingMap.HitObjects.Remove(x));
             WorkingMap.Sort();
+
+            HitObjects.ForEach(x => ActionManager.EditScreen.SelectedHitObjects.Remove(x));
 
             ActionManager.TriggerEvent(EditorActionType.RemoveHitObjectBatch, new EditorHitObjectBatchRemovedEventArgs(HitObjects));
         }

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1122,8 +1122,7 @@ namespace Quaver.Shared.Screens.Edit
             if (SelectedHitObjects.Value.Count == 0)
                 return;
 
-            ActionManager.Perform(new EditorActionRemoveHitObjectBatch(ActionManager, WorkingMap, new List<HitObjectInfo>(SelectedHitObjects.Value)));
-            SelectedHitObjects.Clear();
+            ActionManager.RemoveHitObjectBatch(SelectedHitObjects.Value);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1279,7 +1279,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
                 return;
 
             ActionManager.RemoveHitObject(ho.Info);
-            SelectedHitObjects.Remove(ho.Info);
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #2631

might make more sense to have the editor actions themselves remove from selection instead of manually adding it to every instance of removal