### PR TITLE
Fix osu difficulty names breaking uploading mapsets

### DIFF
--- a/Quaver.Shared/Converters/Osu/Osu.cs
+++ b/Quaver.Shared/Converters/Osu/Osu.cs
@@ -77,6 +77,8 @@ namespace Quaver.Shared.Converters.Osu
                     switch (Path.GetExtension(tempFile).ToLower())
                     {
                         case ".qua":
+                            File.Move(tempFile, $"{extractDirectory}/{Guid.NewGuid()}.qua");
+                            break;
                         case ".mp3":
                         case ".jpg":
                         case ".png":


### PR DESCRIPTION
When importing new osu beatmap it will rename the difficulty names to uuid (easier/safer) instead using their original name.