### PR TITLE
Add Judgement per Lane

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -195,11 +195,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Update Playfield
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
 
+            // Get hit burst lane
+            var judgementHitBurstLane = Math.Clamp(lane, 0, playfield.Stage.JudgementHitBursts.Count - 1);
+
             if (ReplayInputManager == null)
             {
                 playfield.Stage.ComboDisplay.MakeVisible();
                 playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - time);
-                playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(judgement);
+                playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(judgement);
             }
 
             // Update Object Pooling
@@ -223,7 +226,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
                     view.UpdateScoreboardUsers();
                     view.UpdateScoreAndAccuracyDisplays();
-                    playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
+                    playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
 
                     manager.KillPoolObject(gameplayHitObject);
                     break;
@@ -268,6 +271,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             var view = (GameplayScreenView) Ruleset.Screen.View;
 
+            // Get hit burst lane
+            var judgementHitBurstLane = Math.Clamp(lane, 0, playfield.Stage.JudgementHitBursts.Count - 1);
+
             // If LN has been released during a window
             if (judgement != Judgement.Ghost)
             {
@@ -293,7 +299,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 {
                     playfield.Stage.ComboDisplay.MakeVisible();
                     playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.EndTime - time);
-                    playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(judgement);
+                    playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(judgement);
                 }
 
                 // play hitlighting animation on release
@@ -336,7 +342,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             // Perform hit burst animation
             if (ReplayInputManager == null)
-                playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
+                playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
 
             // Update Object Pool
             manager.KillHoldPoolObject(gameplayHitObject);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -199,7 +199,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             {
                 playfield.Stage.ComboDisplay.MakeVisible();
                 playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.StartTime - time);
-                playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+                playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(judgement);
             }
 
             // Update Object Pooling
@@ -223,7 +223,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
                     view.UpdateScoreboardUsers();
                     view.UpdateScoreAndAccuracyDisplays();
-                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+                    playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
 
                     manager.KillPoolObject(gameplayHitObject);
                     break;
@@ -293,7 +293,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 {
                     playfield.Stage.ComboDisplay.MakeVisible();
                     playfield.Stage.HitError.AddJudgement(judgement, gameplayHitObject.Info.EndTime - time);
-                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+                    playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(judgement);
                 }
 
                 // play hitlighting animation on release
@@ -336,7 +336,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             // Perform hit burst animation
             if (ReplayInputManager == null)
