### PR TITLE
Add leaderboard toggle button

### DIFF
--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -10,6 +10,7 @@ using Quaver.Shared.Database.Profiles;
 using Quaver.Shared.Graphics.Menu.Border;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Scheduling;
+using Quaver.Shared.Screens.Menu.UI.Jukebox;
 using Quaver.Shared.Screens.Menu.UI.Visualizer;
 using Quaver.Shared.Screens.Selection.Components;
 using Quaver.Shared.Screens.Selection.UI;
@@ -30,6 +31,7 @@ using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.UI;
+using Wobble.Graphics.UI.Buttons;
 using Wobble.Screens;
 using Wobble.Window;
 
@@ -69,6 +71,14 @@ namespace Quaver.Shared.Screens.Selection
         /// <summary>
         /// </summary>
         private LeaderboardContainer LeaderboardContainer { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private bool IsLeaderboardVisible { get; set; } = true;
+
+        /// <summary>
+        /// </summary>
+        private TextButton ToggleLeaderboardButton { get; set; }
 
         /// <summary>
         /// </summary>
@@ -122,6 +132,7 @@ namespace Quaver.Shared.Screens.Selection
             CreatePlaylistContainer();
             ReorderContainerLayerDepth();
             CreateLeaderboardContainer();
+            CreateLeaderboardToggleContainer();
             CreateModifierSelectorContainer();
             CreateUserProfileContainer();
 
@@ -241,6 +252,26 @@ namespace Quaver.Shared.Screens.Selection
 
             LeaderboardContainer.X = -LeaderboardContainer.Width - ScreenPaddingX;
             LeaderboardContainer.MoveToX(ScreenPaddingX, Easing.OutQuint, 500);
+        }
+
+        private void CreateLeaderboardToggleContainer()
+        {
+            // This code is very similar in design to CreateLeaderboardContainer, to
+            // keep it in sync with the leaderboard's position.
+            ToggleLeaderboardButton = new TextButton(UserInterface.LeaderboardPanel, Fonts.LatoRegular, "Toggle Leaderboard", 24, (o, e) =>
+            {
+                IsLeaderboardVisible = !IsLeaderboardVisible;
+                LeaderboardContainer.Visible = IsLeaderboardVisible;
+            })
+            {
+                Parent = Container,
+                Size = new ScalableVector2(300, 20),
+                Alignment = Alignment.TopLeft,
+                X = ScreenPaddingX,
+                Y = FilterPanel.Y + FilterPanel.Height + LeftPanelSpacingY
+            };
+            ToggleLeaderboardButton.X = -LeaderboardContainer.Width - ScreenPaddingX;
+            ToggleLeaderboardButton.MoveToX(ScreenPaddingX, Easing.OutQuint, 500);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -32,6 +32,7 @@ using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.UI;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Managers;
 using Wobble.Screens;
 using Wobble.Window;
 
@@ -256,22 +257,26 @@ namespace Quaver.Shared.Screens.Selection
 
         private void CreateLeaderboardToggleContainer()
         {
-            // This code is very similar in design to CreateLeaderboardContainer, to
+            // This code is very similar in design to CreateLeaderboardContainer, in order to
             // keep it in sync with the leaderboard's position.
-            ToggleLeaderboardButton = new TextButton(UserInterface.LeaderboardPanel, Fonts.LatoRegular, "Toggle Leaderboard", 24, (o, e) =>
+            ToggleLeaderboardButton = new TextButton(UserInterface.LeaderboardPanel, Fonts.LatoBlack, "<", 18, (o, e) =>
             {
                 IsLeaderboardVisible = !IsLeaderboardVisible;
-                LeaderboardContainer.Visible = IsLeaderboardVisible;
+
+                if (IsLeaderboardVisible) CreateLeaderboardContainer();
+                LeaderboardContainer.MoveToX(IsLeaderboardVisible ? ScreenPaddingX : -300, Easing.OutQuint, 500);
+                ToggleLeaderboardButton.MoveToX(IsLeaderboardVisible ? LeaderboardContainer.Width + ScreenPaddingX : 0, Easing.OutQuint, 500);
+                if (!IsLeaderboardVisible) LeaderboardContainer.Destroy();
             })
             {
                 Parent = Container,
-                Size = new ScalableVector2(300, 20),
+                Size = new ScalableVector2(20, 150),
                 Alignment = Alignment.TopLeft,
                 X = ScreenPaddingX,
                 Y = FilterPanel.Y + FilterPanel.Height + LeftPanelSpacingY
             };
-            ToggleLeaderboardButton.X = -LeaderboardContainer.Width - ScreenPaddingX;
-            ToggleLeaderboardButton.MoveToX(ScreenPaddingX, Easing.OutQuint, 500);
+            ToggleLeaderboardButton.X = -LeaderboardContainer.Width;
+            ToggleLeaderboardButton.MoveToX(LeaderboardContainer.Width + ScreenPaddingX, Easing.OutQuint, 500);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -273,7 +273,7 @@ namespace Quaver.Shared.Screens.Selection
                 Size = new ScalableVector2(20, 150),
                 Alignment = Alignment.TopLeft,
                 X = ScreenPaddingX,
-                Y = FilterPanel.Y + FilterPanel.Height + LeftPanelSpacingY
+                Y = (float)(FilterPanel.Y + FilterPanel.Height + LeftPanelSpacingY + (LeaderboardContainer.Y / 2.5))
             };
             ToggleLeaderboardButton.X = -LeaderboardContainer.Width;
             ToggleLeaderboardButton.MoveToX(LeaderboardContainer.Width + ScreenPaddingX, Easing.OutQuint, 500);


### PR DESCRIPTION
In this pull request, a new, small feature is added to the song selection screen. It is a tiny tab that, when clicked, toggles the leaderboard's visibility. This can be especially useful for those who do not want a leaderboard on screen.

The leaderboard is also destroyed when hidden, and re-instantiated when shown again, so if the player is having lag issues on a lower-end machine due to the leaderboard, they can just simply hide it.

Here is the feature in-game:

https://user-images.githubusercontent.com/42378704/162434774-fdcf9133-a597-40b8-b441-900826226bbd.mp4


