### PR TITLE
Add support for per-lane hitlights.

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -594,7 +594,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
                 var scale = Skin.HitLightingScale / 100;
 
-                hl.Image = Skin.HitLighting.First();
+                hl.Image = Skin.NoteHitLighting[i].First();
                 hl.Size = new ScalableVector2(hl.Image.Width * scale, hl.Image.Height * scale);
 
                 var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, hl.RelativeRectangle,

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -46,7 +46,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         /// </summary>
         public HitLighting(GameplayPlayfieldKeys playfield, int columnIndex)
-            : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitLighting)
+            : base(SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].NoteHitLighting[columnIndex])
         {
             Playfield = playfield;
             ColumnIndex = columnIndex;
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 Tint = Color.White;
 
             // First begin by replacing the frames
-            ReplaceFrames(IsHoldingLongNote ? skin.HoldLighting : skin.HitLighting);
+            ReplaceFrames(IsHoldingLongNote ? skin.NoteHoldLighting[ColumnIndex] : skin.NoteHitLighting[ColumnIndex]);
 
             // Go to the first frame and reset each of the properties
             ChangeTo(0);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -355,12 +355,12 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> HitLighting { get; private set; } = new List<Texture2D>();
+        internal List<List<Texture2D>> NoteHitLighting { get; } = new List<List<Texture2D>>();
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> HoldLighting { get; private set; } = new List<Texture2D>();
+        internal List<List<Texture2D>> NoteHoldLighting { get; } = new List<List<Texture2D>>();
 
         // ----- Lane Covers ----- //
 
@@ -546,8 +546,6 @@ namespace Quaver.Shared.Skinning
         {
             #region LIGHTING
             ColumnLighting = LoadTexture(SkinKeysFolder.Lighting, "column-lighting", false);
-            HitLighting = LoadSpritesheet(SkinKeysFolder.Lighting, "hitlighting", false, 0, 0);
-            HoldLighting = LoadSpritesheet(SkinKeysFolder.Lighting, "holdlighting", false, 0, 0);
             #endregion
 
             #region STAGE
@@ -675,6 +673,34 @@ namespace Quaver.Shared.Skinning
         private string GetResourcePath(string element) => $"{element}";
 
         /// <summary>
+        ///     Loads hit and holdlights
+        /// </summary>
+        /// <param name="lightingOjects"></param>
+        /// <param name="type">Either hitlighting or holdlighting</param>
+        /// <param name="lane"></param>
+        /// <returns></returns>
+        private void LoadLighting(List<List<Texture2D>> lightingObjects, string type, int lane)
+        {
+            var mode = ModeHelper.ToShortHand(Mode).ToLower();
+
+            if (!Directory.Exists($"{Store.Dir}/{mode}"))
+                return;
+            
+            var folder = $"{Store.Dir}/{mode}/Lighting";
+
+            // Check for lane-specific lighting; otherwise, load general lighting for the lane
+            if (Directory.EnumerateFiles(folder).Any(f => f.Contains($"{type}-{lane}")))
+            {
+                lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, $"{type}-{lane}", false, 0, 0));
+            }
+            else
+            {
+                lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, $"{type}", false, 0, 0));
+            }
+        }
+
+
+        /// <summary>
         ///     Loads elements that rely on the lane.
         /// </summary>
         private void LoadLaneSpecificElements()
@@ -718,6 +744,10 @@ namespace Quaver.Shared.Skinning
                 // Receptors
                 NoteReceptorsUp.Add(LoadTexture(SkinKeysFolder.Receptors, $"receptor-up-{i + 1}", false));
                 NoteReceptorsDown.Add(LoadTexture(SkinKeysFolder.Receptors, $"receptor-down-{i + 1}", false));
+
+                // Hitlights
+                LoadLighting(NoteHitLighting, "hitlighting", i + 1);
+                LoadLighting(NoteHoldLighting, "holdlighting", i + 1);
 
                 // Editor
                 EditorLayerNoteHitObjects.Add(LoadTexture(SkinKeysFolder.Editor, $"note-hitobject-{i + 1}", false));

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using IniFileParser;
 using IniFileParser.Model;
 using Microsoft.Xna.Framework;
@@ -673,7 +674,7 @@ namespace Quaver.Shared.Skinning
         private string GetResourcePath(string element) => $"{element}";
 
         /// <summary>
-        ///     Loads hit and holdlights
+        ///     Loads hit and holdlights.
         /// </summary>
         /// <param name="lightingOjects"></param>
         /// <param name="type">Either hitlighting or holdlighting</param>
@@ -683,20 +684,21 @@ namespace Quaver.Shared.Skinning
         {
             var mode = ModeHelper.ToShortHand(Mode).ToLower();
 
-            if (!Directory.Exists($"{Store.Dir}/{mode}"))
-                return;
-            
-            var folder = $"{Store.Dir}/{mode}/Lighting";
+            // If the skin supports the gamemode.
+            if (Directory.Exists($"{Store.Dir}/{mode}"))
+            {
+                var folder = $"{Store.Dir}/{mode}/Lighting";
+                var pattern = type + @"-" + lane + @"@\dx\d\.png$";
 
-            // Check for lane-specific lighting; otherwise, load general lighting for the lane
-            if (Directory.EnumerateFiles(folder).Any(f => f.Contains($"{type}-{lane}")))
-            {
-                lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, $"{type}-{lane}", false, 0, 0));
+                // Check for lane-specific lighting.
+                if (Directory.EnumerateFiles(folder).Any(f => Regex.IsMatch(f, pattern)))
+                {
+                    lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, $"{type}-{lane}", false, 0, 0));
+                    return;
+                }
             }
-            else
-            {
-                lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, $"{type}", false, 0, 0));
-            }
+            // Load normal/legacy lighting if neither previous statements were true.
+            lightingObjects.Add(LoadSpritesheet(SkinKeysFolder.Lighting, type, false, 0, 0));
         }
 
 


### PR DESCRIPTION
Introduce the ability to skin hit and holdlights for individual lanes using the file naming convention "hitlighting-{lane}@{rows}x{columns}.png". If a file with the previous method for lighting is present, it will be loaded for any lanes that do not have a dedicated lighting spritesheet, allowing for full support of currently existing skins.