### PR TITLE
Fix waveform not being fully loaded for long map

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Waveform/EditorPlayfieldWaveform.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Waveform/EditorPlayfieldWaveform.cs
@@ -31,6 +31,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Waveform
 
         private int Stream { get; set; }
 
+        private int FFT_samples { get; set; } = 1024;
+
         private CancellationToken Token { get; }
 
         public EditorPlayfieldWaveform(EditorPlayfield playfield, CancellationToken token)
@@ -128,8 +130,21 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Waveform
             TrackByteLength = Bass.ChannelGetLength(Stream);
             TrackData = new float[TrackByteLength / sizeof(float)];
 
-            TrackByteLength = Bass.ChannelGetData(Stream, TrackData, (int)TrackByteLength);
+            var TrackDataFFT = new float[FFT_samples];
+            var index = 0;
 
+            TrackByteLength = Bass.ChannelGetData(Stream, TrackDataFFT, FFT_samples);
+            while (TrackData.Length - index > FFT_samples)
+            {
+                TrackDataFFT.CopyTo(TrackData, index);
+                TrackDataFFT = new float[FFT_samples];
+                
+                TrackByteLength = Bass.ChannelGetData(Stream, TrackDataFFT, FFT_samples);
+
+                index += FFT_samples / 4;
+            }
+
+            TrackByteLength = Bass.ChannelGetLength(Stream);
             TrackLengthMilliSeconds = Bass.ChannelBytes2Seconds(Stream, TrackByteLength) * 1000.0;
         }
 


### PR DESCRIPTION
resolve #2859 

This PR aims at fixing the waveform not loading fully for really long audio file, by remplacing the single TrackData load by reading small FFT samples from the stream and moving them inside the TrackData, making BASS not overload/have buffer limit/whatever.

https://streamable.com/orazfj video showing the long map mentionned in the issue, all of them have the waveform fully loaded.

I however didn't manage to fix the issue from this map https://quavergame.com/mapset/map/34008 .
But i know the reason of it, the audio file have some corruption inside of it causing BASS to not get the full stream during decode, but simply using ffmpeg and do "ffmpeg -i file.mp3 file2.mp3" literally fix the issue somehow, so...don't think it matter that much.