### PR TITLE
Add Spritesheet for Holdbody and Holdend, HitObject animatable

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
@@ -145,7 +145,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         public Texture2D GetHitObjectTexture()
         {
-            var index = SkinMode.ColorObjectsBySnapDistance ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var snap = SkinMode.ColorObjectsBySnapDistance ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var index = SkinMode.NoteHoldHitObjects[Info.Lane - 1].Count / 9 * snap;
 
             if (ViewLayers.Value)
                 return SkinMode.EditorLayerNoteHitObjects[Info.Lane - 1];
@@ -153,6 +154,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (Info.IsLongNote)
                 return SkinMode.NoteHoldHitObjects[Info.Lane - 1][index];
 
+            index = SkinMode.NoteHitObjects[Info.Lane - 1].Count / 9 * snap;
             return SkinMode.NoteHitObjects[Info.Lane - 1][index];
         }
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
@@ -146,16 +146,20 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         public Texture2D GetHitObjectTexture()
         {
             var snap = SkinMode.ColorObjectsBySnapDistance ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
-            var index = SkinMode.NoteHoldHitObjects[Info.Lane - 1].Count / 9 * snap;
+            var row = SkinMode.NoteHitObjectsSpritesheetRows;
+            var hitObjects = SkinMode.NoteHitObjects[Info.Lane - 1];
+            var holdHitObjects = SkinMode.NoteHoldHitObjects[Info.Lane - 1];
+
+            var index = holdHitObjects.Count / row * snap;
 
             if (ViewLayers.Value)
                 return SkinMode.EditorLayerNoteHitObjects[Info.Lane - 1];
 
             if (Info.IsLongNote)
-                return SkinMode.NoteHoldHitObjects[Info.Lane - 1][index];
+                return index < holdHitObjects.Count ? holdHitObjects[index] : holdHitObjects[holdHitObjects.Count - row - 1];
 
-            index = SkinMode.NoteHitObjects[Info.Lane - 1].Count / 9 * snap;
-            return SkinMode.NoteHitObjects[Info.Lane - 1][index];
+            index = hitObjects.Count / row * snap;
+            return index < hitObjects.Count ? hitObjects[index] : hitObjects[hitObjects.Count - row - 1];
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -237,8 +237,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         private Texture2D GetBodyTexture()
         {
             var snap = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
-            var index = SkinMode.NoteHoldBodies[Info.Lane - 1].Count / 9 * snap;
-            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldBodies[Info.Lane - 1] : SkinMode.NoteHoldBodies[Info.Lane - 1][index];
+            var row = SkinMode.NoteHoldBodiesSpritesheetRows;
+            var holdObjects = SkinMode.NoteHoldBodies[Info.Lane - 1];
+
+            var index = holdObjects.Count / row * snap;
+
+            if (ViewLayers.Value)
+                return SkinMode.EditorLayerNoteHoldBodies[Info.Lane - 1];
+
+            return index < holdObjects.Count ? holdObjects[index] : holdObjects[holdObjects.Count - row - 1];
         }
 
         /// <summary>
@@ -247,8 +254,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         private Texture2D GetTailTexture()
         {
             var snap = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
-            var index = SkinMode.NoteHoldEnds[Info.Lane - 1].Count / 9 * snap;
-            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldEnds[Info.Lane - 1] : SkinMode.NoteHoldEnds[Info.Lane - 1][index];
+            var row = SkinMode.NoteHoldEndsSpritesheetRows;
+            var holdEndObjects = SkinMode.NoteHoldEnds[Info.Lane - 1];
+
+            var index = holdEndObjects.Count / row * snap;
+
+            if (ViewLayers.Value)
+                return SkinMode.EditorLayerNoteHoldEnds[Info.Lane - 1];
+
+            return index < holdEndObjects.Count ? holdEndObjects[index] : holdEndObjects[holdEndObjects.Count - row - 1];
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -236,7 +236,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <returns></returns>
         private Texture2D GetBodyTexture()
         {
-            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldBodies[Info.Lane - 1] : SkinMode.NoteHoldBodies[Info.Lane - 1].First();
+            var index = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldBodies[Info.Lane - 1] : SkinMode.NoteHoldBodies[Info.Lane - 1][index];
         }
 
         /// <summary>
@@ -244,7 +245,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <returns></returns>
         private Texture2D GetTailTexture()
         {
-            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldEnds[Info.Lane - 1] : SkinMode.NoteHoldEnds[Info.Lane - 1];
+            var index = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldEnds[Info.Lane - 1] : SkinMode.NoteHoldEnds[Info.Lane - 1][index];
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -236,7 +236,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <returns></returns>
         private Texture2D GetBodyTexture()
         {
-            var index = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var snap = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var index = SkinMode.NoteHoldBodies[Info.Lane - 1].Count / 9 * snap;
             return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldBodies[Info.Lane - 1] : SkinMode.NoteHoldBodies[Info.Lane - 1][index];
         }
 
@@ -245,7 +246,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <returns></returns>
         private Texture2D GetTailTexture()
         {
-            var index = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var snap = SkinMode.ColorObjectsBySnapDistance && SkinMode.UseHoldSheet ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
+            var index = SkinMode.NoteHoldEnds[Info.Lane - 1].Count / 9 * snap;
             return ViewLayers.Value ? SkinMode.EditorLayerNoteHoldEnds[Info.Lane - 1] : SkinMode.NoteHoldEnds[Info.Lane - 1][index];
         }
 

--- a/Quaver.Shared/Screens/Editor/Actions/Rulesets/Keys/EditorActionFlipObjectsHorizontallyKeys.cs
+++ b/Quaver.Shared/Screens/Editor/Actions/Rulesets/Keys/EditorActionFlipObjectsHorizontallyKeys.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Quaver.API.Maps;
@@ -69,8 +69,8 @@ namespace Quaver.Shared.Screens.Editor.Actions.Rulesets.Keys
                     else
                     {
                         h.Image = skin.NoteHoldHitObjects[h.Info.Lane - 1][index];
-                        ln.Body.Image = skin.NoteHoldBodies[h.Info.Lane - 1].First();
-                        ln.Tail.Image = skin.NoteHoldEnds[h.Info.Lane - 1];
+                        ln.Body.Image = skin.NoteHoldBodies[h.Info.Lane - 1][index];
+                        ln.Tail.Image = skin.NoteHoldEnds[h.Info.Lane - 1][index];
                     }
 
                     ln.ResizeLongNote();

--- a/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/EditorScrollContainerKeys.cs
+++ b/Quaver.Shared/Screens/Editor/UI/Rulesets/Keys/Scrolling/EditorScrollContainerKeys.cs
@@ -367,8 +367,8 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
                 {
                     hitObject = new DrawableEditorHitObjectLong(this, h,
                         skin.NoteHoldHitObjects[h.Lane - 1][index],
-                        skin.NoteHoldBodies[h.Lane - 1].First(),
-                        skin.NoteHoldEnds[h.Lane - 1]);
+                        skin.NoteHoldBodies[h.Lane - 1][index],
+                        skin.NoteHoldEnds[h.Lane - 1][index]);
                 }
             }
             else
@@ -568,7 +568,7 @@ namespace Quaver.Shared.Screens.Editor.UI.Rulesets.Keys.Scrolling
                         else
                         {
                             h.Image = skin.NoteHoldHitObjects[h.Info.Lane - 1][index];
-                            ln.ChangeTextures(skin.NoteHoldBodies[h.Info.Lane - 1].First(), skin.NoteHoldEnds[h.Info.Lane - 1]);
+                            ln.ChangeTextures(skin.NoteHoldBodies[h.Info.Lane - 1][index], skin.NoteHoldEnds[h.Info.Lane - 1][index]);
                         }
                     }
                     else

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -237,7 +237,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     if (gameplayHitObject.Info.IsLongNote)
                     {
                         manager.ChangePoolObjectStatusToHeld(gameplayHitObject);
-                        //gameplayHitObject.StartLongNoteAnimation();
+                        gameplayHitObject.StartLongNoteAnimation();
                     }
                     else
                         manager.RecyclePoolObject(gameplayHitObject);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -237,7 +237,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     if (gameplayHitObject.Info.IsLongNote)
                     {
                         manager.ChangePoolObjectStatusToHeld(gameplayHitObject);
-                        gameplayHitObject.StartLongNoteAnimation();
+                        //gameplayHitObject.StartLongNoteAnimation();
                     }
                     else
                         manager.RecyclePoolObject(gameplayHitObject);
