### PR TITLE
Playlist import with IPC

### DIFF
--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -168,6 +168,6 @@ namespace Quaver.Shared.Database.Playlists
             return missing;
         }
 
-        public void OpenUrl() => BrowserHelper.OpenURL($"https://quavergame.com/mappool/{OnlineMapPoolId}");
+        public void OpenUrl() => BrowserHelper.OpenURL($"https://quavergame.com/playlist/{OnlineMapPoolId}");
     }
 }

--- a/Quaver.Shared/IPC/QuaverIpcHandler.cs
+++ b/Quaver.Shared/IPC/QuaverIpcHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Quaver.Server.Common.Objects.Twitch;
 using Quaver.Shared.Audio;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Graphics.Overlays.Hub;
 using Quaver.Shared.Online;
@@ -52,6 +53,8 @@ namespace Quaver.Shared.IPC
                 HandleMapSelection(message);
             else if (message.StartsWith("mapset/"))
                 HandleMapsetSelection(message);
+            else if (message.StartsWith("playlist/"))
+                HandlePlaylistImport(message);
         }
 
         /// <summary>
@@ -159,6 +162,23 @@ namespace Quaver.Shared.IPC
                 NotificationManager.Show(NotificationLevel.Error, $"An error occurred while fetching mapset information.");
                 Logger.Error(e, LogType.Network);
             }
+        }
+
+        /// <summary>
+        ///     Imports an online playlist
+        /// </summary>
+        /// <param name="message"></param>
+        private static void HandlePlaylistImport(string message)
+        {
+            message = message.Replace("playlist/", "");
+
+            if (!int.TryParse(message, out var id))
+            {
+                NotificationManager.Show(NotificationLevel.Error, $"The provided playlist id was not a valid number.");
+                return;
+            }
+
+            PlaylistManager.ImportPlaylist(id);
         }
 
         /// <summary>

--- a/Quaver.Shared/Online/API/Playlists/APIRequestPlaylistIformation.cs
+++ b/Quaver.Shared/Online/API/Playlists/APIRequestPlaylistIformation.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Quaver.Server.Client;
+using RestSharp;
+
+namespace Quaver.Shared.Online.API.Playlists
+{
+    public class APIRequestPlaylistInformation : APIRequest<PlaylistInformationResponse>
+    {
+        /// <summary>
+        /// </summary>
+        public int Id { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="id"></param>
+        public APIRequestPlaylistInformation(int id) => Id = id;
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public override PlaylistInformationResponse ExecuteRequest()
+        {
+            var request = new RestRequest($"{APIEndpoint}playlist/{Id}", Method.GET);
+            var client = new RestClient(OnlineClient.API_ENDPOINT) { UserAgent = "Quaver" };
+
+            var response = client.Execute(request);
+
+            var json = JObject.Parse(response.Content);
+
+            var responseParsed = JsonConvert.DeserializeObject<PlaylistInformationResponse>(json.ToString());
+
+            return responseParsed;
+        }
+    }
+}

--- a/Quaver.Shared/Online/API/Playlists/PlaylistInformationResponse.cs
+++ b/Quaver.Shared/Online/API/Playlists/PlaylistInformationResponse.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Quaver.Shared.Online.API.Maps;
+
+namespace Quaver.Shared.Online.API.Playlists
+{
+    public class PlaylistInformationResponse
+    {
+        [JsonProperty("status")] public int Status;
+        [JsonProperty("playlist")] public PlaylistInformationResponsePlaylist PlaylistInformation;
+    }
+
+    public class PlaylistInformationResponsePlaylist
+    {
+        [JsonProperty("id")] public int Id;
+        [JsonProperty("user_id")] public int UserId;
+        [JsonProperty("name")] public string Name;
+        [JsonProperty("description")] public string Description;
+        [JsonProperty("like_count")] public int LikeCount;
+        [JsonProperty("map_count")] public int MapCount;
+        [JsonProperty("time_created")] public string TimeCreated;
+        [JsonProperty("time_last_updated")] public string TimeLastUpdated;
+        [JsonProperty("owner_id")] public int OwnerId;
+        [JsonProperty("owner_username")] public string OwnerUsername;
+        [JsonProperty("maps")] public List<MapInformationResponseMap> Maps;
+    }
+}


### PR DESCRIPTION
Creates/Updates a local playlist using a Quaver IPC link (eg. quaver://playlist/555)

The playlist is created with maps that are already downloaded, missing map mass download can be detrimental and has to be discussed before implementation (only allow playlist download for playlists with less than 50 maps for non-donators?)

Missing maps are logged to runtime.log

https://user-images.githubusercontent.com/22303902/173188786-7d1ca23f-4a71-4f92-9a58-a628d109b1f8.mp4

