### PR TITLE
Editor: added reset modifiers and automod toggle keybinds

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -761,6 +761,16 @@ namespace Quaver.Shared.Config
         internal static Bindable<Keys> KeyEditorIncreaseAudioRate { get; private set; }
 
         /// <summary>
+        /// The key to reset modifiers in editor
+        /// </summary>
+        internal static Bindable<Keys> KeyEditorResetModifiers { get; private set; }
+
+        /// <summary>
+        ///     The key to open and close automod in editor
+        /// </summary>
+        internal static Bindable<Keys> KeyEditorAutoMod { get; private set; }
+
+        /// <summary>
         /// </summary>
         internal static Bindable<Keys> KeyScreenshot { get; private set; }
 
@@ -970,6 +980,8 @@ namespace Quaver.Shared.Config
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);
+            KeyEditorAutoMod = ReadValue(@"KeyEditorAutoMod", Keys.M, data);
+            KeyEditorResetModifiers = ReadValue(@"KeyEditorResetModifiers", Keys.D0, data);
             EditorEnableHitsounds = ReadValue(@"EditorEnableHitsounds", true, data);
             EditorEnableKeysounds = ReadValue(@"EditorEnableKeysounds", true, data);
             EditorBeatSnapColorType = ReadValue(@"EditorBeatSnapColorType", EditorBeatSnapColor.Default, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -761,7 +761,7 @@ namespace Quaver.Shared.Config
         internal static Bindable<Keys> KeyEditorIncreaseAudioRate { get; private set; }
 
         /// <summary>
-        /// The key to reset modifiers in editor
+        ///     The key to reset modifiers in editor
         /// </summary>
         internal static Bindable<Keys> KeyEditorResetModifiers { get; private set; }
 

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -476,6 +476,7 @@ namespace Quaver.Shared.Screens.Edit
             HandleKeyPressF6();
             HandleKeyPressF10();
             HandleKeyPressShiftH();
+            HandleToggleAutoMod();
         }
 
         /// <summary>
@@ -761,6 +762,20 @@ namespace Quaver.Shared.Screens.Edit
 
             if (KeyboardManager.IsUniqueKeyPress(Keys.I))
                 PlaceTimingPointOrScrollVelocity();
+
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyEditorResetModifiers.Value))
+                ModManager.RemoveSpeedMods();
+        }
+
+        private void HandleToggleAutoMod()
+        {
+            var view = View as EditScreenView;
+
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyEditorAutoMod.Value))
+            {
+                if (view != null)
+                    view.AutoMod.IsActive.Value = !view.AutoMod.IsActive.Value;
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -358,7 +358,9 @@ namespace Quaver.Shared.Screens.Options
                     {
                         new OptionsItemKeybind(containerRect, "Pause/Play Track", ConfigManager.KeyEditorPausePlay),
                         new OptionsItemKeybind(containerRect, "Decrease Playback Rate", ConfigManager.KeyEditorDecreaseAudioRate),
-                        new OptionsItemKeybind(containerRect, "Increase Playback Rate", ConfigManager.KeyEditorIncreaseAudioRate)
+                        new OptionsItemKeybind(containerRect, "Increase Playback Rate", ConfigManager.KeyEditorIncreaseAudioRate),
+                        new OptionsItemKeybind(containerRect, "Toggle AutoMod", ConfigManager.KeyEditorAutoMod),
+                        new OptionsItemKeybind(containerRect, "Resets modifiers", ConfigManager.KeyEditorResetModifiers)
                     }),
                     new OptionsSubcategory("Misc", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -360,7 +360,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemKeybind(containerRect, "Decrease Playback Rate", ConfigManager.KeyEditorDecreaseAudioRate),
                         new OptionsItemKeybind(containerRect, "Increase Playback Rate", ConfigManager.KeyEditorIncreaseAudioRate),
                         new OptionsItemKeybind(containerRect, "Toggle AutoMod", ConfigManager.KeyEditorAutoMod),
-                        new OptionsItemKeybind(containerRect, "Resets modifiers", ConfigManager.KeyEditorResetModifiers)
+                        new OptionsItemKeybind(containerRect, "Reset modifiers", ConfigManager.KeyEditorResetModifiers)
                     }),
                     new OptionsSubcategory("Misc", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Settings/SettingsDialog.cs
+++ b/Quaver.Shared/Screens/Settings/SettingsDialog.cs
@@ -445,7 +445,9 @@ namespace Quaver.Shared.Screens.Settings
                     new SettingsKeybind(this, "Interface - Navigate Down", ConfigManager.KeyNavigateDown),
                     new SettingsKeybind(this, "Editor - Pause/Play Track", ConfigManager.KeyEditorPausePlay),
                     new SettingsKeybind(this, "Editor - Decrease Audio Playback Rate", ConfigManager.KeyEditorDecreaseAudioRate),
-                    new SettingsKeybind(this, "Editor - Increase Audio Playback Rate", ConfigManager.KeyEditorIncreaseAudioRate)
+                    new SettingsKeybind(this, "Editor - Increase Audio Playback Rate", ConfigManager.KeyEditorIncreaseAudioRate),
+                    new SettingsKeybind(this, "Editor - Toggle AutoMod", ConfigManager.KeyEditorAutoMod),
+                    new SettingsKeybind(this, "Editor - Reset modifiers", ConfigManager.KeyEditorResetModifiers)
                 }),
                 // Misc
                 new SettingsSection(this, FontAwesome.Get(FontAwesomeIcon.fa_question_sign), "Miscellaneous", new List<Drawable>


### PR DESCRIPTION
Added new keybinds in editor:
ctrl + 0 - resets modifiers
M - Toggles automod

Both can be changed from Options
