### PR TITLE
Offset hitobject Sprite with WidthForNoteHeightScale

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -281,7 +281,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             {
                 var hitObOffset = defaultLaneSize * skin.NoteHitObjects[i][0].Height / skin.NoteHitObjects[i][0].Width;
                 var holdHitObOffset = defaultLaneSize * skin.NoteHoldHitObjects[i][0].Height / skin.NoteHoldHitObjects[i][0].Width;
-                var holdEndOffset = defaultLaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
+                var holdEndOffset = LaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
                 var receptorOffset = LaneSize * skin.NoteReceptorsUp[i].Height / skin.NoteReceptorsUp[i].Width;
 
                 if (SkinManager.Skin.Keys[Screen.Map.Mode].DrawLongNoteEnd)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -275,12 +275,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             TimingLinePositionY = new float[ScrollDirections.Length];
             LongNoteSizeAdjustment = new float[ScrollDirections.Length];
 
+            var defaultLaneSize = skin.WidthForNoteHeightScale > 0 ? skin.WidthForNoteHeightScale : LaneSize;
 
             for (var i = 0; i < ScrollDirections.Length; i++)
             {
-                var hitObOffset = LaneSize * skin.NoteHitObjects[i][0].Height / skin.NoteHitObjects[i][0].Width;
-                var holdHitObOffset = LaneSize * skin.NoteHoldHitObjects[i][0].Height / skin.NoteHoldHitObjects[i][0].Width;
-                var holdEndOffset = LaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
+                var hitObOffset = defaultLaneSize * skin.NoteHitObjects[i][0].Height / skin.NoteHitObjects[i][0].Width;
+                var holdHitObOffset = defaultLaneSize * skin.NoteHoldHitObjects[i][0].Height / skin.NoteHoldHitObjects[i][0].Width;
+                var holdEndOffset = defaultLaneSize * skin.NoteHoldEnds[i].Height / skin.NoteHoldEnds[i].Width;
                 var receptorOffset = LaneSize * skin.NoteReceptorsUp[i].Height / skin.NoteReceptorsUp[i].Width;
 
                 if (SkinManager.Skin.Keys[Screen.Map.Mode].DrawLongNoteEnd)


### PR DESCRIPTION
resolve #3158 

Auto mod, Show Hits
WidthForNoteHeightScale = 0
ColumnSize = 90
![6252022 17-28-26-523](https://user-images.githubusercontent.com/68703144/175780390-8fcfec8e-72bf-4eb5-b45e-f815c80cff5c.jpg)

Auto mod, Show Hits
WidthForNoteHeightScale = 300
ColumnSize = 90
![unknown](https://user-images.githubusercontent.com/68703144/175780901-bb6819f2-c162-469e-89dd-56f29ca0afc9.png)

