### PR TITLE
Improve performance of certain SV effects

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -124,13 +124,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     The position at which the next Hit Object must be at in order to add a new Hit Object to the pool.
         ///     TODO: Update upon scroll speed changes
         /// </summary>
-        public float CreateObjectPosition { get; private set; }
+        public float CreateObjectThreshold { get; private set; }
 
         /// <summary>
         ///     The position at which the earliest Hit Object must be at before its recycled.
         ///     TODO: Update upon scroll speed changes
         /// </summary>
-        public float RecycleObjectPosition { get; private set; }
+        public float RecycleObjectThreshold { get; private set; }
 
         /// <summary>
         ///     Current position for Hit Objects.
@@ -474,7 +474,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Add more hit objects to the pool if necessary
             foreach (var lane in HitObjectQueueLanes)
             {
-                while (lane.Count > 0 && CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime) > CreateObjectPosition)
+                while (lane.Count > 0 && Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectThreshold)
                 {
                     CreatePoolObject(lane.Dequeue());
                 }
@@ -631,7 +631,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             foreach (var lane in DeadNoteLanes)
             {
                 while (lane.Count > 0 &&
-                    (CurrentTrackPosition - lane.Peek().LatestTrackPosition > RecycleObjectPosition))
+                    Math.Abs(CurrentTrackPosition - lane.Peek().LatestTrackPosition) > RecycleObjectThreshold)
                 {
                     RecyclePoolObject(lane.Dequeue());
                 }
@@ -672,8 +672,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         private void UpdatePoolingPositions()
         {
-            RecycleObjectPosition = (ObjectPositionMagnitude / 4) / ScrollSpeed;
-            CreateObjectPosition = -ObjectPositionMagnitude / ScrollSpeed;
+            RecycleObjectThreshold = ObjectPositionMagnitude / ScrollSpeed;
+            CreateObjectThreshold = ObjectPositionMagnitude / ScrollSpeed;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -480,8 +480,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Add more hit objects to the pool if necessary
             foreach (var lane in HitObjectQueueLanes)
             {
-                while (lane.Count > 0 && (Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectPositionThreshold ||
-                       lane.Peek().StartTime - CurrentAudioPosition < CreateObjectTimeThreshold))
+                while (lane.Count > 0 && ((Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectPositionThreshold) ||
+                      (lane.Peek().StartTime - CurrentAudioPosition < CreateObjectTimeThreshold)))
                 {
                     CreatePoolObject(lane.Dequeue());
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -124,13 +124,19 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     The position at which the next Hit Object must be at in order to add a new Hit Object to the pool.
         ///     TODO: Update upon scroll speed changes
         /// </summary>
-        public float CreateObjectThreshold { get; private set; }
+        public float CreateObjectPositionThreshold { get; private set; }
 
         /// <summary>
         ///     The position at which the earliest Hit Object must be at before its recycled.
         ///     TODO: Update upon scroll speed changes
         /// </summary>
-        public float RecycleObjectThreshold { get; private set; }
+        public float RecycleObjectPositionThreshold { get; private set; }
+
+        /// <summary>
+        ///     A new hitobject is added to the pool if the next one is needs to be hit within this many milliseconds
+        ///     TODO: Update upon scroll speed changes
+        /// </summary>
+        public float CreateObjectTimeThreshold { get; private set; }
 
         /// <summary>
         ///     Current position for Hit Objects.
@@ -474,7 +480,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Add more hit objects to the pool if necessary
             foreach (var lane in HitObjectQueueLanes)
             {
-                while (lane.Count > 0 && Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectThreshold)
+                while (lane.Count > 0 && (Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectPositionThreshold) ||
+                       lane.Peek().StartTime - CurrentAudioPosition < CreateObjectTimeThreshold)
                 {
                     CreatePoolObject(lane.Dequeue());
                 }
@@ -631,7 +638,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             foreach (var lane in DeadNoteLanes)
             {
                 while (lane.Count > 0 &&
-                    Math.Abs(CurrentTrackPosition - lane.Peek().LatestTrackPosition) > RecycleObjectThreshold)
+                    Math.Abs(CurrentTrackPosition - lane.Peek().LatestTrackPosition) > RecycleObjectPositionThreshold)
                 {
                     RecyclePoolObject(lane.Dequeue());
                 }
@@ -672,8 +679,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         private void UpdatePoolingPositions()
         {
-            RecycleObjectThreshold = ObjectPositionMagnitude / ScrollSpeed;
-            CreateObjectThreshold = ObjectPositionMagnitude / ScrollSpeed;
+            RecycleObjectPositionThreshold = ObjectPositionMagnitude / ScrollSpeed;
+            CreateObjectPositionThreshold = ObjectPositionMagnitude / ScrollSpeed;
+
+            CreateObjectTimeThreshold = ObjectPositionMagnitude / ScrollSpeed / TrackRounding;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -480,8 +480,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // Add more hit objects to the pool if necessary
             foreach (var lane in HitObjectQueueLanes)
             {
-                while (lane.Count > 0 && (Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectPositionThreshold) ||
-                       lane.Peek().StartTime - CurrentAudioPosition < CreateObjectTimeThreshold)
+                while (lane.Count > 0 && (Math.Abs(CurrentTrackPosition - GetPositionFromTime(lane.Peek().StartTime)) < CreateObjectPositionThreshold ||
+                       lane.Peek().StartTime - CurrentAudioPosition < CreateObjectTimeThreshold))
                 {
                     CreatePoolObject(lane.Dequeue());
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -120,7 +120,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
                     var offset = HitObjectManager.GetPositionFromTime(songPos);
 
                     // Do not initialize any timing lines that do not appear in gameplay
-                    if (!(HitObjectManager.CurrentTrackPosition - offset > HitObjectManager.RecycleObjectThreshold && songPos < HitObjectManager.CurrentAudioPosition))
+                    if (!(HitObjectManager.CurrentTrackPosition - offset > HitObjectManager.RecycleObjectPositionThreshold && songPos < HitObjectManager.CurrentAudioPosition))
                         temp.Add(new TimingLineInfo(songPos, offset));
                 }
             }
@@ -145,9 +145,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
             while (Info.Count > 0)
             {
-                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectThreshold)
+                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectPositionThreshold)
                     Info.Dequeue();
-                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectThreshold)
+                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectPositionThreshold)
                     CreatePoolObject(Info.Dequeue());
                 else
                     break;
@@ -167,7 +167,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             }
 
             // Recycle necessary pool objects
-            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectThreshold && Pool.Peek().Info.StartTime < HitObjectManager.CurrentAudioPosition)
+            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectPositionThreshold && Pool.Peek().Info.StartTime < HitObjectManager.CurrentAudioPosition)
             {
                 var line = Pool.Dequeue();
                 if (Info.Count > 0)
@@ -179,7 +179,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             }
 
             // Create new pool objects if they are in range
