### PR TITLE
Log response from server

### DIFF
--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorUploadingMapsetDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorUploadingMapsetDialog.cs
@@ -59,6 +59,8 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
 
                 var path = MapManager.Selected.Value.Mapset.ExportToZip(false);
                 var response = OnlineManager.Client.UploadMapset(path);
+                
+                Logger.Important(response.ToString(), LogType.Network);
 
                 var folderPath = $"{ConfigManager.SongDirectory.Value}/{screen.Map.Directory}";
 


### PR DESCRIPTION
Few people complained they have issues with uploading their mapsets. 
Would be good to have the response from the server in the logs for better debugging.