### PR TITLE
Rewrite LoadPlaylists to use Tasks

### DIFF
--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -29,11 +29,6 @@ namespace Quaver.Shared.Database.Playlists
         public static List<Playlist> Playlists { get; private set; } = new List<Playlist>();
 
         /// <summary>
-        ///     Tasks list
-        /// </summary>
-        public static List<Task> Tasks { get; private set; } = new List<Task>();
-
-        /// <summary>
         ///     The currently selected playlist
         /// </summary>
         public static Bindable<Playlist> Selected { get; } = new Bindable<Playlist>(null);
@@ -146,6 +141,7 @@ namespace Quaver.Shared.Database.Playlists
         /// </summary>
         private static void LoadPlaylists()
         {
+            var tasks = new List<Task>();
             Playlists = new List<Playlist>();
             Selected.Value = null;
 
@@ -158,7 +154,7 @@ namespace Quaver.Shared.Database.Playlists
 
                 foreach (var playlist in playlists)
                 {
-                    Tasks.Add(Task.Run(() =>
+                    tasks.Add(Task.Run(() =>
                     {
                         foreach (var mapset in MapManager.Mapsets)
                         {
@@ -174,7 +170,7 @@ namespace Quaver.Shared.Database.Playlists
                     }));
                 }
 
-                Task.WaitAll(Tasks.ToArray());
+                Task.WaitAll(tasks.ToArray());
 
                 Playlists = Playlists.Concat(playlists).ToList();
 

--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -189,9 +189,7 @@ namespace Quaver.Shared.Database.Playlists
                 Playlists = Playlists.Concat(playlists).ToList();
 
                 foreach (var playlist in playlists)
-                    Logger.Important(
-                        $"Loaded Quaver playlist: {playlist.Name ?? ""} w/ {playlist.Maps?.Count ?? 0} maps!",
-                        LogType.Runtime);
+                    Logger.Important($"Loaded Quaver playlist: {playlist.Name ?? ""} w/ {playlist.Maps?.Count ?? 0} maps!", LogType.Runtime);
             }
             catch (Exception e)
             {

--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -17,7 +17,6 @@ using Quaver.Shared.Online.API.Playlists;
 using Quaver.Shared.Scheduling;
 using SQLite;
 using Wobble.Bindables;
-using Wobble.Helpers;
 using Wobble.Logging;
 
 namespace Quaver.Shared.Database.Playlists

--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -17,6 +17,7 @@ using Quaver.Shared.Online.API.Playlists;
 using Quaver.Shared.Scheduling;
 using SQLite;
 using Wobble.Bindables;
+using Wobble.Helpers;
 using Wobble.Logging;
 
 namespace Quaver.Shared.Database.Playlists
@@ -142,16 +143,6 @@ namespace Quaver.Shared.Database.Playlists
         }
 
         /// <summary>
-        ///     Convert list to concurrent dictionary
-        /// </summary>
-        public static ConcurrentDictionary<TKey, TValue> ToConcurrentDictionary<TKey, TValue>
-            (this IEnumerable<TValue> source, Func<TValue, TKey> valueSelector)
-        {
-            return new ConcurrentDictionary<TKey, TValue>
-                (source.ToDictionary(valueSelector));
-        }
-
-        /// <summary>
         ///     Loads playlists from the database
         /// </summary>
         private static void LoadPlaylists()
@@ -164,7 +155,7 @@ namespace Quaver.Shared.Database.Playlists
                 var playlists = DatabaseManager.Connection.Table<Playlist>().ToList();
                 var playlistMaps = DatabaseManager.Connection.Table<PlaylistMap>().ToList();
 
-                var playlistDictionary = playlists.ToConcurrentDictionary(x => x.Id);
+                var playlistDictionary = ConcurrentDictionaryExtensions.ToConcurrentDictionary(playlists, playlist => playlist.Id);
 
                 foreach (var playlist in playlists)
                 {

--- a/Quaver.Shared/Helpers/ConcurrentDictionaryExtensions.cs
+++ b/Quaver.Shared/Helpers/ConcurrentDictionaryExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Quaver.Shared.Helpers
+{
+    public class ConcurrentDictionaryExtensions
+    {
+        /// <summary>
+        ///     Convert list to concurrent dictionary
+        /// </summary>
+        public static ConcurrentDictionary<TKey, TValue> ToConcurrentDictionary<TKey, TValue>
+            (IEnumerable<TValue> source, Func<TValue, TKey> valueSelector)
+        {
+            return new ConcurrentDictionary<TKey, TValue>(source.ToDictionary(valueSelector));
+        }
+    }
+}


### PR DESCRIPTION
LoadPlaylists now uses Tasks and its rewriten in better optimized way.

Changed Dictionary to ConcurrentDictionary because its thread safe.
Tasks uses thread pool.

Some tests:
From original code: RUNTIME - DEBUG: 00:00:37.1226258
New code: RUNTIME - DEBUG: 00:00:07.1438216

All tests are done with https://www.mediafire.com/file/cb6yrh0f0bpyyuv/quaver.zip/file