### PR TITLE
Create base keybind config system

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -30,6 +30,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.PlaceBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Dialogs;
 using Quaver.Shared.Screens.Edit.Dialogs.Metadata;
+using Quaver.Shared.Screens.Edit.Input;
 using Quaver.Shared.Screens.Edit.Plugins;
 using Quaver.Shared.Screens.Edit.Plugins.Timing;
 using Quaver.Shared.Screens.Edit.UI;
@@ -227,6 +228,10 @@ namespace Quaver.Shared.Screens.Edit
 
         /// <summary>
         /// </summary>
+        public EditorInputManager InputManager { get; }
+
+        /// <summary>
+        /// </summary>
         public Bindable<SelectContainerPanel> ActiveLeftPanel { get; set; } = new Bindable<SelectContainerPanel>(SelectContainerPanel.MapPreview);
 
         /// <summary>
@@ -281,6 +286,7 @@ namespace Quaver.Shared.Screens.Edit
             AddFileWatcher();
 
             View = new EditScreenView(this);
+            InputManager = new EditorInputManager(this);
         }
 
         /// <inheritdoc />
@@ -447,6 +453,8 @@ namespace Quaver.Shared.Screens.Edit
 
             if (view.IsImGuiHovered)
                 return;
+
+            InputManager.HandleInput();
 
             HandleKeyPressSpace();
             HandleKeyPressPlayfieldZoom();

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -156,9 +156,10 @@ namespace Quaver.Shared.Screens.Edit.Input
                 .IgnoreUnmatchedProperties()
                 .Build();
 
-            EditorInputConfig config;
+            var config = ds.Deserialize<EditorInputConfig>(file);
 
-            config = ds.Deserialize<EditorInputConfig>(file);
+            if (config == null)
+                throw new Exception("Config file is empty");
 
             return config;
         }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -159,7 +159,10 @@ namespace Quaver.Shared.Screens.Edit.Input
             var config = ds.Deserialize<EditorInputConfig>(file);
 
             if (config == null)
-                throw new Exception("Config file is empty");
+            {
+                Logger.Debug("Config file was empty, creating new default", LogType.Runtime);
+                config = new EditorInputConfig();
+            }
 
             return config;
         }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -35,23 +35,19 @@ namespace Quaver.Shared.Screens.Edit.Input
             {
                 Logger.Debug("No editor key config found, using default", LogType.Runtime);
                 config.SaveToConfig();
+                return config;
             }
