### PR TITLE
Don't scale miss window for harder default judgements

### DIFF
--- a/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
+++ b/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
@@ -115,7 +115,10 @@ namespace Quaver.Shared.Database.Judgements
             windows.Great /= (float) Math.Pow(constant, n);
             windows.Good /= (float) Math.Pow(constant, n);
             windows.Okay /= (float) Math.Pow(constant, n);
-            windows.Miss /= (float) Math.Pow(constant, n);
+            // Only scale the miss timing on easier windows because scaling the bad timings
+            // on harder windows enables for less penalty than what easier window players would recieve.
+            if (n < 0)
+                windows.Miss /= (float) Math.Pow(constant, n);
 
             windows.Marvelous = (int) windows.Marvelous;
             windows.Perfect = (int) windows.Perfect;

--- a/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
+++ b/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
@@ -114,11 +114,13 @@ namespace Quaver.Shared.Database.Judgements
             windows.Perfect /= (float) Math.Pow(constant, n);
             windows.Great /= (float) Math.Pow(constant, n);
             windows.Good /= (float) Math.Pow(constant, n);
-            windows.Okay /= (float) Math.Pow(constant, n);
             // Only scale the miss timing on easier windows because scaling the bad timings
             // on harder windows enables for less penalty than what easier window players would recieve.
             if (n < 0)
+            {
+                windows.Okay /= (float) Math.Pow(constant, n);
                 windows.Miss /= (float) Math.Pow(constant, n);
+            }
 
             windows.Marvelous = (int) windows.Marvelous;
             windows.Perfect = (int) windows.Perfect;


### PR DESCRIPTION
Miss window for the default presets have been updated. 
If we were to scale down the miss judgement on harder judgements, it would make it easier to acc because
every miss judgement gets smaller and smaller, while miss judgements on easier timing windows get bigger and bigger.

To elaborate, let's say two players, one using peaceful, the other using impossible, both hit a note at 150ms.
The player with peaceful judgement receives an "Ok", while the player with impossible judgement receives a miss.
The player with the peaceful judgement takes a stronger blow to their accuracy than the one with impossible judgement,