### PR TITLE
Dropdown fixes

### DIFF
--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -364,7 +364,8 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
             if (ItemContainer.ScreenRectangle.Contains(mousePoint) || ScreenRectangle.Contains(mousePoint))
                 return;
 
-            Close();
+            if(Opened)
+                Close();
         }
     }
 }

--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -10,6 +10,8 @@ using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Input;
+using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Graphics.Form.Dropdowns
@@ -135,6 +137,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
             Hovered += OnHovered;
             LeftHover += OnHoverLeft;
             Clicked += OnClicked;
+            ClickedOutside += OnClickedOutside;
         }
 
         /// <inheritdoc />
@@ -142,6 +145,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// </summary>
         public override void Destroy()
         {
+            Logger.Debug("Destroy dropdown!!!!!!!!!", LogType.Runtime);
             ItemSelected = null;
             base.Destroy();
         }
@@ -347,6 +351,21 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
 
             if (invokeEvent)
                 ItemSelected?.Invoke(this, new DropdownClickedEventArgs(item));
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        private void OnClickedOutside(object sender, EventArgs e)
+        {
+            var mousePoint = MouseManager.CurrentState.Position.ToPoint();
+
+            if (ItemContainer.ScreenRectangle.Contains(mousePoint) || ScreenRectangle.Contains(mousePoint))
+                return;
+
+            Close();
         }
     }
 }

--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -145,7 +145,6 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// </summary>
         public override void Destroy()
         {
-            Logger.Debug("Destroy dropdown!!!!!!!!!", LogType.Runtime);
             ItemSelected = null;
             base.Destroy();
         }

--- a/Quaver.Shared/Graphics/Form/Dropdowns/DropdownItem.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/DropdownItem.cs
@@ -10,6 +10,7 @@ using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Input;
+using Wobble.Logging;
 
 namespace Quaver.Shared.Graphics.Form.Dropdowns
 {
@@ -55,7 +56,6 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
             Hovered += OnHovered;
             LeftHover += OnHoverLeft;
             Clicked += OnClicked;
-            ClickedOutside += OnClickedOutside;
         }
 
         /// <inheritdoc />
@@ -136,21 +136,6 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
                 return;
 
             Dropdown.SelectItem(this);
-            Dropdown.Close();
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        /// <exception cref="NotImplementedException"></exception>
-        private void OnClickedOutside(object sender, EventArgs e)
-        {
-            var mousePoint = MouseManager.CurrentState.Position.ToPoint();
-
-            if (Dropdown.ItemContainer.ScreenRectangle.Contains(mousePoint) || Dropdown.ScreenRectangle.Contains(mousePoint))
-                return;
-
             Dropdown.Close();
         }
     }

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -104,6 +104,18 @@ namespace Quaver.Shared.Screens.Options
             CurrentSearchQuery?.Dispose();
             IsKeybindFocused?.Dispose();
 
+            // Make sure to destroy everything that's not visible
+            foreach (var section in Sections)
+            {
+                foreach (var subcategory in section.Subcategories)
+                {
+                    foreach (var item in subcategory.Items)
+                    {
+                        item.Destroy();
+                    }
+                }
+            }
+
             base.Destroy();
         }
 


### PR DESCRIPTION
ToDos:

- [x] Opening options in DropdownItem close() is called 31 times
Fixed by moving ClickedOutside to Dropdown, it resolves the issue.

- [x] Dropdown destroy is called only for the visible dropdowns
Presented in Options when opening the dialog its creating all dropdowns, but on closing it only closes the visible dropdowns, which leaves the rest in memory and might be the reason why its blocking everything on screen to be clickable.
Possible fix: to create only the visible dropdowns in the selected tab or to destroy everything when the dialog is closed

- [x] Dropdown close is triggered for all dropdowns instead just for the one that we interacted with

Debugging info: 
Starting the game and going to Select screen dropdowns items count is just 30.
Starting the game going to Options closing and going to Select screen dropdowns items count is 102.

This PR will try to resolve all issues in https://github.com/Quaver/Quaver/issues/3543