### PR TITLE
Close stale issues and PR action

### DIFF
--- a/.github/workflows/close-stale-issues-and-pr.yml
+++ b/.github/workflows/close-stale-issues-and-pr.yml
@@ -1,0 +1,18 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 2 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
+          days-before-stale: 2
+          days-before-close: 7
+          days-before-pr-close: -1
+          any-of-labels: 'needs-op-response'

--- a/.github/workflows/close-stale-issues-and-pr.yml
+++ b/.github/workflows/close-stale-issues-and-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v8
         with:
           stale-issue-message: 'This issue is stale because it has been open 2 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 7 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 2 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           days-before-stale: 2
           days-before-close: 7

--- a/.github/workflows/close-stale-issues-and-pr.yml
+++ b/.github/workflows/close-stale-issues-and-pr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v8
         with:
           stale-issue-message: 'This issue is stale because it has been open 2 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 7 days with no activity.'
           close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity.'
           days-before-stale: 2
           days-before-close: 7


### PR DESCRIPTION
It will close as stale issues and PRs if:
The label "needs op response" is added
2 days are passed

It will close the issue if 7 days are passed.
PRs won't be closed.