### PR TITLE
Use BPM scroll off by default

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1393,7 +1393,8 @@ namespace Quaver.Shared.Screens.Edit
                     DifficultyName = "",
                     Description = $"Created at {TimeHelper.GetUnixTimestampMilliseconds()}",
                     BackgroundFile = "",
-                    Mode = GameMode.Keys4
+                    Mode = GameMode.Keys4,
+                    BPMDoesNotAffectScrollVelocity = true
                 };
 
                 // Create a new directory to house the map.


### PR DESCRIPTION
BPM scroll does not see wide usage nowadays and fixed scroll is preferred 99% of the time, so it makes sense to use change the default