### PR TITLE
Make rate mods sort first in list

### DIFF
--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -321,7 +321,44 @@ namespace Quaver.Shared.Modifiers
 
                 try
                 {
-                    list.Add(mod);
+                    switch (mod)
+                    {
+                        case ModIdentifier.Speed05X:
+                        case ModIdentifier.Speed055X:
+                        case ModIdentifier.Speed06X:
+                        case ModIdentifier.Speed065X:
+                        case ModIdentifier.Speed07X:
+                        case ModIdentifier.Speed075X:
+                        case ModIdentifier.Speed08X:
+                        case ModIdentifier.Speed085X:
+                        case ModIdentifier.Speed09X:
+                        case ModIdentifier.Speed095X:
+                        case ModIdentifier.Speed105X:
+                        case ModIdentifier.Speed11X:
+                        case ModIdentifier.Speed115X:
+                        case ModIdentifier.Speed12X:
+                        case ModIdentifier.Speed125X:
+                        case ModIdentifier.Speed13X:
+                        case ModIdentifier.Speed135X:
+                        case ModIdentifier.Speed14X:
+                        case ModIdentifier.Speed145X:
+                        case ModIdentifier.Speed15X:
+                        case ModIdentifier.Speed155X:
+                        case ModIdentifier.Speed16X:
+                        case ModIdentifier.Speed165X:
+                        case ModIdentifier.Speed17X:
+                        case ModIdentifier.Speed175X:
+                        case ModIdentifier.Speed18X:
+                        case ModIdentifier.Speed185X:
+                        case ModIdentifier.Speed19X:
+                        case ModIdentifier.Speed195X:
+                        case ModIdentifier.Speed20X:
+                            list.Insert(0, mod);
+                            break;
+                        default:
+                            list.Add(mod);
+                            break;
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Closes https://github.com/Quaver/Quaver/issues/1387
Related Quaver.API PR: https://github.com/Quaver/Quaver.API/pull/134

.05x rates sort with the normal rates
NSV no longer sorts before rate mods

I think this affects pretty much every place mod icons are used, such as map leaderboard, multiplayer lobbies, results screen.
