### PR TITLE
Set current directory to exe location before reading config

### DIFF
--- a/Quaver/Program.cs
+++ b/Quaver/Program.cs
@@ -83,12 +83,12 @@ namespace Quaver
                 SendCrashLog(exception);
             };
 
-            ConfigManager.Initialize();
-            StartIpcServer();
-
             // Change the working directory to where the executable is.
             Directory.SetCurrentDirectory(WorkingDirectory);
             Environment.CurrentDirectory = WorkingDirectory;
+
+            ConfigManager.Initialize();
+            StartIpcServer();
 
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;


### PR DESCRIPTION
Currently, doing a `dotnet run` or `dotnet watch` causes game folders and config to be created in whatever directory I run the command in, which is usually where all the code is. This change makes it so that the folders and config are created/checked in the same directory as the executable so that I don't end up making a mess.