### PR TITLE
Fix failing replays

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/GameplayRuleset.cs
@@ -134,7 +134,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets
         }
 
         /// <summary>
-        ///     Polls <see cref="ScoreProcessor"/> and updates <see cref="StandardizedReplayPlayer"/>
+        ///     Polls <see cref="ReplayCapturer"/> and updates <see cref="StandardizedReplayPlayer"/>
         ///     with the standardized scoring values
         /// </summary>
         public void UpdateStandardizedScoreProcessor(bool force = false)

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -212,21 +212,25 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 // Handle early miss cases here.
                 case Judgement.Miss when info.IsLongNote:
                     // Add another miss when hit missing LNS
-                    ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(Judgement.Miss, true);
-                    Ruleset.ScoreProcessor.Stats.Add(
-                        new HitStat(
-                            HitStatType.Miss,
-                            KeyPressType.Press,
-                            info.HitObjectInfo, time,
-                            Judgement.Miss,
-                            time,
-                            Ruleset.ScoreProcessor.Accuracy,
-                            Ruleset.ScoreProcessor.Health
-                        ));
+                    if (ReplayInputManager == null)
+                    {
+                        ((ScoreProcessorKeys)Ruleset.ScoreProcessor).CalculateScore(Judgement.Miss, true);
 
-                    view.UpdateScoreboardUsers();
-                    view.UpdateScoreAndAccuracyDisplays();
-                    playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
+                        Ruleset.ScoreProcessor.Stats.Add(
+                            new HitStat(
+                                HitStatType.Miss,
+                                KeyPressType.Press,
+                                info.HitObjectInfo, time,
+                                Judgement.Miss,
+                                int.MinValue,
+                                Ruleset.ScoreProcessor.Accuracy,
+                                Ruleset.ScoreProcessor.Health
+                            ));
+
+                        view.UpdateScoreboardUsers();
+                        view.UpdateScoreAndAccuracyDisplays();
+                        playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
+                    }
 
                     info.State = HitObjectState.Dead;
                     break;

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -671,7 +671,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // The release window. (Window * Multiplier)
             var window = Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay] * Ruleset.ScoreProcessor.WindowReleaseMultiplier[Judgement.Okay];
 
-            // Check to see if any LN releases were missed (Counts as an okay instead of a miss.)
+            // Check to see if any LN releases were missed (Counts as a good instead of a miss.)
             foreach (var lane in HeldLongNoteLanes)
             {
                 while (lane.Count > 0 && (int)CurrentAudioOffset > lane.Peek().EndTime + window)


### PR DESCRIPTION
Hitmissing LNs were causing an extra miss judgement's worth of damage in replays

Fixes #2331
Fixes #3518 

Regarding #3518, it looks like scoring is precomputed, so the hit differences shouldn't have an effect(?). I don't think the spectating replay differences are caused by this.