### PR TITLE
[Skinning] new Judgement Counter feature

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -55,13 +55,15 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                     Alignment = Alignment.MidRight,
                     Parent = this,
                     Image = SkinManager.Skin.JudgementOverlay,
-                    Alpha = skin.JudgementCounterAlpha
+                    Alpha = skin.JudgementCounterAlpha,
+                    X = skin.JudgementCounterPosX
                 };
 
                 // Normalize the position of the first one so that all the rest will be completely in the middle.
                 if (i == 0)
                 {
                     Y = Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count * -JudgementDisplays[key].Height / 2f;
+                    Y += skin.JudgementCounterPosY;
                     continue;
                 }
 

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -9,9 +9,11 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Quaver.API.Enums;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Skinning;
 using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
 
 namespace Quaver.Shared.Screens.Gameplay.UI.Counter
 {
@@ -31,6 +33,11 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
         /// </summary>
         private Dictionary<Judgement, JudgementCounterItem> JudgementDisplays { get; }
 
+        /// <summary>
+        ///     The background of judgement displays.
+        /// </summary>
+        private Dictionary<Judgement, Sprite> JudgementDisplaysBackground { get; }
+
         /// <inheritdoc />
         /// <summary>
         ///     Ctor -
@@ -41,12 +48,27 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
 
             // Create the judgement displays.
             JudgementDisplays = new Dictionary<Judgement, JudgementCounterItem>();
+            JudgementDisplaysBackground = new Dictionary<Judgement, Sprite>();
 
             var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
             for (var i = 0; i < Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count; i++)
             {
                 var key = (Judgement)i;
                 var color = SkinManager.Skin.Keys[Screen.Map.Mode].JudgeColors[key];
+
+                if (SkinManager.Skin.JudgementOverlayBackground != UserInterface.BlankBox)
+                {
+                    JudgementDisplaysBackground[key] = new Sprite()
+                    {
+                        Alignment = Alignment.MidRight,
+                        Parent = this,
+                        Image = SkinManager.Skin.JudgementOverlayBackground,
+                        Alpha = skin.JudgementCounterAlpha,
+                        X = skin.JudgementCounterPosX,
+                        Y = skin.JudgementCounterPosY,
+                        Size = new ScalableVector2(skin.JudgementCounterSize, skin.JudgementCounterSize)
+                    };
+                }
 
                 // Default it to an inactive color.
                 JudgementDisplays[key] = new JudgementCounterItem(this, key, new Color(color.R / 2, color.G / 2, color.B / 2),
@@ -63,7 +85,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                 // Normalize the position of the first one so that all the rest will be completely in the middle.
                 if (i == 0)
                 {
-                    Y += Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count * -JudgementDisplays[key].Height / 2f;
+                    Y = Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count * -JudgementDisplays[key].Height / 2f;
                     continue;
                 }
 
@@ -71,6 +93,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                     JudgementDisplays[key].X = JudgementDisplays[(Judgement)(i - 1)].X + JudgementDisplays[key].Width + 5;
                 else
                     JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5;
+
+                if (SkinManager.Skin.JudgementOverlayBackground != UserInterface.BlankBox)
+                    JudgementDisplaysBackground[key].Position = JudgementDisplays[key].Position;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -56,18 +56,21 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                     Parent = this,
                     Image = SkinManager.Skin.JudgementOverlay,
                     Alpha = skin.JudgementCounterAlpha,
-                    X = skin.JudgementCounterPosX
-                };
+                    X = skin.JudgementCounterPosX,
+                    Y = skin.JudgementCounterPosY
+            };
 
                 // Normalize the position of the first one so that all the rest will be completely in the middle.
                 if (i == 0)
                 {
-                    Y = Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count * -JudgementDisplays[key].Height / 2f;
-                    Y += skin.JudgementCounterPosY;
+                    Y += Screen.Ruleset.ScoreProcessor.CurrentJudgements.Count * -JudgementDisplays[key].Height / 2f;
                     continue;
                 }
 
-                JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5;
+                if (skin.JudgementCounterHorizontal)
+                    JudgementDisplays[key].X = JudgementDisplays[(Judgement)(i - 1)].X + JudgementDisplays[key].Width + 5;
+                else
+                    JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5;
             }
         }
 

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -90,9 +90,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                 }
 
                 if (skin.JudgementCounterHorizontal)
