### PR TITLE
Improve scrolling performance in song select

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -260,7 +260,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateTitle()
         {
-            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "SONG TITLE", 26)
+            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "SONG TITLE", 26, false)
             {
                 Parent = this,
                 Position = new ScalableVector2(TitleX, 18),
@@ -274,7 +274,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateArtist()
         {
-            Artist = new SpriteTextPlus(Title.Font, "Artist", 20)
+            Artist = new SpriteTextPlus(Title.Font, "Artist", 20, false)
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
@@ -310,7 +310,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 UsePreviousSpriteBatchOptions = true
             };
 
-            Creator = new SpriteTextPlus(Title.Font, "Creator", Artist.FontSize)
+            Creator = new SpriteTextPlus(Title.Font, "Creator", Artist.FontSize, false)
             {
                 Parent = this,
                 Position = new ScalableVector2(ByText.X + ByText.Width + ArtistCreatorSpacingX, Artist.Y),
@@ -368,7 +368,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateDifficultyName()
         {
-            DifficultyName = new SpriteTextPlus(Title.Font, "Difficulty", 20)
+            DifficultyName = new SpriteTextPlus(Title.Font, "Difficulty", 20, false)
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Artist.Y),


### PR DESCRIPTION
Requires https://github.com/Quaver/Wobble/pull/128

Fixes #3433

Disable caching for text that frequently changes while scrolling through song select. Idk how well scrolling will work with ice's 43k maps, but absolute scrolling works pretty well now with my 6k maps.