### PR TITLE
Defined ServicePointManager.SecurityProtocol as TLS 1.2, seems to fix empty responses

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -407,6 +407,8 @@ namespace Quaver.Shared
         {
             DeleteTemporaryFiles();
 
+			System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+
             DatabaseManager.Initialize();
             ScoreDatabaseCache.CreateTable();
             MapDatabaseCache.Load(false);


### PR DESCRIPTION
Seems to fix #3491. News and download menu searches work. I cannot login to see if global chat messages and multiplayer map downloads work.