### PR TITLE
Make right-clicking on a selection of hitobjects remove all of them

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1289,6 +1289,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (ho == null)
                 return;
 
+            if (SelectedHitObjects.Value.Contains(ho.Info))
+            {
+                ActionManager.EditScreen.DeleteSelectedObjects();
+                return;
+            }
+
             ActionManager.RemoveHitObject(ho.Info);
         }
 


### PR DESCRIPTION
Current behavior is that it removes just the hitobject right clicked on.

Also deletes the group if dragging right click while holding control

Resolves #2072