@@ -261,7 +261,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             // Update animations
             playfield.Stage.HitLightingObjects[lane].StopHolding();
-            gameplayHitObject.StopLongNoteAnimation();
+            //gameplayHitObject.StopLongNoteAnimation();
 
             // Dequeue from pool
             gameplayHitObject = manager.HeldLongNoteLanes[lane].Dequeue();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -105,7 +105,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// <summary>
         ///     The hold body sprite for long notes.
         /// </summary>
-        public AnimatableSprite LongNoteBodySprite { get; private set; }
+        public Sprite LongNoteBodySprite { get; private set; }
 
         /// <summary>
         ///     The hold end sprite for long notes.
@@ -196,8 +196,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 HitObjectSprite.Rotation = GetObjectRotation(MapManager.Selected.Value.Mode, lane);
 
             // Create Hold Body
-            var bodies = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldBodies[lane];
-            LongNoteBodySprite = new AnimatableSprite(bodies)
+            LongNoteBodySprite = new Sprite()
             {
                 Alignment = Alignment.TopLeft,
                 Size = new ScalableVector2(laneSize , 0),
@@ -213,11 +212,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 Size = new ScalableVector2(laneSize, 0),
                 Parent = playfield.Stage.HitObjectContainer
             };
-
-            // Set long note end properties.
-            LongNoteEndSprite.Image = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldEnds[lane];
-            LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.Image.Height / LongNoteEndSprite.Image.Width;
-            LongNoteEndOffset = LongNoteEndSprite.Height / 2f;
 
             // We set the parent of the HitObjectSprite **AFTER** we create the long note
             // so that the body of the long note isn't drawn over the object.
