### PR TITLE
Reimplement text caching in song select

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -95,6 +95,20 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         public Sprite OnlineGrade { get; set; }
 
+        private bool _isCached = true;
+        public bool IsCached
+        {
+            get => _isCached;
+            set
+            {
+                if (value == _isCached)
+                    return;
+
+                SetCaching(value);
+                _isCached = value;
+            }
+        }
+
         /// <summary>
         /// </summary>
         /// <param name="mapset"></param>
@@ -260,7 +274,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateTitle()
         {
-            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "SONG TITLE", 26, false)
+            Title = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "SONG TITLE", 26)
             {
                 Parent = this,
                 Position = new ScalableVector2(TitleX, 18),
@@ -274,7 +288,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateArtist()
         {
-            Artist = new SpriteTextPlus(Title.Font, "Artist", 20, false)
+            Artist = new SpriteTextPlus(Title.Font, "Artist", 20)
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Title.Y + Title.Height + 5),
@@ -310,7 +324,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 UsePreviousSpriteBatchOptions = true
             };
 
-            Creator = new SpriteTextPlus(Title.Font, "Creator", Artist.FontSize, false)
+            Creator = new SpriteTextPlus(Title.Font, "Creator", Artist.FontSize)
             {
                 Parent = this,
                 Position = new ScalableVector2(ByText.X + ByText.Width + ArtistCreatorSpacingX, Artist.Y),
@@ -368,7 +382,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         /// </summary>
         private void CreateDifficultyName()
         {
-            DifficultyName = new SpriteTextPlus(Title.Font, "Difficulty", 20, false)
+            DifficultyName = new SpriteTextPlus(Title.Font, "Difficulty", 20)
             {
                 Parent = this,
                 Position = new ScalableVector2(Title.X, Artist.Y),
@@ -592,6 +606,17 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 
             Logger.Important($"User opened mapset: {ParentMapset.Item.Artist} - {ParentMapset.Item.Title}", LogType.Runtime, false);
             MapManager.SelectMapFromMapset(ParentMapset.Item);
+        }
+
+        /// <summary>
+        ///     Enables/disables caching of frequently changed strings
+        /// </summary>
+        private void SetCaching(bool cache)
+        {
+            Title.IsCached = cache;
+            Artist.IsCached = cache;
+            Creator.IsCached = cache;
+            DifficultyName.IsCached = cache;
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -115,10 +115,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             TimeElapsedUntilInitializationRequest += gameTime.ElapsedGameTime.TotalMilliseconds;
             InitializeMapsets(false);
 
-            // disable caching of frequently changing text if scrolling fast enough
+            // Disable caching of frequently changing text if scrolling fast enough
+            // Caching stays disabled until scrolling stops to prevent repeated recaching when scroll speed fluctuates
             var deltaY = CurrentY - PreviousY;
             var speed = Math.Abs(deltaY) / gameTime.ElapsedGameTime.TotalMilliseconds;
-            IsCached = speed <= CacheThreshold;
+            IsCached = !(speed > CacheThreshold || (!IsCached && speed != 0));
 
             base.Update(gameTime);
         }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -80,6 +80,15 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             }
         }
 
+        /// <summary>
+        ///     Caching is disabled when the scroll speed exceeds this value.
+        ///     This value should be low enough to disable caching when selecting a random mapset, absolute scrolling, mashing PgUp/PgDn,
+        ///     but should be high enough to avoid disabling caching when up/down are mashed.
+        ///
+        ///     Units: change in y-position / milliseconds since last update
+        /// </summary>
+        public double CacheThreshold { get; } = 100;
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -106,7 +115,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             TimeElapsedUntilInitializationRequest += gameTime.ElapsedGameTime.TotalMilliseconds;
             InitializeMapsets(false);
 
-            IsCached = !IsMiddleMouseDragging;
+            // disable caching of frequently changing text if scrolling fast enough
+            var deltaY = CurrentY - PreviousY;
+            var speed = Math.Abs(deltaY) / gameTime.ElapsedGameTime.TotalMilliseconds;
+            IsCached = speed <= CacheThreshold;
 
             base.Update(gameTime);
         }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -63,6 +63,23 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             }
         }
 
+        /// <summary>
+        ///     Whether frequently changing text is being cached or not
+        /// </summary>
+        private bool _isCached = true;
+        public bool IsCached
+        {
+            get => _isCached;
+            private set
+            {
+                if (value == _isCached)
+                    return;
+
+                SetCaching(value);
+                _isCached = value;
+            }
+        }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -88,6 +105,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         {
             TimeElapsedUntilInitializationRequest += gameTime.ElapsedGameTime.TotalMilliseconds;
             InitializeMapsets(false);
+
+            IsCached = !IsMiddleMouseDragging;
 
             base.Update(gameTime);
         }
@@ -349,5 +368,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
             var mapsetNotSelected = MiddleMapset != null && MiddleMapset.Item.Maps.First() != MapManager.Selected.Value;
             return mapsetNotSelected && GetCurrentlySelectedMapset() == null;
         }
+
+        private void SetCaching(bool cache) => Pool.ForEach(mapset => ((DrawableMapset)mapset).DrawableContainer.IsCached = cache);
     }
 }


### PR DESCRIPTION
Requires https://github.com/Quaver/Wobble/pull/129

Frequently changing text is cached if there is little to no scrolling going on. Caching is still disabled when scrolling really fast, such as when using middle click or selecting a random mapset. 

Also happens to fix the issue with blurry non-cached text that Yalter mentioned in [#3737](https://github.com/Quaver/Quaver/pull/3737#issuecomment-1382933110) by just avoiding the problem like before lol