-                    JudgementDisplays[key].X = JudgementDisplays[(Judgement)(i - 1)].X + JudgementDisplays[key].Width + 5;
+                    JudgementDisplays[key].X = JudgementDisplays[(Judgement)(i - 1)].X + JudgementDisplays[key].Width + 5 + skin.JudgementCounterPadding;
                 else
-                    JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5;
+                    JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5 + skin.JudgementCounterPadding;
 
                 if (SkinManager.Skin.JudgementOverlayBackground[key] != UserInterface.BlankBox)
                     JudgementDisplaysBackground[key].Position = JudgementDisplays[key].Position;

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -56,13 +56,13 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                 var key = (Judgement)i;
                 var color = SkinManager.Skin.Keys[Screen.Map.Mode].JudgeColors[key];
 
-                if (SkinManager.Skin.JudgementOverlayBackground != UserInterface.BlankBox)
+                if (SkinManager.Skin.JudgementOverlayBackground[key] != UserInterface.BlankBox)
                 {
                     JudgementDisplaysBackground[key] = new Sprite()
                     {
                         Alignment = Alignment.MidRight,
                         Parent = this,
-                        Image = SkinManager.Skin.JudgementOverlayBackground,
+                        Image = SkinManager.Skin.JudgementOverlayBackground[key],
                         Alpha = skin.JudgementCounterAlpha,
                         X = skin.JudgementCounterPosX,
                         Y = skin.JudgementCounterPosY,
@@ -76,7 +76,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                 {
                     Alignment = Alignment.MidRight,
                     Parent = this,
-                    Image = SkinManager.Skin.JudgementOverlay,
+                    Image = SkinManager.Skin.JudgementOverlay[key],
                     Alpha = skin.JudgementCounterAlpha,
                     X = skin.JudgementCounterPosX,
                     Y = skin.JudgementCounterPosY
@@ -94,7 +94,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                 else
                     JudgementDisplays[key].Y = JudgementDisplays[(Judgement)(i - 1)].Y + JudgementDisplays[key].Height + 5;
 
-                if (SkinManager.Skin.JudgementOverlayBackground != UserInterface.BlankBox)
+                if (SkinManager.Skin.JudgementOverlayBackground[key] != UserInterface.BlankBox)
                     JudgementDisplaysBackground[key].Position = JudgementDisplays[key].Position;
             }
         }

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounter.cs
@@ -58,7 +58,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
                     Alpha = skin.JudgementCounterAlpha,
                     X = skin.JudgementCounterPosX,
                     Y = skin.JudgementCounterPosY
-            };
+                };
 
                 // Normalize the position of the first one so that all the rest will be completely in the middle.
                 if (i == 0)

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
@@ -88,7 +88,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
             {
                 Alignment = Alignment.MidCenter,
                 Parent = this,
-                Tint = skin.JudgementCounterFontColor,
+                Tint = skin.UseJudgementColorForNumbers ? color * 2 : skin.JudgementCounterFontColor,
                 X = 0,
                 FontSize = (int)(Width * 0.35f)
             };

--- a/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Counter/JudgementCounterItem.cs
@@ -46,6 +46,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
 
                 // Change the color to its active one.
                 Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].JudgeColors[Judgement];
+                Alpha = DefaultAlpha;
 
                 SpriteText.Text = value == 0
                     ? JudgementHelper.JudgementToShortName(Judgement)
@@ -63,6 +64,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
         /// </summary>
         private Color InactiveColor { get; }
 
+        private float DefaultAlpha { get; }
+
         /// <inheritdoc />
         /// <summary>
         ///     Ctor -
@@ -77,6 +80,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
             ParentDisplay = parentDisplay;
 
             Size = new ScalableVector2(size.X, size.Y);
+            DefaultAlpha = Alpha;
 
             var skin = SkinManager.Skin.Keys[parentDisplay.Screen.Map.Mode];
 
@@ -99,7 +103,10 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Counter
         public override void Update(GameTime gameTime)
         {
             // Make sure the color is always tweening down back to its inactive one.
-            FadeToColor(InactiveColor, gameTime.ElapsedGameTime.TotalMilliseconds, 360);
+            if (SkinManager.Skin.Keys[ParentDisplay.Screen.Map.Mode].JudgementCounterFadeToAlpha)
+                FadeTo(0, Wobble.Graphics.Animations.Easing.Linear, 360);
+            else
+                FadeToColor(InactiveColor, gameTime.ElapsedGameTime.TotalMilliseconds, 360);
 
             base.Update(gameTime);
         }

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -211,6 +211,8 @@ namespace Quaver.Shared.Skinning
 
         internal bool JudgementCounterHorizontal { get; private set; }
 
