### PR TITLE
Add and implement skinning Judgement Burst Pos X

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -565,7 +565,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 {
                     Parent = Playfield.ForegroundContainer,
                     Alignment = Alignment.MidCenter,
-                    X = skin.DisplayJudgementsInEachColumn ? Receptors[lane].X - playfieldOffset : 0
+                    X = skin.DisplayJudgementsInEachColumn ? Receptors[lane].X - playfieldOffset : (skin.JudgementBurstPosX)
                 };
 
                 if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -565,7 +565,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 {
                     Parent = Playfield.ForegroundContainer,
                     Alignment = Alignment.MidCenter,
-                    X = skin.DisplayJudgementsInEachColumn ? Receptors[lane].X - playfieldOffset : (skin.JudgementBurstPosX)
+                    X = skin.DisplayJudgementsInEachColumn ? (Receptors[lane].X - playfieldOffset) : skin.JudgementBurstPosX
                 };
 
                 if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -166,6 +166,9 @@ namespace Quaver.Shared.Skinning
         internal float ComboDisplayScale { get; private set; }
 
         [FixedScale]
+        internal float JudgementBurstPosX { get; private set; }
+
+        [FixedScale]
         internal float JudgementBurstPosY { get; private set; }
 
         internal bool DisplayJudgementsInEachColumn { get; private set; }
@@ -484,6 +487,7 @@ namespace Quaver.Shared.Skinning
             KpsDisplayPosY = ConfigHelper.ReadInt32((int) KpsDisplayPosY, ini["KpsDisplayPosY"]);
             ComboPosX = ConfigHelper.ReadInt32((int) ComboPosX, ini["ComboPosX"]);
             ComboPosY = ConfigHelper.ReadInt32((int) ComboPosY, ini["ComboPosY"]);
+            JudgementBurstPosX = ConfigHelper.ReadInt32((int)JudgementBurstPosX, ini["JudgementBurstPosX"]);
             JudgementBurstPosY = ConfigHelper.ReadInt32((int) JudgementBurstPosY, ini["JudgementBurstPosY"]);
             DisplayJudgementsInEachColumn = ConfigHelper.ReadBool(DisplayJudgementsInEachColumn, ini["DisplayJudgementsInEachColumn"]);
             RotateJudgements = ConfigHelper.ReadBool(RotateJudgements, ini["RotateJudgements"]);


### PR DESCRIPTION
Add JudgementBurstPosX to be modified on skin.ini.
JudgementBurstPosX  is the X Offset of the judgement hit burst.
Only take an effect when DisplayJudgementsInEachColumn is false.