-            else
-            {
-                try
-                {
-                    using (var file = File.OpenText(ConfigPath))
-                    {
-                        config = Deserialize(file);
-                    }
 
-                    Logger.Debug("Loaded editor key config", LogType.Runtime);
-                    config.SaveToConfig(); // Reformat after loading
-                }
-                catch (Exception e)
-                {
-                    Logger.Error($"Could not load editor key config, using default: {e.Message}", LogType.Runtime);
-                }
+            try
+            {
+                using (var file = File.OpenText(ConfigPath))
+                    config = Deserialize(file);
+                Logger.Debug("Loaded editor key config", LogType.Runtime);
+                config.SaveToConfig(); // Reformat after loading
+            }
+            catch (Exception e)
+            {
+                Logger.Error($"Could not load editor key config, using default: {e.Message}", LogType.Runtime);
             }
 
             return config;

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics.Notifications;
+using Wobble.Logging;
+using Wobble.Platform;
+using YamlDotNet.Serialization;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    [Serializable]
+    public class EditorInputConfig
+    {
+        [YamlIgnore] public static string ConfigPath = ConfigManager.GameDirectory.Value + "/editor_keys.yaml";
+
+        public bool ReverseScrollSeekDirection { get; private set; }
+        public Dictionary<KeybindActions, KeybindList> Keybinds { get; private set; }
+        public Dictionary<string, KeybindList> PluginKeybinds { get; private set; }
+
+        public EditorInputConfig()
+        {
+            ReverseScrollSeekDirection = true;
+            Keybinds = DefaultKeybinds;
+            PluginKeybinds = new Dictionary<string, KeybindList>();
+        }
+
+        public static EditorInputConfig LoadFromConfig()
+        {
+            EditorInputConfig config;
+
+            if (!File.Exists(ConfigPath))
+            {
+                Logger.Debug("No editor key config found, using default", LogType.Runtime);
+                config = new EditorInputConfig();
+            }
+            else
+            {
+                using (var file = File.OpenText(EditorInputConfig.ConfigPath))
+                {
+                    config = EditorInputConfig.Deserialize(file);
+                }
+
+                Logger.Debug("Loaded editor key config", LogType.Runtime);
+            }
+
+            config.SaveToConfig(); // Reformat after loading
+
+            return config;
+        }
+
+        public KeybindList GetOrDefault(KeybindActions action) => Keybinds.GetValueOrDefault(action, new KeybindList());
+
+        public KeybindList GetPluginKeybindOrDefault(string name) => PluginKeybinds.GetValueOrDefault(name, new KeybindList());
+
+        public void AddKeybindToAction(KeybindActions action, Keybind keybind)
+        {
+            if (!Keybinds.ContainsKey(action))
+                Keybinds.Add(action, new KeybindList(keybind));
+            else
+                Keybinds[action].Add(keybind);
+        }
+
+        public bool RemoveKeybindFromAction(KeybindActions action, Keybind keybind)
+        {
+            if (Keybinds.ContainsKey(action))
+                return Keybinds[action].Remove(keybind);
+            return false;
+        }
+
+        public void SaveToConfig()
+        {
+            File.WriteAllText(ConfigPath, Serialize());
+            Logger.Debug("Saved editor key config to file", LogType.Runtime);
+        }
+
+        public void OpenConfigFile()
+        {
+            try
+            {
+                Utils.NativeUtils.OpenNatively(ConfigPath);
+            }
+            catch (Exception e)
+            {
+                NotificationManager.Show(NotificationLevel.Error, "An error occurred while opening the config file.");
+                Logger.Debug(e.ToString(), LogType.Runtime);
+            }
+        }
+
+        public void FillMissingKeys(bool fillWithDefaultBinds)
+        {
+            var count = 0;
+
+            foreach (var (action, defaultBind) in DefaultKeybinds)
+            {
+                if (!Keybinds.ContainsKey(action))
+                {
+                    var bind = fillWithDefaultBinds ? defaultBind : new KeybindList();
+                    Keybinds.Add(action, bind);
+                    count++;
+                }
+            }
+
+            if (count > 0)
+            {
+                SaveToConfig();
+                Logger.Debug($"Filled {count} missing action keybinds in key config file", LogType.Runtime);
+                NotificationManager.Show(NotificationLevel.Success, $"Filled {count} missing action keybinds");
+            }
+            else
+                NotificationManager.Show(NotificationLevel.Info, $"No actions keybinds are missing");
+        }
+
+        public void ResetConfigFile()
+        {
+            ReverseScrollSeekDirection = true;
+            Keybinds = DefaultKeybinds;
+            PluginKeybinds = new Dictionary<string, KeybindList>();
+            SaveToConfig();
+            NotificationManager.Show(NotificationLevel.Success, "Reset all editor keybinds");
+            Logger.Debug("Reset editor keybind config file", LogType.Runtime);
+        }
+
+        public Dictionary<Keybind, HashSet<KeybindActions>> ReverseDictionary()
+        {
+            var dict = new Dictionary<Keybind, HashSet<KeybindActions>>();
+
+            foreach (var (action, keybinds) in Keybinds)
+            {
+                foreach (var keybind in keybinds.MatchingKeybinds())
+                {
+                    if (dict.ContainsKey(keybind))
+                        dict[keybind].Add(action);
+                    else
+                        dict[keybind] = new HashSet<KeybindActions>() {action};
+                }
+            }
+
+            return dict;
+        }
+
+        private static EditorInputConfig Deserialize(StreamReader file)
+        {
+            var ds = new DeserializerBuilder()
+                .WithTypeConverter(new KeybindYamlTypeConverter())
+                .IgnoreUnmatchedProperties()
+                .Build();
+
+            var config = ds.Deserialize<EditorInputConfig>(file);
+
+            return config;
+        }
+
+        private string Serialize()
+        {
+            var serializer = new SerializerBuilder()
+                .WithEventEmitter(next => new KeybindListYamlFlowStyle(next))
+                .WithTypeConverter(new KeybindYamlTypeConverter())
+                .DisableAliases()
+                .Build();
+
+            var stringWriter = new StringWriter {NewLine = "\r\n"};
+            serializer.Serialize(stringWriter, this);
+            return stringWriter.ToString();
+        }
+
+        [YamlIgnore] public static Dictionary<KeybindActions, KeybindList> DefaultKeybinds = new Dictionary<KeybindActions, KeybindList>();
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -78,8 +78,15 @@ namespace Quaver.Shared.Screens.Edit.Input
 
         public void SaveToConfig()
         {
-            File.WriteAllText(ConfigPath, Serialize());
-            Logger.Debug("Saved editor key config to file", LogType.Runtime);
+            try
+            {
+                File.WriteAllText(ConfigPath, Serialize());
+                Logger.Debug("Saved editor key config to file", LogType.Runtime);
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e.ToString(), LogType.Runtime);
+            }
         }
 
         public void OpenConfigFile()

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -45,6 +45,10 @@ namespace Quaver.Shared.Screens.Edit.Input
                 Logger.Debug("Loaded editor key config", LogType.Runtime);
                 config.SaveToConfig(); // Reformat after loading
             }
