### PR TITLE
Make the avatar use the new mask script for gradient

### DIFF
--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
@@ -62,7 +62,8 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
             GameBase.Game.ScheduledRenderTargetDraws.Add(() =>
             {
-                Avatar.Image = Avatar.PerformBlend(Avatar.Image, SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask);
+                var mask = SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask;
+                Avatar.Image = Avatar.PerformBlend(Avatar.Image, mask);
             });
         }
     }

--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
@@ -6,6 +6,7 @@ using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
 using Quaver.Shared.Skinning;
 using Steamworks;
+using Wobble;
 using Wobble.Assets;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -22,7 +23,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
         /// <summary>
         /// </summary>
-        private CircleAvatar Avatar { get; }
+        private Sprite Avatar { get; }
 
         public ResultsScreenHeaderAvatar(float size, Bindable<ScoreProcessor> processor)
         {
@@ -31,11 +32,12 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
             var avatarSize = size - OFFSET * 2;
 
-            Avatar = new CircleAvatar(new ScalableVector2(avatarSize, avatarSize), UserInterface.UnknownAvatar)
+            Avatar = new Sprite()
             {
                 Parent = this,
                 Alignment = Alignment.MidCenter,
-                Image = SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask
+                Size = new ScalableVector2(avatarSize, avatarSize),
+                Image = UserInterface.UnknownAvatar
             };
 
             if (SteamManager.UserAvatars != null)
@@ -50,13 +52,18 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
                     var tex = SteamManager.UserAvatarsLarge[steamId];
 
                     if (tex != UserInterface.UnknownAvatar && SteamManager.UserAvatarsLarge.ContainsKey(steamId))
-                        Avatar.AvatarSprite.Image = tex;
+                        Avatar.Image = tex;
                     else if (tex == UserInterface.UnknownAvatar && SteamManager.UserAvatars.ContainsKey(steamId))
-                        Avatar.AvatarSprite.Image = SteamManager.UserAvatars[steamId];
+                        Avatar.Image = SteamManager.UserAvatars[steamId];
                     else
-                        Avatar.AvatarSprite.Image = UserInterface.UnknownAvatar;
+                        Avatar.Image = UserInterface.UnknownAvatar;
                 }
             }
+
+            GameBase.Game.ScheduledRenderTargetDraws.Add(() =>
+            {
+                Avatar.Image = SpriteAlphaMaskBlend.PerformBlend(Avatar.Image, SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask);
+            });
         }
     }
 }

--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderAvatar.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
         /// <summary>
         /// </summary>
-        private Sprite Avatar { get; }
+        private SpriteAlphaMaskBlend Avatar { get; }
 
         public ResultsScreenHeaderAvatar(float size, Bindable<ScoreProcessor> processor)
         {
@@ -32,7 +32,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
             var avatarSize = size - OFFSET * 2;
 
-            Avatar = new Sprite()
+            Avatar = new SpriteAlphaMaskBlend()
             {
                 Parent = this,
                 Alignment = Alignment.MidCenter,
@@ -62,7 +62,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
             GameBase.Game.ScheduledRenderTargetDraws.Add(() =>
             {
-                Avatar.Image = SpriteAlphaMaskBlend.PerformBlend(Avatar.Image, SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask);
+                Avatar.Image = Avatar.PerformBlend(Avatar.Image, SkinManager.Skin?.Results?.ResultsAvatarMask ?? UserInterface.ResultsAvatarMask);
             });
         }
     }


### PR DESCRIPTION
Make use of https://github.com/Quaver/Wobble/pull/120 so that the mask can have different alpha value

Does require https://github.com/Quaver/Wobble/pull/120

Here is a result of the effect 
![Quaver_tdwKVPF3Vj](https://user-images.githubusercontent.com/68703144/158022196-9ea705ac-a711-48f4-b262-2d9d95d147dc.png)

using this mask
![avatar-mask](https://user-images.githubusercontent.com/68703144/158022220-6366c91f-cdc8-4871-8a4e-5227f16b63bb.png)