@@ -264,9 +258,18 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             HitObjectSprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode);
             HitObjectSprite.Visible = true;
             HitObjectSprite.Tint = tint;
+
+            // Set long note end properties.
+            LongNoteEndSprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode, true, true);
+            LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.Image.Height / LongNoteEndSprite.Image.Width;
+            LongNoteEndOffset = LongNoteEndSprite.Height / 2f;
+
+            // Update the long note body sprite.
+            LongNoteBodySprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode, true, false);
+
             InitialTrackPosition = manager.GetPositionFromTime(Info.StartTime);
             CurrentlyBeingHeld = false;
-            StopLongNoteAnimation();
+            //StopLongNoteAnimation();
 
             // Update hit body's size to match image ratio
             HitObjectSprite.Size = new ScalableVector2(laneSize, defaultLaneSize * HitObjectSprite.Image.Height / HitObjectSprite.Image.Width);
@@ -468,7 +471,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     If not, we default it to the first beat snap in the list.
         /// </summary>
         /// <returns></returns>
-        private Texture2D GetHitObjectTexture(int lane, GameMode mode)
+        private Texture2D GetHitObjectTexture(int lane, GameMode mode, bool longNoteSprite = false, bool isLongNoteEnd = false)
         {
             lane = lane - 1;
             var skin = SkinManager.Skin.Keys[mode];
@@ -477,6 +480,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 var objects = Info.IsLongNote ? skin.NoteHoldHitObjects[lane] : skin.NoteHitObjects[lane];
 
+                if (longNoteSprite)
+                {
+                    objects = isLongNoteEnd ? skin.NoteHoldEnds[lane] : skin.NoteHoldBodies[lane];
+                }
+
                 if (HitObjectManager.SnapIndices.ContainsKey(Info))
                 {
                     var snap = HitObjectManager.SnapIndices[Info];
@@ -484,6 +492,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 }
 
                 return objects.First();
+            }
+
+            if (longNoteSprite)
+            {
+                return isLongNoteEnd ? skin.NoteHoldEnds[lane].First() : skin.NoteHoldBodies[lane].First();
             }
 
             return Info.IsLongNote ? skin.NoteHoldHitObjects[lane].First() : skin.NoteHitObjects[lane].First();