+            catch (YamlException e)
+            {
+                Logger.Error($"Could not load editor key config, using default: Failed to parse configuration in line {e.Start.Line}", LogType.Runtime);
+            }
             catch (Exception e)
             {
                 Logger.Error($"Could not load editor key config, using default: {e.Message}", LogType.Runtime);
@@ -154,14 +158,7 @@ namespace Quaver.Shared.Screens.Edit.Input
 
             EditorInputConfig config;
 
-            try
-            {
-                config = ds.Deserialize<EditorInputConfig>(file);
-            }
-            catch (YamlException e)
-            {
-                throw new Exception($"Failed to parse configuration in line {e.Start.Line}");
-            }
+            config = ds.Deserialize<EditorInputConfig>(file);
 
             return config;
         }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -179,7 +179,6 @@ namespace Quaver.Shared.Screens.Edit.Input
 
         [YamlIgnore] public static Dictionary<KeybindActions, KeybindList> DefaultKeybinds = new Dictionary<KeybindActions, KeybindList>()
         {
-            { KeybindActions.DebugAction, new KeybindList(KeyModifiers.Ctrl, Keys.Enter) }
         };
     }
 }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using Quaver.Shared.Config;
-using Quaver.Shared.Graphics.Notifications;
 using Wobble.Logging;
 using Wobble.Platform;
 using YamlDotNet.Serialization;
@@ -82,7 +81,6 @@ namespace Quaver.Shared.Screens.Edit.Input
             }
             catch (Exception e)
             {
-                NotificationManager.Show(NotificationLevel.Error, "An error occurred while opening the config file.");
                 Logger.Debug(e.ToString(), LogType.Runtime);
             }
         }
@@ -105,10 +103,7 @@ namespace Quaver.Shared.Screens.Edit.Input
             {
                 SaveToConfig();
                 Logger.Debug($"Filled {count} missing action keybinds in key config file", LogType.Runtime);
-                NotificationManager.Show(NotificationLevel.Success, $"Filled {count} missing action keybinds");
             }
-            else
-                NotificationManager.Show(NotificationLevel.Info, $"No actions keybinds are missing");
         }
 
         public void ResetConfigFile()
@@ -117,7 +112,6 @@ namespace Quaver.Shared.Screens.Edit.Input
             Keybinds = DefaultKeybinds;
             PluginKeybinds = new Dictionary<string, KeybindList>();
             SaveToConfig();
-            NotificationManager.Show(NotificationLevel.Success, "Reset all editor keybinds");
             Logger.Debug("Reset editor keybind config file", LogType.Runtime);
         }
 

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -90,7 +90,7 @@ namespace Quaver.Shared.Screens.Edit.Input
             }
             catch (Exception e)
             {
-                Logger.Debug(e.ToString(), LogType.Runtime);
+                Logger.Error(e.ToString(), LogType.Runtime);
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Xna.Framework.Input;
 using Quaver.Shared.Config;
 using Wobble.Logging;
 using Wobble.Platform;
@@ -158,6 +159,9 @@ namespace Quaver.Shared.Screens.Edit.Input
             return stringWriter.ToString();
         }
 
-        [YamlIgnore] public static Dictionary<KeybindActions, KeybindList> DefaultKeybinds = new Dictionary<KeybindActions, KeybindList>();
+        [YamlIgnore] public static Dictionary<KeybindActions, KeybindList> DefaultKeybinds = new Dictionary<KeybindActions, KeybindList>()
+        {
+            { KeybindActions.DebugAction, new KeybindList(KeyModifiers.Ctrl, Keys.Enter) }
+        };
     }
 }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -1,0 +1,147 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Quaver.Shared.Screens.Edit.Dialogs;