+        internal bool JudgementCounterFadeToAlpha { get; private set; }
+
         internal bool DrawLongNoteEnd { get; private set; }
 
         internal Color DeadNoteColor { get; private set; }
@@ -491,6 +493,7 @@ namespace Quaver.Shared.Skinning
             JudgementCounterPosX = ConfigHelper.ReadInt32((int) JudgementCounterPosX, ini["JudgementCounterPosX"]);
             JudgementCounterPosY = ConfigHelper.ReadInt32((int) JudgementCounterPosY, ini["JudgementCounterPosY"]);
             JudgementCounterHorizontal = ConfigHelper.ReadBool(JudgementCounterHorizontal, ini["JudgementCounterHorizontal"]);
+            JudgementCounterFadeToAlpha = ConfigHelper.ReadBool(JudgementCounterFadeToAlpha, ini["JudgementCounterFadeToAlpha"]);
             DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);
             ScoreDisplayScale = ConfigHelper.ReadInt32((int) ScoreDisplayScale, ini["ScoreDisplayScale"]);
             RatingDisplayScale = ConfigHelper.ReadInt32((int) RatingDisplayScale, ini["RatingDisplayScale"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -203,6 +203,12 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float JudgementCounterSize { get; private set; }
 
+        [FixedScale]
+        internal float JudgementCounterPosX { get; private set; }
+
+        [FixedScale]
+        internal float JudgementCounterPosY { get; private set; }
+
         internal bool DrawLongNoteEnd { get; private set; }
 
         internal Color DeadNoteColor { get; private set; }
@@ -480,6 +486,8 @@ namespace Quaver.Shared.Skinning
             JudgementCounterAlpha = ConfigHelper.ReadFloat(JudgementCounterAlpha, ini["JudgementCounterAlpha"]);
             JudgementCounterFontColor = ConfigHelper.ReadColor(JudgementCounterFontColor, ini["JudgementCounterFontColor"]);
             JudgementCounterSize = ConfigHelper.ReadInt32((int) JudgementCounterSize, ini["JudgementCounterSize"]);
+            JudgementCounterPosX = ConfigHelper.ReadInt32((int) JudgementCounterPosX, ini["JudgementCounterPosX"]);
+            JudgementCounterPosY = ConfigHelper.ReadInt32((int) JudgementCounterPosY, ini["JudgementCounterPosY"]);
             DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);
             ScoreDisplayScale = ConfigHelper.ReadInt32((int) ScoreDisplayScale, ini["ScoreDisplayScale"]);
             RatingDisplayScale = ConfigHelper.ReadInt32((int) RatingDisplayScale, ini["RatingDisplayScale"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -200,6 +200,8 @@ namespace Quaver.Shared.Skinning
 
         internal Color JudgementCounterFontColor { get; private set; }
 
+        internal bool UseJudgementColorForNumbers { get; private set; }
+
         [FixedScale]
         internal float JudgementCounterSize { get; private set; }
 
@@ -489,6 +491,7 @@ namespace Quaver.Shared.Skinning
             SongTimeProgressActiveColor = ConfigHelper.ReadColor(SongTimeProgressActiveColor, ini["SongTimeProgressActiveColor"]);
             JudgementCounterAlpha = ConfigHelper.ReadFloat(JudgementCounterAlpha, ini["JudgementCounterAlpha"]);
             JudgementCounterFontColor = ConfigHelper.ReadColor(JudgementCounterFontColor, ini["JudgementCounterFontColor"]);
+            UseJudgementColorForNumbers = ConfigHelper.ReadBool(UseJudgementColorForNumbers, ini["UseJudgementColorForNumbers"]);
             JudgementCounterSize = ConfigHelper.ReadInt32((int) JudgementCounterSize, ini["JudgementCounterSize"]);
             JudgementCounterPosX = ConfigHelper.ReadInt32((int) JudgementCounterPosX, ini["JudgementCounterPosX"]);
             JudgementCounterPosY = ConfigHelper.ReadInt32((int) JudgementCounterPosY, ini["JudgementCounterPosY"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -209,6 +209,8 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float JudgementCounterPosY { get; private set; }
 
+        internal bool JudgementCounterHorizontal { get; private set; }
+
         internal bool DrawLongNoteEnd { get; private set; }
 
         internal Color DeadNoteColor { get; private set; }
@@ -488,6 +490,7 @@ namespace Quaver.Shared.Skinning
             JudgementCounterSize = ConfigHelper.ReadInt32((int) JudgementCounterSize, ini["JudgementCounterSize"]);
             JudgementCounterPosX = ConfigHelper.ReadInt32((int) JudgementCounterPosX, ini["JudgementCounterPosX"]);
             JudgementCounterPosY = ConfigHelper.ReadInt32((int) JudgementCounterPosY, ini["JudgementCounterPosY"]);
+            JudgementCounterHorizontal = ConfigHelper.ReadBool(JudgementCounterHorizontal, ini["JudgementCounterHorizontal"]);
             DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);
             ScoreDisplayScale = ConfigHelper.ReadInt32((int) ScoreDisplayScale, ini["ScoreDisplayScale"]);
             RatingDisplayScale = ConfigHelper.ReadInt32((int) RatingDisplayScale, ini["RatingDisplayScale"]);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -211,6 +211,8 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float JudgementCounterPosY { get; private set; }
 
+        internal float JudgementCounterPadding { get; private set; }
+
         internal bool JudgementCounterHorizontal { get; private set; }
 
         internal bool JudgementCounterFadeToAlpha { get; private set; }
@@ -495,6 +497,7 @@ namespace Quaver.Shared.Skinning
             JudgementCounterSize = ConfigHelper.ReadInt32((int) JudgementCounterSize, ini["JudgementCounterSize"]);
             JudgementCounterPosX = ConfigHelper.ReadInt32((int) JudgementCounterPosX, ini["JudgementCounterPosX"]);
             JudgementCounterPosY = ConfigHelper.ReadInt32((int) JudgementCounterPosY, ini["JudgementCounterPosY"]);
+            JudgementCounterPadding = ConfigHelper.ReadInt32((int) JudgementCounterPadding, ini["JudgementCounterPadding"]);
             JudgementCounterHorizontal = ConfigHelper.ReadBool(JudgementCounterHorizontal, ini["JudgementCounterHorizontal"]);
             JudgementCounterFadeToAlpha = ConfigHelper.ReadBool(JudgementCounterFadeToAlpha, ini["JudgementCounterFadeToAlpha"]);
             DrawLongNoteEnd = ConfigHelper.ReadBool(DrawLongNoteEnd, ini["DrawLongNoteEnd"]);

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -521,7 +521,7 @@ namespace Quaver.Shared.Skinning
                 var judgementOverlayBackground = $"judgement-overlay-background-{j.ToString().ToLower()}";
 
                 // Compatibility for old skin.
-                if (!File.Exists($"{Dir}/{folder}/{judgementOverlay}"))
+                if (!File.Exists($"{Dir}/{folder}/{judgementOverlay}.png"))
                     judgementOverlay = "judgement-overlay";
 
                 Judgements[j] = LoadSpritesheet($"/{folder}/", element,

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -183,6 +183,11 @@ namespace Quaver.Shared.Skinning
         internal Texture2D JudgementOverlay { get; private set; }
 
         /// <summary>
+        ///     The background of the judgement overlay.
+        /// </summary>
+        internal Texture2D JudgementOverlayBackground { get; private set; }
+
+        /// <summary>
         ///     The scoreboard displayed on the screen for the player.
         /// </summary>
         internal Texture2D Scoreboard { get; private set; }
@@ -519,8 +524,11 @@ namespace Quaver.Shared.Skinning
 
             // Load judgement overlay
             const string judgementOverlay = "judgement-overlay";
+            const string judgementOverlayBackground = "judgement-overlay-background";
             JudgementOverlay = LoadSingleTexture( $"{Dir}/{folder}/{judgementOverlay}",
                 $"Quaver.Resources/Textures/Skins/Shared/Judgements/{judgementOverlay}.png");
+            JudgementOverlayBackground = LoadSingleTexture( $"{Dir}/{folder}/{judgementOverlayBackground}",
+                null);
         }
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -180,12 +180,12 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     The overlay that displayed the judgement counts.
         /// </summary>
-        internal Texture2D JudgementOverlay { get; private set; }
+        internal Dictionary<Judgement, Texture2D> JudgementOverlay { get; } = new Dictionary<Judgement, Texture2D>();
 
         /// <summary>
         ///     The background of the judgement overlay.
         /// </summary>
-        internal Texture2D JudgementOverlayBackground { get; private set; }
+        internal Dictionary<Judgement, Texture2D> JudgementOverlayBackground { get; } = new Dictionary<Judgement, Texture2D>();
 
         /// <summary>
         ///     The scoreboard displayed on the screen for the player.
@@ -510,25 +510,27 @@ namespace Quaver.Shared.Skinning
         {
             const string folder = "Judgements";
 
-            // Load Judgements
+            // Load Judgements and judgement overlay
             foreach (Judgement j in Enum.GetValues(typeof(Judgement)))
             {
                 if (j == Judgement.Ghost)
                     continue;
 
                 var element = $"judge-{j.ToString().ToLower()}";
+                var judgementOverlay = $"judgement-overlay-{j.ToString().ToLower()}";
+                var judgementOverlayBackground = $"judgement-overlay-background-{j.ToString().ToLower()}";
+
+                // Compatibility for old skin.
+                if (!File.Exists($"/{folder}/{judgementOverlay}"))
+                    judgementOverlay = "judgement-overlay";
 
                 Judgements[j] = LoadSpritesheet($"/{folder}/", element,
                     $"Quaver.Resources/Textures/Skins/Shared/Judgements/{element}", 0, 0);
+                JudgementOverlay[j] = LoadSingleTexture($"/{folder}/{judgementOverlay}",
+                    $"Quaver.Resources/Textures/Skins/Shared/Judgements/judgement-overlay.png");
+                JudgementOverlayBackground[j] = LoadSingleTexture($"/{folder}/{judgementOverlayBackground}",
+                    null);
             }
-
-            // Load judgement overlay
-            const string judgementOverlay = "judgement-overlay";
-            const string judgementOverlayBackground = "judgement-overlay-background";
-            JudgementOverlay = LoadSingleTexture( $"{Dir}/{folder}/{judgementOverlay}",
-                $"Quaver.Resources/Textures/Skins/Shared/Judgements/{judgementOverlay}.png");
-            JudgementOverlayBackground = LoadSingleTexture( $"{Dir}/{folder}/{judgementOverlayBackground}",
-                null);
         }
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -521,14 +521,14 @@ namespace Quaver.Shared.Skinning
                 var judgementOverlayBackground = $"judgement-overlay-background-{j.ToString().ToLower()}";
 
                 // Compatibility for old skin.
-                if (!File.Exists($"/{folder}/{judgementOverlay}"))
+                if (!File.Exists($"{Dir}/{folder}/{judgementOverlay}"))
                     judgementOverlay = "judgement-overlay";
 
                 Judgements[j] = LoadSpritesheet($"/{folder}/", element,
                     $"Quaver.Resources/Textures/Skins/Shared/Judgements/{element}", 0, 0);
-                JudgementOverlay[j] = LoadSingleTexture($"/{folder}/{judgementOverlay}",
+                JudgementOverlay[j] = LoadSingleTexture($"{Dir}/{folder}/{judgementOverlay}",
                     $"Quaver.Resources/Textures/Skins/Shared/Judgements/judgement-overlay.png");
-                JudgementOverlayBackground[j] = LoadSingleTexture($"/{folder}/{judgementOverlayBackground}",
+                JudgementOverlayBackground[j] = LoadSingleTexture($"{Dir}/{folder}/{judgementOverlayBackground}",
                     null);
             }
         }


### PR DESCRIPTION
Closes #2626 
Closes #2582

New skin.ini Feature : 
- **JudgementCounterPosX** and **JudgementCounterPosY**
    - Allow to move the judgement counter around the screen
- **JudgementCounterPadding**
    - Change the padding/distance between the counter
- **JudgementCounterHorizontal**
    - Arrange the counter horizontally instead of vertically
- **JudgementCounterFadeToAlpha**
    - Change the animation of the judgement-overlay to fade with alpha, rather than fading with color
- **UseJudgementColorForNumbers**
    - The font will use the color of the judgement

New files : 
- **judgement-overlay-background-(marv-miss)**
    - Add a background to the judgement-overlay. Since there is no default for it, it's drawing get skipped if no file found.
- judgement-overlay can now be edited per judgement => **judgement-overlay-(marv-miss)**
    - For compatibility sake with default and old skin, if there is no specific judgement-overlay-(marv-miss), it will default to using the judgement-overlay file.
    
![7302022 19-28-49-604](https://user-images.githubusercontent.com/68703144/181934897-e6cac809-0f67-4b45-8251-d458087c62c5.jpg)

Here is a test skin using all of the new feature :
[JudgementCounterTestSkin.zip](https://github.com/Quaver/Quaver/files/9227001/JudgementCounterTestSkin.zip)
 