### PR TITLE
Disable loading of playlists after importing

### DIFF
--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -296,7 +296,7 @@ namespace Quaver.Shared.Database.Maps
         /// <summary>
         ///     Fetches all maps, groups them into mapsets, sets them to allow them to be played.
         /// </summary>
-        public static void OrderAndSetMapsets()
+        public static void OrderAndSetMapsets(bool skipPlaylistLoad = false)
         {
             OtherGameMapDatabaseCache.Initialize();
 
@@ -309,7 +309,8 @@ namespace Quaver.Shared.Database.Maps
             MapManager.Mapsets = MapsetHelper.OrderMapsByDifficulty(MapsetHelper.OrderMapsetsByArtist(mapsets));
             MapManager.RecentlyPlayed = new List<Map>();
 
-            PlaylistManager.Load();
+            if(!skipPlaylistLoad)
+                PlaylistManager.Load();
 
             // Schedule maps that don't have difficulty ratings to recalculate.
             // If forcing a full recalculation due to diff calc updates, then the difficulty processor version should just be bumped

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -342,7 +342,7 @@ namespace Quaver.Shared.Database.Maps
                 }
             });
 
-            MapDatabaseCache.OrderAndSetMapsets();
+            MapDatabaseCache.OrderAndSetMapsets(true);
             Queue.Clear();
 
             if (MapManager.Mapsets.Count == 0)


### PR DESCRIPTION
Disabled loading of all playlists when importing mapset/s, I don't think its required to scan everything again on each import, because its slows now import.