+using Quaver.Shared.Screens.Edit.Plugins;
+using Quaver.Shared.Screens.Edit.UI;
+using Quaver.Shared.Screens.Edit.UI.Playfield.Waveform;
+using Wobble;
+using Wobble.Graphics;
+using Wobble.Graphics.UI.Dialogs;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    public class EditorInputManager
+    {
+        public EditorInputConfig InputConfig { get; }
+        public EditScreen Screen { get; }
+        private EditScreenView View { get; }
+
+        private Dictionary<Keybind, HashSet<KeybindActions>> KeybindDictionary;
+        private GenericKeyState PreviousKeyState;
+
+        private const int HoldRepeatActionDelay = 250;
+        private const int HoldRepeatActionInterval = 25;
+        private Dictionary<KeybindActions, long> LastActionPress = new Dictionary<KeybindActions, long>();
+        private Dictionary<KeybindActions, long> LastActionTime = new Dictionary<KeybindActions, long>();
+
+        private static HashSet<KeybindActions> HoldRepeatActions = new HashSet<KeybindActions>()
+        {
+        };
+
+        private static HashSet<KeybindActions> HoldAndReleaseActions = new HashSet<KeybindActions>()
+        {
+        };
+
+        private static HashSet<KeybindActions> EnabledActionsDuringGameplayPreview = new HashSet<KeybindActions>()
+        {
+        };
+
+        public EditorInputManager(EditScreen screen)
+        {
+            InputConfig = EditorInputConfig.LoadFromConfig();
+            KeybindDictionary = InputConfig.ReverseDictionary();
+            PreviousKeyState = new GenericKeyState(GenericKeyManager.GetPressedKeys());
+            Screen = screen;
+        }
+
+        public void HandleInput()
+        {
+            if (DialogManager.Dialogs.Count != 0) return;
+            var view = (EditScreenView)Screen.View;
+            if (view.IsImGuiHovered) return;
+
+            HandleKeypresses();
+            HandleKeyReleasesAfterHoldAction();
+            HandlePluginKeypresses();
+
+            HandleMouseInputs();
+        }
+
+        private void HandleKeypresses()
+        {
+            var keyState = new GenericKeyState(GenericKeyManager.GetPressedKeys());
+            var uniqueKeypresses = keyState.UniqueKeypresses(PreviousKeyState);
+            foreach (var pressedKeybind in keyState.PressedKeybinds())
+            {
+                HashSet<KeybindActions> actions;
+
+                if (!KeybindDictionary.TryGetValue(pressedKeybind, out actions)) continue;
+
+                foreach (var action in actions)
+                {
+                    if (uniqueKeypresses.Contains(pressedKeybind))
+                    {
+                        HandleAction(action);
+                        LastActionPress[action] = GameBase.Game.TimeRunning;
+                    }
+                    else if (CanRepeat(action))
+                        HandleAction(action);
+                    else if (CanHold(action))
+                        HandleAction(action, false);
+                }
+            }
+
+            PreviousKeyState = keyState;
+        }
+
+        private void HandleKeyReleasesAfterHoldAction()
+        {
+            foreach (var action in HoldAndReleaseActions)
+            {
+                var binds = InputConfig.GetOrDefault(action);
+                if (binds.IsNotBound()) continue;
+
+                if (binds.IsUniqueRelease())
+                    HandleAction(action, false, true);
+            }
+        }
+
+        private long TimeSinceLastPress(KeybindActions action) => GameBase.Game.TimeRunning - LastActionPress.GetValueOrDefault(action, GameBase.Game.TimeRunning);
+        private long TimeSinceLastAction(KeybindActions action) => GameBase.Game.TimeRunning - LastActionTime.GetValueOrDefault(action, GameBase.Game.TimeRunning);
+
+        private bool CanRepeat(KeybindActions action)
+        {
+            if (!HoldRepeatActions.Contains(action))
+                return false;
+
+            return TimeSinceLastAction(action) > HoldRepeatActionInterval && TimeSinceLastPress(action) > HoldRepeatActionDelay;
+        }
+
+        private bool CanHold(KeybindActions action)
+        {
+            if (!HoldAndReleaseActions.Contains(action))
+                return false;
+
+            return TimeSinceLastAction(action) > HoldRepeatActionInterval;
+        }
+
+        private void HandleAction(KeybindActions action, bool isKeypress = true, bool isRelease = false)
+        {
+            switch (action)
+            {
+                // Action cases
+
+                default:
+                    return;
+            }
+
+            LastActionTime[action] = GameBase.Game.TimeRunning;
+        }
+
+        private void HandleMouseInputs()
+        {
+        }
+
+        private void HandlePluginKeypresses()
+        {
+            foreach (var (pluginName, keybinds) in InputConfig.PluginKeybinds)
+            {
+                if (keybinds.IsUniquePress())
+                {
+                    // Toggle plugin
+                }
+            }
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -122,9 +122,6 @@ namespace Quaver.Shared.Screens.Edit.Input
             switch (action)
             {
                 // Action cases
-                case KeybindActions.DebugAction:
-                    NotificationManager.Show(NotificationLevel.Info, "Debug action was activated");
-                    break;
                 default:
                     return;
             }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -52,17 +52,17 @@ namespace Quaver.Shared.Screens.Edit.Input
             if (DialogManager.Dialogs.Count != 0) return;
             if (View.IsImGuiHovered) return;
 
-            HandleKeypresses();
+            HandleKeyPresses();
             HandleKeyReleasesAfterHoldAction();
-            HandlePluginKeypresses();
+            HandlePluginKeyPresses();
 
             HandleMouseInputs();
         }
 
-        private void HandleKeypresses()
+        private void HandleKeyPresses()
         {
             var keyState = new GenericKeyState(GenericKeyManager.GetPressedKeys());
-            var uniqueKeypresses = keyState.UniqueKeypresses(PreviousKeyState);
+            var uniqueKeyPresses = keyState.UniqueKeyPresses(PreviousKeyState);
             foreach (var pressedKeybind in keyState.PressedKeybinds())
             {
                 HashSet<KeybindActions> actions;
@@ -71,7 +71,7 @@ namespace Quaver.Shared.Screens.Edit.Input
 
                 foreach (var action in actions)
                 {
-                    if (uniqueKeypresses.Contains(pressedKeybind))
+                    if (uniqueKeyPresses.Contains(pressedKeybind))
                     {
                         HandleAction(action);
                         LastActionPress[action] = GameBase.Game.TimeRunning;
@@ -117,7 +117,7 @@ namespace Quaver.Shared.Screens.Edit.Input
             return TimeSinceLastAction(action) > HoldRepeatActionInterval;
         }
 
-        private void HandleAction(KeybindActions action, bool isKeypress = true, bool isRelease = false)
+        private void HandleAction(KeybindActions action, bool isKeyPress = true, bool isRelease = false)
         {
             switch (action)
             {
@@ -136,7 +136,7 @@ namespace Quaver.Shared.Screens.Edit.Input
         {
         }
 
-        private void HandlePluginKeypresses()
+        private void HandlePluginKeyPresses()
         {
             foreach (var (pluginName, keybinds) in InputConfig.PluginKeybinds)
             {

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Screens.Edit.Dialogs;
 using Quaver.Shared.Screens.Edit.Plugins;
 using Quaver.Shared.Screens.Edit.UI;
@@ -43,13 +44,13 @@ namespace Quaver.Shared.Screens.Edit.Input
             KeybindDictionary = InputConfig.ReverseDictionary();
             PreviousKeyState = new GenericKeyState(GenericKeyManager.GetPressedKeys());
             Screen = screen;
+            View = (EditScreenView)screen.View;
         }
 
         public void HandleInput()
         {
             if (DialogManager.Dialogs.Count != 0) return;
-            var view = (EditScreenView)Screen.View;
-            if (view.IsImGuiHovered) return;
+            if (View.IsImGuiHovered) return;
 
             HandleKeypresses();
             HandleKeyReleasesAfterHoldAction();
@@ -121,7 +122,9 @@ namespace Quaver.Shared.Screens.Edit.Input
             switch (action)
             {
                 // Action cases
-
+                case KeybindActions.DebugAction:
+                    NotificationManager.Show(NotificationLevel.Info, "Debug action was activated");
+                    break;
                 default:
                     return;
             }

--- a/Quaver.Shared/Screens/Edit/Input/GenericKeyState.cs
+++ b/Quaver.Shared/Screens/Edit/Input/GenericKeyState.cs
@@ -36,10 +36,10 @@ namespace Quaver.Shared.Screens.Edit.Input
             return set;
         }
 
-        public HashSet<Keybind> UniqueKeypresses(GenericKeyState previousState)
+        public HashSet<Keybind> UniqueKeyPresses(GenericKeyState previousState)
         {
-            var newKeypresses = Pressed.Except(previousState.Pressed);
-            var uniqueKeyState = new GenericKeyState(Modifiers, newKeypresses);
+            var newKeyPresses = Pressed.Except(previousState.Pressed);
+            var uniqueKeyState = new GenericKeyState(Modifiers, newKeyPresses);
             return uniqueKeyState.PressedKeybinds();
         }
 

--- a/Quaver.Shared/Screens/Edit/Input/GenericKeyState.cs
+++ b/Quaver.Shared/Screens/Edit/Input/GenericKeyState.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+using Wobble.Input;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    public class GenericKeyState
+    {
+        public HashSet<KeyModifiers> Modifiers {get;}
+        public HashSet<GenericKey> Pressed {get;}
+
+        public GenericKeyState(IEnumerable<GenericKey> keys)
+        {
+            Modifiers = new HashSet<KeyModifiers>();
+            Pressed = new HashSet<GenericKey>(keys);
+
+            CheckForModifier(Keys.LeftControl, KeyModifiers.Ctrl);
+            CheckForModifier(Keys.RightControl, KeyModifiers.Ctrl);
+            CheckForModifier(Keys.LeftAlt, KeyModifiers.Alt);
+            CheckForModifier(Keys.RightAlt, KeyModifiers.Alt);
+            CheckForModifier(Keys.LeftShift, KeyModifiers.Shift);
+            CheckForModifier(Keys.RightShift, KeyModifiers.Shift);
+        }
+
+        public GenericKeyState(HashSet<KeyModifiers> modifiers, IEnumerable<GenericKey> pressed)
+        {
+            Modifiers = modifiers;
+            Pressed = new HashSet<GenericKey>(pressed);
+        }
+
+        public HashSet<Keybind> PressedKeybinds()
+        {
+            var set = new HashSet<Keybind>();
+            foreach (var key in Pressed) set.Add(new Keybind(Modifiers, key));
+            return set;
+        }
+
+        public HashSet<Keybind> UniqueKeypresses(GenericKeyState previousState)
+        {
+            var newKeypresses = Pressed.Except(previousState.Pressed);
+            var uniqueKeyState = new GenericKeyState(Modifiers, newKeypresses);
+            return uniqueKeyState.PressedKeybinds();
+        }
+
+        private void CheckForModifier(Keys key, KeyModifiers modifier)
+        {
+            var genericKey = new GenericKey() {KeyboardKey = key};
+            if (Pressed.Contains(genericKey))
+            {
+                Pressed.Remove(genericKey);
+                Modifiers.Add(modifier);
+            }
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/KeyModifiers.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeyModifiers.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    [Serializable]
+    public enum KeyModifiers
+    {
+        Ctrl,
+        Shift,
+        Alt,
+        Free
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/Keybind.cs
+++ b/Quaver.Shared/Screens/Edit/Input/Keybind.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+using Wobble.Input;
+using Wobble.Logging;
+using YamlDotNet.Serialization;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    [Serializable]
+    public class Keybind
+    {
+        [YamlIgnore] public static Keybind None = new Keybind(Keys.None);
+
+        public HashSet<KeyModifiers> Modifiers { get; } = new HashSet<KeyModifiers>();
+        public GenericKey Key { get; } = new GenericKey() {KeyboardKey = Keys.None};
+
+        public Keybind(string notation)
+        {
+            var keys = notation.Trim().Split("+").Select(s => s.Trim());
+            foreach (var keyString in keys)
+            {
+                KeyModifiers mod;
+                if (Enum.TryParse(keyString, out mod))
+                    Modifiers.Add(mod);
+                else if (Key.KeyboardKey == Keys.None)
+                {
+                    GenericKey parsed;
+                    if (GenericKey.TryParse(keyString, out parsed))
+                        Key = parsed;
+                    else
+                        Logger.Error($"Encountered unknown key name {keyString} during keybind parsing", LogType.Runtime);
+                }
+            }
+        }
+
+        public Keybind(Keys key) => Key = new GenericKey() {KeyboardKey = key};
+
+        public Keybind(KeyModifiers mod, Keys key)
+        {
+            Key = new GenericKey() {KeyboardKey = key};
+            Modifiers.Add(mod);
+        }
+
+        public Keybind(ICollection<KeyModifiers> mods, Keys key)
+        {
+            Key = new GenericKey() {KeyboardKey = key};
+            Modifiers = new HashSet<KeyModifiers>(mods);
+        }
+
+        public Keybind(ICollection<KeyModifiers> mods, GenericKey key)
+        {
+            Key = key;
+            Modifiers = new HashSet<KeyModifiers>(mods);
+        }
+
+        public HashSet<Keybind> MatchingKeybinds()
+        {
+            var set = new HashSet<Keybind>();
+
+            if (!Modifiers.Contains(KeyModifiers.Free))
+                set.Add(this);
+            else
+            {
+                var allModifiers = Enum.GetValues(typeof(KeyModifiers)).Cast<KeyModifiers>();
+                var freeModifiers = allModifiers.Except(Modifiers).ToList();
+                foreach (var modifiers in PowerSetOfModifiers(freeModifiers))
+                    set.Add(new Keybind(modifiers, Key));
+            }
+
+            return set;
+        }
+
+        private HashSet<HashSet<KeyModifiers>> PowerSetOfModifiers(List<KeyModifiers> modifiers)
+        {
+            var powerSetLength = (int)Math.Pow(2, modifiers.Count());
+            var powerSet = new HashSet<HashSet<KeyModifiers>>(powerSetLength);
+
+            for (int bitMask = 0; bitMask < powerSetLength; bitMask++)
+            {
+                var subSet = new HashSet<KeyModifiers>(modifiers.Where(x => ((1 << modifiers.IndexOf(x)) & bitMask) != 0));
+                powerSet.Add(subSet);
+            }
+
+            return powerSet;
+        }
+
+        private bool ModifiersAreCorrect()
+        {
+            var currentState = new HashSet<KeyModifiers>();
+
+            if (KeyboardManager.IsCtrlDown()) currentState.Add(KeyModifiers.Ctrl);
+            if (KeyboardManager.IsAltDown()) currentState.Add(KeyModifiers.Alt);
+            if (KeyboardManager.IsShiftDown()) currentState.Add(KeyModifiers.Shift);
+
+            if (!Modifiers.Contains(KeyModifiers.Free))
+            {
+                return Modifiers.SetEquals(currentState);
+            }
+            else
+            {
+                currentState.Add(KeyModifiers.Free);
+                return Modifiers.IsSubsetOf(currentState);
+            }
+        }
+
+        public bool IsUniquePress() => ModifiersAreCorrect() && GenericKeyManager.IsUniquePress(Key);
+        public bool IsUniqueRelease() => ModifiersAreCorrect() && GenericKeyManager.IsUniqueRelease(Key);
+
+        public bool IsDown() => ModifiersAreCorrect() && GenericKeyManager.IsDown(Key);
+
+        public bool IsUp() => !IsDown();
+
+        public override string ToString()
+        {
+            var keys = Modifiers.Select(m => m.ToString()).ToList();
+            keys.Add(Key.ToString());
+            return String.Join('+', keys);
+        }
+
+        protected bool Equals(Keybind other) => ToString() == other.ToString();
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Keybind)obj);
+        }
+
+        public override int GetHashCode() => ToString().GetHashCode();
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    [Serializable]
+    public enum KeybindActions
+    {
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
@@ -5,5 +5,6 @@ namespace Quaver.Shared.Screens.Edit.Input
     [Serializable]
     public enum KeybindActions
     {
+        DebugAction
     }
 }

--- a/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
@@ -5,6 +5,5 @@ namespace Quaver.Shared.Screens.Edit.Input
     [Serializable]
     public enum KeybindActions
     {
-        DebugAction
     }
 }

--- a/Quaver.Shared/Screens/Edit/Input/KeybindList.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindList.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    [Serializable]
+    public class KeybindList : HashSet<Keybind>
+    {
+        public KeybindList() => Add(new Keybind(Keys.None));
+
+        public KeybindList(string notation) : base(notation.Split(',').Select(s => new Keybind(s)))
+        {
+        }
+
+        public KeybindList(Keys key) => Add(new Keybind(key));
+        public KeybindList(KeyModifiers mod, Keys key) => Add(new Keybind(mod, key));
+        public KeybindList(Keybind keybind) => Add(keybind);
+
+        public KeybindList(List<string> binds) : base(binds.Select(b => new Keybind(b)))
+        {
+        }
+
+        public KeybindList(IEnumerable<Keybind> keybinds) : base(keybinds)
+        {
+        }
+
+        new public void Add(Keybind keybind)
+        {
+            if (Equals(keybind, Keybind.None)) return;
+
+            if (Count == 1 && Contains(Keybind.None)) Remove(Keybind.None);
+            base.Add(keybind);
+        }
+
+        new public bool Remove(Keybind keybind)
+        {
+            if (Equals(keybind, Keybind.None)) return false;
+
+            var result = base.Remove(keybind);
+            if (Count == 0) Add(Keybind.None);
+
+            return result;
+        }
+
+        public bool IsNotBound() => Count == 1 && Contains(Keybind.None);
+
+        public HashSet<Keybind> MatchingKeybinds()
+        {
+            var binds = new HashSet<Keybind>();
+            foreach (var keybind in this) binds.UnionWith(keybind.MatchingKeybinds());
+            return binds;
+        }
+
+        public bool IsUniquePress() => this.Any(k => k.IsUniquePress());
+        public bool IsUniqueRelease() => this.Any(k => k.IsUniqueRelease());
+        public bool IsDown() => this.Any(k => k.IsDown());
+        public bool IsUp() => this.Any(k => k.IsUp());
+        public override string ToString() => String.Join(", ", this.Where(k => !k.Equals(Keybind.None)).Select(k => k.ToString()));
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/KeybindListYamlFlowStyle.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindListYamlFlowStyle.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    public sealed class KeybindListYamlFlowStyle : ChainedEventEmitter
+    {
+        public KeybindListYamlFlowStyle(IEventEmitter nextEmitter) : base(nextEmitter)
+        {
+        }
+
+        public override void Emit(SequenceStartEventInfo eventInfo, IEmitter emitter)
+        {
+            if (typeof(IEnumerable<Keybind>).IsAssignableFrom(eventInfo.Source.Type))
+                eventInfo = new SequenceStartEventInfo(eventInfo.Source) {Style = SequenceStyle.Flow};
+            nextEmitter.Emit(eventInfo, emitter);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Input/KeybindYamlTypeConverter.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindYamlTypeConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Quaver.Shared.Screens.Edit.Input
+{
+    internal sealed class KeybindYamlTypeConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type) => type == typeof(Keybind);
+
+        public object ReadYaml(IParser parser, Type type)
+        {
+            if (!parser.Accept<Scalar>()) return Keybind.None;
+            var scalar = parser.Current as Scalar;
+            if (scalar == null) return Keybind.None;
+
+            var result = new Keybind(scalar.Value);
+            parser.MoveNext();
+
+            return result;
+        }
+
+        public void WriteYaml(IEmitter emitter, object value, Type type) =>
+            emitter.Emit(new Scalar(null, ((Keybind)value).ToString()));
+    }
+}


### PR DESCRIPTION
## Keybind rules

- Left/Right modifiers keys are generalized into a single modifier variant
- Keybinds consist of one non-modifier key and any number of modifiers
- If the number of pressed modifiers does not exactly match, it will not match the keybind (Shift+Alt+S does not match Shift+S)
  - The "Free" modifier removes that condition and will match even if excess modifiers are pressed
  - If other modifiers are used along with the free modifier, the other modifiers must be pressed

## Configuration file

- Uses YAML format that (de)serializes the EditorInputConfig class
- File format is laid out in action->keybinds
- Uses custom serializing for the Keybind by parsing from/into its string representation using [KeybindYamlTypeConverter](https://github.com/Quaver/Quaver/pull/3688/files#diff-a0763781deb6d4468d823e2911a81583dc8c67c9694a90775d0f4f75f96453a6)
- Uses custom list style for the KeybindList deserialization using [KeybindListYamlFlowStyle](https://github.com/Quaver/Quaver/pull/3688/files#diff-d7c0b69eb6a9714403e11dbfa34044c3e826a8ec379aa640132a315142ee97e2)

## Keybind matching system

- Uses a generalized key state and gets all matched keybinds by comparing the current and previous state
  - Uses a reverse dictionary of keybind->actions to match the keybinds
  - A previous, more intuitive system that iterates over the action->keybinds dictionary and checks for unique keypresses for each action on each frame is inefficient, the FPS difference is 950 to 1050 on my setup

## Press/Hold/Release actions

- The time since the last keypress for an action and the time since the last execution of an action are recorded.
- Actions defined in `EditorInputManager.HoldRepeatActions`, are repeated in an interval after being held a certain amount of time. This is used in the future for seeking or zooming.
- Actions defined in `EditorInputManager.HoldAndReleaseActions` can be held and are executed on every frame the key is held down, and finally when the key is released. The states are mainly used for (long) note placement in the future.
- HandleAction() receives isPress and isRelease in order to check whether the currently executed action is a press, hold or release.

## Actions added in the subsequent updates

If actions are added in the future, they will not be added to the config automatically. An option will be provided to the user to fill missing actions either unbound or with the new default binds in the editor interface, using `EditorInputConfig.FillMissingKeys(bool fillWithDefaultBinds)`.

## Adding new keybind actions

1. Add new enum item in the `KeybindActions`
2. Add new default keybind in `EditorInputConfig.DefaultKeybinds`
3. Add new case in `EditorInputManager.HandleAction()`