### PR TITLE
Remove IsPlaying in Download Mapsets

### DIFF
--- a/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
+++ b/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
@@ -218,7 +218,7 @@ namespace Quaver.Shared.Screens.Downloading
         /// </summary>
         private void Initialize()
         {
-            if (AudioEngine.Track != null && AudioEngine.Track.IsPlaying)
+            if (AudioEngine.Track != null)
                 AudioEngine.Track?.Stop();
 
             ModManager.RemoveSpeedMods();


### PR DESCRIPTION
Fixes https://github.com/Quaver/Quaver/issues/3494

After testing looks like the track does not get cleared because its not yet started but its loaded.
This resolves the issue.