### PR TITLE
Add an option to unlock windows key during gameplay

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -407,6 +407,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> SkipResultsScreenAfterQuit { get; private set; }
 
         /// <summary>
+        /// If true, the windows key is locked during gameplay
+        /// </summary>
+        internal static Bindable<bool> LockWinkeyDuringGameplay { get; private set; }
+
+        /// <summary>
         ///     If true, it'll use hitobjects specifically for viewing layers in the editor.
         /// </summary>
         internal static Bindable<bool> EditorViewLayers { get; private set; }
@@ -1006,6 +1011,7 @@ namespace Quaver.Shared.Config
             DisplayJudgementCounter = ReadValue(@"DisplayJudgementCounter", true, data);
             HitErrorFadeTime = ReadInt(@"HitErrorFadeTime", 1000, 100, 5000, data);
             SkipResultsScreenAfterQuit = ReadValue(@"SkipResultsScreenAfterQuit", false, data);
+            LockWinkeyDuringGameplay = ReadValue(@"LockWinkeyDuringGameplay", true, data);
             DisplayComboAlerts = ReadValue(@"DisplayComboAlerts", true, data);
             LaneCoverTopHeight = ReadInt(@"LaneCoverTopHeight", 25, 0, 75, data);
             LaneCoverBottomHeight = ReadInt(@"LaneCoverBottomHeight", 25, 0, 75, data);

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -478,7 +478,7 @@ namespace Quaver.Shared.Screens.Gameplay
             if (ReplayCapturer != null)
                 ReplayCapturer.Replay.TimePlayed = TimePlayed;
 
-            if (!InReplayMode)
+            if (!InReplayMode && ConfigManager.LockWinkeyDuringGameplay.Value)
                 Utils.NativeUtils.DisableWindowsKey();
 
             base.OnFirstUpdate();

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -214,7 +214,8 @@ namespace Quaver.Shared.Screens.Options
                     {
                         new OptionsItemCheckbox(containerRect, "Enable Tap To Pause", ConfigManager.TapToPause),
                         new OptionsItemCheckbox(containerRect, "Enable Tap To Restart", ConfigManager.TapToRestart),
-                        new OptionsItemCheckbox(containerRect, "Skip Results Screen After Quitting", ConfigManager.SkipResultsScreenAfterQuit)
+                        new OptionsItemCheckbox(containerRect, "Skip Results Screen After Quitting", ConfigManager.SkipResultsScreenAfterQuit),
+                        new OptionsItemCheckbox(containerRect, "Lock Windows Key during gameplay", ConfigManager.LockWinkeyDuringGameplay)
                     }),
                     new OptionsSubcategory("User Interface", new List<OptionsItem>()
                     {


### PR DESCRIPTION
I personally want the winkey to be available to me to switch the keyboard layout (winkey + space) :)
Set the default to `true` to keep the behavior as close to original as possible. Ideally, nothing should be broken by this change,