-            while (Info.Count > 0 && HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectThreshold)
+            while (Info.Count > 0 && HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectPositionThreshold)
                 CreatePoolObject(Info.Dequeue());
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -120,7 +120,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
                     var offset = HitObjectManager.GetPositionFromTime(songPos);
 
                     // Do not initialize any timing lines that do not appear in gameplay
-                    if (!(HitObjectManager.CurrentTrackPosition - offset > HitObjectManager.RecycleObjectPosition && songPos < HitObjectManager.CurrentAudioPosition))
+                    if (!(HitObjectManager.CurrentTrackPosition - offset > HitObjectManager.RecycleObjectThreshold && songPos < HitObjectManager.CurrentAudioPosition))
                         temp.Add(new TimingLineInfo(songPos, offset));
                 }
             }
@@ -145,9 +145,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
             while (Info.Count > 0)
             {
-                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectPosition)
+                if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.RecycleObjectThreshold)
                     Info.Dequeue();
-                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
+                else if (HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectThreshold)
                     CreatePoolObject(Info.Dequeue());
                 else
                     break;
@@ -167,7 +167,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             }
 
             // Recycle necessary pool objects
-            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectPosition && Pool.Peek().Info.StartTime < HitObjectManager.CurrentAudioPosition)
+            while (Pool.Count > 0 && Pool.Peek().CurrentTrackPosition > HitObjectManager.RecycleObjectThreshold && Pool.Peek().Info.StartTime < HitObjectManager.CurrentAudioPosition)
             {
                 var line = Pool.Dequeue();
                 if (Info.Count > 0)
@@ -179,7 +179,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             }
 
             // Create new pool objects if they are in range
-            while (Info.Count > 0 && HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset > HitObjectManager.CreateObjectPosition)
+            while (Info.Count > 0 && HitObjectManager.CurrentTrackPosition - Info.Peek().TrackOffset < HitObjectManager.CreateObjectThreshold)
                 CreatePoolObject(Info.Dequeue());
         }
 


### PR DESCRIPTION
Fixes #3658, #3728
Partially addresses #3674

Game no longer adds a hitobject to the hitobject pool for each note past the receptors, now one is only added for each note past the receptors that is also within some distance of them. This makes it so that the game doesn't try to add 1000 objects to the pool when the map teleports a bajillion units forward and back, like in [Drater's Elevator](https://quavergame.com/mapset/map/71929).

The hitobject recycling threshold is set to be the same as the hitobject creation threshold so that missed notes don't disappear early if the map is scrolling in reverse with a slow user scroll speed. Similar to the change with the creation threshold, the recycling threshold was changed to affect notes a distance above the receptors, so that notes missed in a reverse scrolling section can eventually be recycled.

Fixes #2777

In addition to the position-based threshold for adding hitobjects to the pool, a time-based threshold has been added so that far-away notes that need to be hit soon are still loaded. This prevents a rare bug where missing certain notes in an SV map that contains "invisible" notes could prevent the loading of all notes in a lane.