-                playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+                playfield.Stage.JudgementHitBurst[Math.Clamp(lane, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
 
             // Update Object Pool
             manager.KillHoldPoolObject(gameplayHitObject);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -210,8 +210,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     if (judgement != Judgement.Miss)
                         playfield.Stage.HitError.AddJudgement(judgement, VirtualPlayer.ScoreProcessor.Stats[i].HitDifference);
 
-                    var lane = Math.Clamp(VirtualPlayer.ScoreProcessor.Stats[i].HitObject.Lane - 1, 0, playfield.Stage.JudgementHitBurst.Count - 1);
-                    playfield.Stage.JudgementHitBurst[lane].PerformJudgementAnimation(judgement);
+                    var lane = Math.Clamp(VirtualPlayer.ScoreProcessor.Stats[i].HitObject.Lane - 1, 0, playfield.Stage.JudgementHitBursts.Count - 1);
+                    playfield.Stage.JudgementHitBursts[lane].PerformJudgementAnimation(judgement);
 
                     CurrentVirtualReplayStat++;
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -210,7 +210,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     if (judgement != Judgement.Miss)
                         playfield.Stage.HitError.AddJudgement(judgement, VirtualPlayer.ScoreProcessor.Stats[i].HitDifference);
 
-                    playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(judgement);
+                    var lane = Math.Clamp(VirtualPlayer.ScoreProcessor.Stats[i].HitObject.Lane - 1, 0, playfield.Stage.JudgementHitBurst.Count - 1);
+                    playfield.Stage.JudgementHitBurst[lane].PerformJudgementAnimation(judgement);
 
                     CurrentVirtualReplayStat++;
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -528,7 +528,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (im?.ReplayInputManager == null)
                     {
                         playfield.Stage.ComboDisplay.MakeVisible();
-                        playfield.Stage.JudgementHitBurst[Math.Clamp(hitObject.Info.Lane - 1, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
+                        playfield.Stage.JudgementHitBursts[Math.Clamp(hitObject.Info.Lane - 1, 0, playfield.Stage.JudgementHitBursts.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
                     }
 
                     // If ManiaHitObject is an LN, kill it and count it as another miss because of the tail.
@@ -611,7 +611,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (im?.ReplayInputManager == null)
                     {
                         stage.ComboDisplay.MakeVisible();
-                        stage.JudgementHitBurst[Math.Clamp(hitObject.Info.Lane - 1, 0, stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(missedReleaseJudgement);
+                        stage.JudgementHitBursts[Math.Clamp(hitObject.Info.Lane - 1, 0, stage.JudgementHitBursts.Count - 1)].PerformJudgementAnimation(missedReleaseJudgement);
                     }
 
                     stage.HitLightingObjects[hitObject.Info.Lane - 1].StopHolding();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -528,7 +528,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (im?.ReplayInputManager == null)
                     {
                         playfield.Stage.ComboDisplay.MakeVisible();
-                        playfield.Stage.JudgementHitBurst.PerformJudgementAnimation(Judgement.Miss);
+                        playfield.Stage.JudgementHitBurst[Math.Clamp(hitObject.Info.Lane - 1, 0, playfield.Stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
                     }
 
                     // If ManiaHitObject is an LN, kill it and count it as another miss because of the tail.
@@ -611,7 +611,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (im?.ReplayInputManager == null)
                     {
                         stage.ComboDisplay.MakeVisible();
-                        stage.JudgementHitBurst.PerformJudgementAnimation(missedReleaseJudgement);
+                        stage.JudgementHitBurst[Math.Clamp(hitObject.Info.Lane - 1, 0, stage.JudgementHitBurst.Count - 1)].PerformJudgementAnimation(missedReleaseJudgement);
                     }
 
                     stage.HitLightingObjects[hitObject.Info.Lane - 1].StopHolding();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -20,6 +20,7 @@ using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Health;
 using Quaver.Shared.Screens.Gameplay.UI;
 using Quaver.Shared.Screens.Gameplay.UI.Health;
@@ -128,7 +129,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     The JudgementHitBurst Sprite.
         /// </summary>
-        public JudgementHitBurst JudgementHitBurst { get; private set; }
+        public List<JudgementHitBurst> JudgementHitBurst { get; private set; }
 
         /// <summary>
         ///     When hitting an object, this is the sprite that will be shown at
@@ -541,6 +542,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// </summary>
         private void CreateJudgementHitBurst()
         {
+            var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
+            JudgementHitBurst = new List<JudgementHitBurst>(); 
+
             // Default the frames to miss.
             var frames = SkinManager.Skin.Judgements[Judgement.Miss];
 
@@ -550,11 +554,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             // Set size w/ scaling.
             var size = new Vector2(firstFrame.Width, firstFrame.Height) * Skin.JudgementHitBurstScale / firstFrame.Height;
 
-            JudgementHitBurst = new JudgementHitBurst(Screen, frames, size, Skin.JudgementBurstPosY)
+            var judgementBurstCount = skin.DisplayJudgementsInEachColumn == true ? Screen.Map.GetKeyCount(Screen.Map.HasScratchKey) : 1;
+
+            for (var i = 0; i < judgementBurstCount; i++)
             {
-                Parent = Playfield.ForegroundContainer,
-                Alignment = Alignment.MidCenter,
-            };
+                var judgementHitBurst = new JudgementHitBurst(Screen, frames, size, Skin.JudgementBurstPosY)
+                {
+                    Parent = Playfield.ForegroundContainer,
+                    Alignment = Alignment.MidCenter,
+                    X = skin.DisplayJudgementsInEachColumn == true ? Receptors[i].X - (Playfield.Width / 2 - (Playfield.LaneSize / 2)) : 0
+                };
+
+                if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)
+                    judgementHitBurst.Rotation = GameplayHitObjectKeys.GetObjectRotation(Screen.Map.Mode, i);
+
+                JudgementHitBurst.Add(judgementHitBurst);
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -562,7 +562,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 {
                     Parent = Playfield.ForegroundContainer,
                     Alignment = Alignment.MidCenter,
-                    X = skin.DisplayJudgementsInEachColumn == true ? Receptors[i].X - (Playfield.Width / 2 - (Playfield.LaneSize / 2)) : 0
+                    X = skin.DisplayJudgementsInEachColumn == true ? Receptors[i].X - ((Playfield.Width / 2) - (Playfield.LaneSize / 2)) : 0
                 };
 
                 if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -129,7 +129,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     The JudgementHitBurst Sprite.
         /// </summary>
-        public List<JudgementHitBurst> JudgementHitBurst { get; private set; }
+        public List<JudgementHitBurst> JudgementHitBursts { get; private set; }
 
         /// <summary>
         ///     When hitting an object, this is the sprite that will be shown at
@@ -543,7 +543,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         private void CreateJudgementHitBurst()
         {
             var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
-            JudgementHitBurst = new List<JudgementHitBurst>(); 
+            JudgementHitBursts = new List<JudgementHitBurst>(); 
 
             // Default the frames to miss.
             var frames = SkinManager.Skin.Judgements[Judgement.Miss];
@@ -554,21 +554,24 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             // Set size w/ scaling.
             var size = new Vector2(firstFrame.Width, firstFrame.Height) * Skin.JudgementHitBurstScale / firstFrame.Height;
 
-            var judgementBurstCount = skin.DisplayJudgementsInEachColumn == true ? Screen.Map.GetKeyCount(Screen.Map.HasScratchKey) : 1;
+            var judgementBurstCount = skin.DisplayJudgementsInEachColumn ?
+                Screen.Map.GetKeyCount(Screen.Map.HasScratchKey) : 1;
 
-            for (var i = 0; i < judgementBurstCount; i++)
+            var playfieldOffset = (Playfield.Width / 2) - (Playfield.LaneSize / 2);
+
+            for (var lane = 0; lane < judgementBurstCount; lane++)
             {
                 var judgementHitBurst = new JudgementHitBurst(Screen, frames, size, Skin.JudgementBurstPosY)
                 {
                     Parent = Playfield.ForegroundContainer,
                     Alignment = Alignment.MidCenter,
-                    X = skin.DisplayJudgementsInEachColumn == true ? Receptors[i].X - ((Playfield.Width / 2) - (Playfield.LaneSize / 2)) : 0
+                    X = skin.DisplayJudgementsInEachColumn ? Receptors[lane].X - playfieldOffset : 0
                 };
 
                 if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)
-                    judgementHitBurst.Rotation = GameplayHitObjectKeys.GetObjectRotation(Screen.Map.Mode, i);
+                    judgementHitBurst.Rotation = GameplayHitObjectKeys.GetObjectRotation(Screen.Map.Mode, lane);
 
-                JudgementHitBurst.Add(judgementHitBurst);
+                JudgementHitBursts.Add(judgementHitBurst);
             }
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -281,9 +281,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBurst[0].OriginalPosY < 0)
-                            for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
-                                playfield.Stage.JudgementHitBurst[i].OriginalPosY *= previewMultiplier;
+                        if (playfield.Stage.JudgementHitBursts[0].OriginalPosY < 0)
+                            for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
+                                playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
 
                         if (playfield.Stage.OriginalComboDisplayY < 0)
                             playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
@@ -293,16 +293,16 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
                         playfield.Stage.HitError.Y -= filterPanelHeight + MenuBorder.HEIGHT;
-                        for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
-                            playfield.Stage.JudgementHitBurst[i].OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
+                        for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
+                            playfield.Stage.JudgementHitBursts[i].OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
                         playfield.Stage.OriginalComboDisplayY -= filterPanelHeight + MenuBorder.HEIGHT;
 
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBurst[0].OriginalPosY < 0)
-                            for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
-                                playfield.Stage.JudgementHitBurst[i].OriginalPosY *= previewMultiplier;
+                        if (playfield.Stage.JudgementHitBursts[0].OriginalPosY < 0)
+                            for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
+                                playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
 
                         if (playfield.Stage.OriginalComboDisplayY < 0)
                             playfield.Stage.OriginalComboDisplayY *= previewMultiplier;

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -281,8 +281,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBurst.OriginalPosY < 0)
-                            playfield.Stage.JudgementHitBurst.OriginalPosY *= previewMultiplier;
+                        if (playfield.Stage.JudgementHitBurst[0].OriginalPosY < 0)
+                            for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
+                                playfield.Stage.JudgementHitBurst[i].OriginalPosY *= previewMultiplier;
 
                         if (playfield.Stage.OriginalComboDisplayY < 0)
                             playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
@@ -292,14 +293,16 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
                         playfield.Stage.HitError.Y -= filterPanelHeight + MenuBorder.HEIGHT;
-                        playfield.Stage.JudgementHitBurst.OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
+                        for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
+                            playfield.Stage.JudgementHitBurst[i].OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
                         playfield.Stage.OriginalComboDisplayY -= filterPanelHeight + MenuBorder.HEIGHT;
 
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBurst.OriginalPosY < 0)
-                            playfield.Stage.JudgementHitBurst.OriginalPosY *= previewMultiplier;
+                        if (playfield.Stage.JudgementHitBurst[0].OriginalPosY < 0)
+                            for (var i = 0; i < playfield.Stage.JudgementHitBurst.Count; i++)
+                                playfield.Stage.JudgementHitBurst[i].OriginalPosY *= previewMultiplier;
 
                         if (playfield.Stage.OriginalComboDisplayY < 0)
                             playfield.Stage.OriginalComboDisplayY *= previewMultiplier;

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -168,6 +168,10 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float JudgementBurstPosY { get; private set; }
 
+        internal bool DisplayJudgementsInEachColumn { get; private set; }
+
+        internal bool RotateJudgements { get; private set; }
+
         [FixedScale]
         internal float HitErrorPosX { get; private set; }
 
@@ -481,6 +485,8 @@ namespace Quaver.Shared.Skinning
             ComboPosX = ConfigHelper.ReadInt32((int) ComboPosX, ini["ComboPosX"]);
             ComboPosY = ConfigHelper.ReadInt32((int) ComboPosY, ini["ComboPosY"]);
             JudgementBurstPosY = ConfigHelper.ReadInt32((int) JudgementBurstPosY, ini["JudgementBurstPosY"]);
+            DisplayJudgementsInEachColumn = ConfigHelper.ReadBool(DisplayJudgementsInEachColumn, ini["DisplayJudgementsInEachColumn"]);
+            RotateJudgements = ConfigHelper.ReadBool(RotateJudgements, ini["RotateJudgements"]);
             HealthBarType = ConfigHelper.ReadEnum(HealthBarType, ini["HealthBarType"]);
             HealthBarKeysAlignment = ConfigHelper.ReadEnum(HealthBarKeysAlignment, ini["HealthBarKeysAlignment"]);
             HealthBarScale = ConfigHelper.ReadInt32((int) HealthBarScale, ini["HealthBarScale"]);


### PR DESCRIPTION
Closes https://github.com/Quaver/Quaver/issues/2674

New skin.ini features : 
- **DisplayJudgementsInEachColumn**
    - As the name indicate, instead of one judgement in the middle, now there is a judgement for each lane, centered on each of them
- **RotateJudgements**
    - Only work if DisplayJudgementsInEachColumn is true. Rotate the judgement based on the lane it is

https://user-images.githubusercontent.com/68703144/184557660-8d40a290-4f97-41dd-9314-490b27ce2dbf.mp4


