### PR TITLE
Fix effect volume not being consistent with the global volume when changed

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -434,7 +434,7 @@ namespace Quaver.Shared
                 AudioSample.GlobalVolume = e.Value * ConfigManager.VolumeEffect.Value / 100f;
             };
             ConfigManager.VolumeMusic.ValueChanged += (sender, e) => AudioTrack.GlobalVolume = ConfigManager.VolumeGlobal.Value * e.Value / 100f;
-            ConfigManager.VolumeEffect.ValueChanged += (sender, e) => AudioSample.GlobalVolume = ConfigManager.VolumeEffect.Value * e.Value / 100f;
+            ConfigManager.VolumeEffect.ValueChanged += (sender, e) => AudioSample.GlobalVolume = ConfigManager.VolumeGlobal.Value * e.Value / 100f;
 
             ConfigManager.Pitched.ValueChanged += (sender, e) =>
             {


### PR DESCRIPTION
Fixes a bug that caused the effect volume to be louder than it should be when changed. (#1958 and #2878)