@@ -524,13 +537,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     Starts looping the long note sprite.
         ///     It will only be initiated when the player presses the note.
         /// </summary>
-        public void StartLongNoteAnimation() => LongNoteBodySprite.StartLoop(Direction.Forward, 30);
+        //public void StartLongNoteAnimation() => LongNoteBodySprite.StartLoop(Direction.Forward, 30);
 
         /// <summary>
         ///     Stops looping the long note sprite.
         ///     It will only be initiated when the player releases the note.
         /// </summary>
-        public void StopLongNoteAnimation() => LongNoteBodySprite.StopLoop();
+        //public void StopLongNoteAnimation() => LongNoteBodySprite.StopLoop();
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -261,6 +261,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             HitObjectSprite.Image = GetHitObjectTexture(HitObjectSprite, info.Lane, manager.Ruleset.Mode);
             HitObjectSprite.Visible = true;
             HitObjectSprite.Tint = tint;
+
             var lastHitObjectFrame = HitObjectSprite.DefaultFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHitObjects[Info.Lane].Count / 9);
             HitObjectSprite.StartLoop(Direction.Forward, SkinManager.Skin?.Keys[manager.Ruleset.Mode].HitObjectsFps ?? 5, 0, lastHitObjectFrame);
 
@@ -486,15 +487,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 var objects = Info.IsLongNote ? skin.NoteHoldHitObjects[lane] : skin.NoteHitObjects[lane];
 
                 if (longNoteSprite)
-                {
                     objects = isLongNoteEnd ? skin.NoteHoldEnds[lane] : skin.NoteHoldBodies[lane];
-                }
 
                 if (HitObjectManager.SnapIndices.ContainsKey(Info))
                 {
                     var snap = HitObjectManager.SnapIndices[Info];
                     var columns = objects.Count / 9;
-                    sprite.DefaultFrame = columns == 0 ? snap : snap * columns;
+
+                    sprite.DefaultFrame = snap * columns;
+
                     return snap < objects.Count ? objects[snap * columns] : objects[objects.Count - 1];
                 }
 
@@ -502,9 +503,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             }
 
             if (longNoteSprite)
-            {
                 return isLongNoteEnd ? skin.NoteHoldEnds[lane].First() : skin.NoteHoldBodies[lane].First();
-            }
 
             return Info.IsLongNote ? skin.NoteHoldHitObjects[lane].First() : skin.NoteHitObjects[lane].First();
         }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -189,7 +189,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 Alignment = Alignment.TopLeft,
                 Position = new ScalableVector2(posX, 0),
-                SpriteEffect = flipNoteBody ? SpriteEffects.FlipVertically : SpriteEffects.None
+                SpriteEffect = flipNoteBody ? SpriteEffects.FlipVertically : SpriteEffects.None,
+                Rows = SkinManager.Skin.Keys[ruleset.Mode].NoteHitObjectsSpritesheetRows,
+                Columns = SkinManager.Skin.Keys[ruleset.Mode].NoteHitObjectsSpritesheetColumns
             };
 
             // Handle rotating the objects automatically
@@ -203,7 +205,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 Alignment = Alignment.TopLeft,
                 Size = new ScalableVector2(laneSize , 0),
                 Position = new ScalableVector2(posX, 0),
-                Parent = playfield.Stage.HitObjectContainer
+                Parent = playfield.Stage.HitObjectContainer,
+                Rows = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldBodiesSpritesheetRows,
+                Columns = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldBodiesSpritesheetColumns
             };
 
             // Create the Hold End
@@ -213,7 +217,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 Alignment = Alignment.TopLeft,
                 Position = new ScalableVector2(posX, 0),
                 Size = new ScalableVector2(laneSize, 0),
-                Parent = playfield.Stage.HitObjectContainer
+                Parent = playfield.Stage.HitObjectContainer,
+                Rows = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldEndsSpritesheetRows,
+                Columns = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldEndsSpritesheetColumns
             };
 
             // We set the parent of the HitObjectSprite **AFTER** we create the long note
@@ -262,7 +268,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             HitObjectSprite.Visible = true;
             HitObjectSprite.Tint = tint;
 
-            var lastHitObjectFrame = HitObjectSprite.DefaultFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHitObjects[Info.Lane].Count / 9);
+            var lastHitObjectFrame = HitObjectSprite.FirstFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHitObjects[Info.Lane].Count / HitObjectSprite.Rows);
             HitObjectSprite.StartLoop(Direction.Forward, SkinManager.Skin?.Keys[manager.Ruleset.Mode].HitObjectsFps ?? 5, 0, lastHitObjectFrame);
 
             // Set long note end properties.
@@ -492,11 +498,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 if (HitObjectManager.SnapIndices.ContainsKey(Info))
                 {
                     var snap = HitObjectManager.SnapIndices[Info];
-                    var columns = objects.Count / 9;
 
-                    sprite.DefaultFrame = snap * columns;
-
-                    return snap < objects.Count ? objects[snap * columns] : objects[objects.Count - 1];
+                    if (snap * sprite.Columns < objects.Count)
+                    {
+                        sprite.FirstFrame = snap * sprite.Columns;
+                        return objects[snap * sprite.Columns];
+                    }
+                    else
+                    {
+                        sprite.FirstFrame = objects.Count - sprite.Columns;
+                        return objects[objects.Count - sprite.Columns];
+                    }
                 }
 
                 return objects.First();
@@ -545,8 +557,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public void StartLongNoteAnimation()
         {
-            var lastHoldBodyFrame = LongNoteBodySprite.DefaultFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHoldBodies[Info.Lane].Count / 9);
-            var lastHoldEndFrame = LongNoteEndSprite.DefaultFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHoldEnds[Info.Lane].Count / 9);
+            var lastHoldBodyFrame = LongNoteBodySprite.FirstFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHoldBodies[Info.Lane].Count / LongNoteBodySprite.Rows);
+            var lastHoldEndFrame = LongNoteEndSprite.FirstFrame + (SkinManager.Skin.Keys[Ruleset.Mode].NoteHoldEnds[Info.Lane].Count / LongNoteEndSprite.Rows);
             LongNoteBodySprite.StartLoop(Direction.Forward, SkinManager.Skin?.Keys[Ruleset.Mode].HoldBodyFps ?? 5, 0, lastHoldBodyFrame);
             LongNoteEndSprite.StartLoop(Direction.Forward, SkinManager.Skin?.Keys[Ruleset.Mode].HoldEndFps ?? 5, 0, lastHoldEndFrame);
         }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -280,7 +280,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             {
                 var hitObOffset = LaneSize * skin.NoteHitObjects[i][0].Height / skin.NoteHitObjects[i][0].Width;
                 var holdHitObOffset = LaneSize * skin.NoteHoldHitObjects[i][0].Height / skin.NoteHoldHitObjects[i][0].Width;
-                var holdEndOffset = LaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
+                var holdEndOffset = LaneSize * skin.NoteHoldEnds[i][0].Height / skin.NoteHoldEnds[i][0].Width;
                 var receptorOffset = LaneSize * skin.NoteReceptorsUp[i].Height / skin.NoteReceptorsUp[i].Width;
 
                 if (SkinManager.Skin.Keys[Screen.Map.Mode].DrawLongNoteEnd)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -293,24 +293,44 @@ namespace Quaver.Shared.Skinning
         // ----- HitObjects ----- //
 
         /// <summary>
-        ///
         /// </summary>
         internal List<List<Texture2D>> NoteHitObjects { get; } = new List<List<Texture2D>>();
 
         /// <summary>
-        ///
         /// </summary>
         internal List<List<Texture2D>> NoteHoldHitObjects { get; } = new List<List<Texture2D>>();
 
         /// <summary>
-        ///
+        /// </summary>
+        internal int NoteHitObjectsSpritesheetColumns { get; set; } = 1;
+
+        /// <summary>
+        /// </summary>
+        internal int NoteHitObjectsSpritesheetRows { get; set; } = 9;
+
+        /// <summary>
         /// </summary>
         internal List<List<Texture2D>> NoteHoldBodies { get;} = new List<List<Texture2D>>();
 
         /// <summary>
-        ///
         /// </summary>
         internal List<List<Texture2D>> NoteHoldEnds { get; } = new List<List<Texture2D>>();
+
+        /// <summary>
+        /// </summary>
+        internal int NoteHoldBodiesSpritesheetColumns { get; set; } = 1;
+
+        /// <summary>
+        /// </summary>
+        internal int NoteHoldBodiesSpritesheetRows { get; set; } = 9;
+
+        /// <summary>
+        /// </summary>
+        internal int NoteHoldEndsSpritesheetColumns { get; set; } = 1;
+
+        /// <summary>
+        /// </summary>
+        internal int NoteHoldEndsSpritesheetRows { get; set; } = 9;
 
         /// <summary>
         /// </summary>
@@ -598,7 +618,7 @@ namespace Quaver.Shared.Skinning
             }
 
             var folderName = shared ? folder.ToString() : $"/{ModeHelper.ToShortHand(Mode).ToLower()}/{folder.ToString()}/";
-            return Store.LoadSpritesheet(folderName, element, resource, rows, columns, extension);
+            return Store.LoadSpritesheet(folderName, element, resource, rows, columns, extension, this);
         }
 
         /// <summary>
@@ -679,7 +699,7 @@ namespace Quaver.Shared.Skinning
                 else
                 {
                     var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
-                    
+
                     NoteHitObjects.Add(objects);
                     NoteHoldHitObjects.Add(objects);
 

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -741,5 +741,29 @@ namespace Quaver.Shared.Skinning
                 EditorLayerNoteHoldEnds.Add(LoadTexture(SkinKeysFolder.Editor, $"note-holdend-{i + 1}", false));
             }
         }
+
+        /// <summary>
+        ///     Set the row and column value of the spritesheets.
+        /// </summary>
+        public void SetSpritesheetValue(string element, int row, int column)
+        {
+            switch (element)
+            {
+                case "note-hitobject-sheet":
+                    NoteHitObjectsSpritesheetRows = row;
+                    NoteHitObjectsSpritesheetColumns = column;
+                    break;
+                case "note-holdbody-sheet":
+                    NoteHoldBodiesSpritesheetRows = row;
+                    NoteHoldBodiesSpritesheetColumns = column;
+                    break;
+                case "note-holdend-sheet":
+                    NoteHoldEndsSpritesheetRows = row;
+                    NoteHoldEndsSpritesheetColumns = column;
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 }

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -232,6 +232,12 @@ namespace Quaver.Shared.Skinning
 
         internal bool UseHoldSheet { get; private set; }
 
+        internal int HitObjectsFps { get; private set; }
+
+        internal int HoldBodyFps { get; private set; }
+
+        internal int HoldEndFps { get; private set; }
+
         [FixedScale]
         internal float ScratchLaneSize { get; private set; }
 
@@ -499,6 +505,9 @@ namespace Quaver.Shared.Skinning
             HealthBarPosOffsetY = ConfigHelper.ReadInt32((int) HealthBarPosOffsetY, ini["HealthBarPosOffsetY"]);
             UseHitObjectSheet = ConfigHelper.ReadBool(UseHitObjectSheet, ini["UseHitObjectSheet"]);
             UseHoldSheet = ConfigHelper.ReadBool(UseHoldSheet, ini["UseHoldSheet"]);
+            HitObjectsFps = ConfigHelper.ReadInt32(HitObjectsFps, ini["HitObjectsFps"]);
+            HoldBodyFps = ConfigHelper.ReadInt32(HoldBodyFps, ini["HoldBodyFps"]);
+            HoldEndFps = ConfigHelper.ReadInt32(HoldEndFps, ini["HoldEndFps"]);
             ScratchLaneSize = ConfigHelper.ReadFloat(ScratchLaneSize, ini["ScratchLaneSize"]);
             RotateHitObjectsByColumn = ConfigHelper.ReadBool(RotateHitObjectsByColumn, ini["RotateHitObjectsByColumn"]);
             JudgementHitBurstFps = ConfigHelper.ReadInt32(JudgementHitBurstFps, ini["JudgementHitBurstFps"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -230,6 +230,8 @@ namespace Quaver.Shared.Skinning
 
         internal bool UseHitObjectSheet { get; private set; }
 
+        internal bool UseHoldSheet { get; private set; }
+
         [FixedScale]
         internal float ScratchLaneSize { get; private set; }
 
@@ -302,7 +304,7 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> NoteHoldEnds { get; } = new List<Texture2D>();
+        internal List<List<Texture2D>> NoteHoldEnds { get; } = new List<List<Texture2D>>();
 
         /// <summary>
         /// </summary>
@@ -496,6 +498,7 @@ namespace Quaver.Shared.Skinning
             HealthBarPosOffsetX = ConfigHelper.ReadInt32((int) HealthBarPosOffsetX, ini["HealthBarPosOffsetX"]);
             HealthBarPosOffsetY = ConfigHelper.ReadInt32((int) HealthBarPosOffsetY, ini["HealthBarPosOffsetY"]);
             UseHitObjectSheet = ConfigHelper.ReadBool(UseHitObjectSheet, ini["UseHitObjectSheet"]);
+            UseHoldSheet = ConfigHelper.ReadBool(UseHoldSheet, ini["UseHoldSheet"]);
             ScratchLaneSize = ConfigHelper.ReadFloat(ScratchLaneSize, ini["ScratchLaneSize"]);
             RotateHitObjectsByColumn = ConfigHelper.ReadBool(RotateHitObjectsByColumn, ini["RotateHitObjectsByColumn"]);
             JudgementHitBurstFps = ConfigHelper.ReadInt32(JudgementHitBurstFps, ini["JudgementHitBurstFps"]);
@@ -656,6 +659,8 @@ namespace Quaver.Shared.Skinning
                 if (Store.Config != null)
                     ColumnColors[i] = ConfigHelper.ReadColor(ColumnColors[i], Store.Config[ModeHelper.ToShortHand(Mode).ToUpper()][$"ColumnColor{i + 1}"]);
 
+                const int snapCount = 9;
+
                 // HitObjects
                 if (!UseHitObjectSheet)
                 {
@@ -664,13 +669,10 @@ namespace Quaver.Shared.Skinning
                 }
                 else
                 {
-                    const int snapCount = 9;
-
                     var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
-
+                    
                     NoteHitObjects.Add(objects);
                     NoteHoldHitObjects.Add(objects);
-
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
                         NoteHitObjects[i].Add(NoteHitObjects[i].Last());
@@ -680,8 +682,25 @@ namespace Quaver.Shared.Skinning
                 }
 
                 // LNS
-                NoteHoldBodies.Add(LoadSpritesheet(SkinKeysFolder.HitObjects, $"note-holdbody-{i + 1}", false, 0, 0));
-                NoteHoldEnds.Add(LoadTexture(SkinKeysFolder.HitObjects, $"note-holdend-{i + 1}", false));
+                if (!UseHoldSheet)
+                {
+                    NoteHoldBodies.Add(LoadSpritesheet(SkinKeysFolder.HitObjects, $"note-holdbody-{i + 1}", false, 0, 0));
+                    NoteHoldEnds.Add(LoadSpritesheet(SkinKeysFolder.HitObjects, $"note-holdend-{i + 1}", false, 0, 0));
+                }
+                else
+                {
+                    var objectsBody = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdbody-sheet", false, snapCount, 1);
+                    var objectsEnd = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdend-sheet", false, snapCount, 1);
+
+                    NoteHoldBodies.Add(objectsBody);
+                    NoteHoldEnds.Add(objectsEnd);
+
+                    for (var j = 0; j < snapCount - NoteHoldBodies[i].Count; j++)
+                    {
+                        NoteHoldBodies[i].Add(NoteHoldBodies[i].Last());
+                        NoteHoldEnds[i].Add(NoteHoldEnds[i].Last());
+                    }
+                }
 
                 // Receptors
                 NoteReceptorsUp.Add(LoadTexture(SkinKeysFolder.Receptors, $"receptor-up-{i + 1}", false));

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -375,7 +375,7 @@ namespace Quaver.Shared.Skinning
         /// <param name="extension"></param>
         /// <returns></returns>
         internal  List<Texture2D> LoadSpritesheet(string folder, string element, string resource, int rows, int columns,
-            string extension = ".png")
+            string extension = ".png", SkinKeys keys = null)
         {
             try
             {
@@ -395,6 +395,25 @@ namespace Quaver.Shared.Skinning
                         {
                             // Load it up if so.
                             var texture = AssetLoader.LoadTexture2DFromFile(f);
+
+                            // Save the column and row value for elements that need them.
+                            switch (element)
+                            {
+                                case "note-hitobject-sheet":
+                                    keys.NoteHitObjectsSpritesheetRows = int.Parse(match.Groups[1].Value);
+                                    keys.NoteHitObjectsSpritesheetColumns = int.Parse(match.Groups[2].Value);
+                                    break;
+                                case "note-holdbody-sheet":
+                                    keys.NoteHoldBodiesSpritesheetRows = int.Parse(match.Groups[1].Value);
+                                    keys.NoteHoldBodiesSpritesheetColumns = int.Parse(match.Groups[2].Value);
+                                    break;
+                                case "note-holdend-sheet":
+                                    keys.NoteHoldEndsSpritesheetRows = int.Parse(match.Groups[1].Value);
+                                    keys.NoteHoldEndsSpritesheetColumns = int.Parse(match.Groups[2].Value);
+                                    break;
+                                default:
+                                    break;
+                            }
 
                             return AssetLoader.LoadSpritesheetFromTexture(texture, int.Parse(match.Groups[1].Value),
                                 int.Parse(match.Groups[2].Value));

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -396,8 +396,9 @@ namespace Quaver.Shared.Skinning
                             // Load it up if so.
                             var texture = AssetLoader.LoadTexture2DFromFile(f);
 
-                            // Save the values of the spritesheets.
-                            keys.SetSpritesheetValue(element, int.Parse(match.Groups[1].Value),
+                            // Save the values of Keys spritesheets if a SkinKeys is specified.
+                            if (keys != null)
+                                keys.SetSpritesheetValue(element, int.Parse(match.Groups[1].Value),
                                 int.Parse(match.Groups[2].Value));
 
                             return AssetLoader.LoadSpritesheetFromTexture(texture, int.Parse(match.Groups[1].Value),

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -396,24 +396,9 @@ namespace Quaver.Shared.Skinning
                             // Load it up if so.
                             var texture = AssetLoader.LoadTexture2DFromFile(f);
 
-                            // Save the column and row value for elements that need them.
-                            switch (element)
-                            {
-                                case "note-hitobject-sheet":
-                                    keys.NoteHitObjectsSpritesheetRows = int.Parse(match.Groups[1].Value);
-                                    keys.NoteHitObjectsSpritesheetColumns = int.Parse(match.Groups[2].Value);
-                                    break;
-                                case "note-holdbody-sheet":
-                                    keys.NoteHoldBodiesSpritesheetRows = int.Parse(match.Groups[1].Value);
-                                    keys.NoteHoldBodiesSpritesheetColumns = int.Parse(match.Groups[2].Value);
-                                    break;
-                                case "note-holdend-sheet":
-                                    keys.NoteHoldEndsSpritesheetRows = int.Parse(match.Groups[1].Value);
-                                    keys.NoteHoldEndsSpritesheetColumns = int.Parse(match.Groups[2].Value);
-                                    break;
-                                default:
-                                    break;
-                            }
+                            // Save the values of the spritesheets.
+                            keys.SetSpritesheetValue(element, int.Parse(match.Groups[1].Value),
+                                int.Parse(match.Groups[2].Value));
 
                             return AssetLoader.LoadSpritesheetFromTexture(texture, int.Parse(match.Groups[1].Value),
                                 int.Parse(match.Groups[2].Value));


### PR DESCRIPTION
Added a skinning option ``UseHoldSheet`` to be able to use ``note-holdbody-sheet@9x1.png`` and ``note-holdend-sheet@9x1.png`` for snap-colored Long Note.

The Hitobjects, HoldBody and HoldEnd spritesheet can also be animatable. The Column are for the snap color, and the rows are for the animation.

Added ``HitObjectsFps, HoldBodyFps, HoldEndFps`` to control the animation speed.

Showcase here (with editor too) : https://streamable.com/jdkaep

Skin for testing purpose : [Hold-snap-color-and-animation.zip](https://github.com/Quaver/Quaver/files/8405652/Hold-snap-color-and-animation.zip)


REQUIRE https://github.com/Quaver/Wobble/pull/121


