### PR TITLE
Add the Ability to Swap Lanes of Selected HitObjects

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -20,6 +20,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap;
 using Quaver.Shared.Screens.Edit.Actions.Hitsounds.Add;
 using Quaver.Shared.Screens.Edit.Actions.Hitsounds.Remove;
 using Quaver.Shared.Screens.Edit.Actions.Layers.Colors;
@@ -115,6 +116,12 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Event invoked when a batch of hitobjects have been flipped
         /// </summary>
         public event EventHandler<EditorHitObjectsFlippedEventArgs> HitObjectsFlipped;
+
+
+        /// <summary>
+        ///     Event invoked when a batch of hitobjects have been swapped between 2 lanes
+        /// </summary>
+        public event EventHandler<EditorLanesSwappedEventArgs> LanesSwapped;
 
         /// <summary>
         ///     Event invoked when a batch of hitobjects have been reversed
@@ -647,6 +654,9 @@ namespace Quaver.Shared.Screens.Edit.Actions
                 case EditorActionType.FlipHitObjects:
                     HitObjectsFlipped?.Invoke(this, (EditorHitObjectsFlippedEventArgs)args);
                     break;
+                case EditorActionType.SwapLanes:
+                    LanesSwapped?.Invoke(this, (EditorLanesSwappedEventArgs)args);
+                    break;
                 case EditorActionType.MoveHitObjects:
                     HitObjectsMoved?.Invoke(this, (EditorHitObjectsMovedEventArgs)args);
                     break;
@@ -756,6 +766,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             HitObjectBatchRemoved = null;
             HitObjectBatchPlaced = null;
             HitObjectsFlipped = null;
+            LanesSwapped = null;
             HitObjectsMoved = null;
             HitsoundAdded = null;
             HitsoundRemoved = null;

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionType.cs
@@ -9,6 +9,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
         RemoveHitObjectBatch,
         PlaceHitObjectBatch,
         FlipHitObjects,
+        SwapLanes,
         MoveHitObjects,
         AddHitsound,
         RemoveHitsound,

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorActionSwapLanes.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorActionSwapLanes.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Quaver.API.Maps;
+using Quaver.API.Maps.Structures;
+
+namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap
+{
+    public class EditorActionSwapLanes : IEditorAction
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public EditorActionType Type { get; } = EditorActionType.SwapLanes;
+
+        /// <summary>
+        /// </summary>
+        private EditorActionManager ActionManager { get; }
+
+        /// <summary>
+        /// </summary>
+        private Qua WorkingMap { get; }
+
+        /// <summary>
+        /// </summary>
+        private List<HitObjectInfo> HitObjects { get; }
+
+        private int SwapLane1 { get; }
+        private int SwapLane2 { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="actionManager"></param>
+        /// <param name="workingMap"></param>
+        /// <param name="hitObjects"></param>
+        /// <param name="swapLane1"></param>
+        /// <param name="swapLane2"></param>
+        public EditorActionSwapLanes(EditorActionManager actionManager, Qua workingMap, List<HitObjectInfo> hitObjects,
+            int swapLane1, int swapLane2)
+        {
+            ActionManager = actionManager;
+            WorkingMap = workingMap;
+            HitObjects = hitObjects;
+            SwapLane1 = swapLane1;
+            SwapLane2 = swapLane2;
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Perform()
+        {
+            foreach (var h in HitObjects)
+            {
+                if (h.Lane == SwapLane1)
+                    h.Lane = SwapLane2;
+                else if (h.Lane == SwapLane2)
+                    h.Lane = SwapLane1;
+            }
+
+            ActionManager.TriggerEvent(EditorActionType.SwapLanes, new EditorLanesSwappedEventArgs(HitObjects, SwapLane1, SwapLane2));
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public void Undo() => Perform();
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorLanesSwappedEventArgs.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorLanesSwappedEventArgs.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Quaver.API.Maps.Structures;
+
+namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap
+{
+    public class EditorLanesSwappedEventArgs : EventArgs
+    {
+        public List<HitObjectInfo> HitObjects { get; }
+
+        private int SwapLane1 { get; }
+        private int SwapLane2 { get; }
+
+        public EditorLanesSwappedEventArgs(List<HitObjectInfo> hitObjects, int swapLane1, int swapLane2)
+        {
+            HitObjects = hitObjects;
+            SwapLane1 = swapLane1;
+            SwapLane2 = swapLane2;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -223,6 +223,21 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.MenuItem("Flip Objects", "CTRL + H", false, Screen.SelectedHitObjects.Value.Count > 0))
                 Screen.FlipSelectedObjects();
 
+            if (ImGui.BeginMenu("Swap Lanes of Objects", Screen.SelectedHitObjects.Value.Count > 0))
+            {
+                for (var i = 1; i <= Screen.WorkingMap.GetKeyCount(); i++)
+                {
+                    for (var j = i + 1; j <= Screen.WorkingMap.GetKeyCount(); j++)
+                    {
+                        if (ImGui.MenuItem($"Lane {i} and {j}", $"ALT + {i} + {j}"))
+                        {
+                            Screen.SwapSelectedObjects(i, j);
+                        }
+                    }
+                }
+                ImGui.EndMenu();
+            }
+
             if (ImGui.BeginMenu($"Move Objects To Layer", Screen.SelectedHitObjects.Value.Count > 0))
             {
                 if (ImGui.MenuItem("Default Layer", ""))

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -227,12 +227,18 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             {
                 for (var i = 1; i <= Screen.WorkingMap.GetKeyCount(); i++)
                 {
-                    for (var j = i + 1; j <= Screen.WorkingMap.GetKeyCount(); j++)
-                    {
-                        if (ImGui.MenuItem($"Lane {i} and {j}", $"ALT + {i} + {j}"))
+                    if (ImGui.BeginMenu($"Lane {i}"))
+                    { 
+                        for (var j = 1; j <= Screen.WorkingMap.GetKeyCount(); j++)
                         {
-                            Screen.SwapSelectedObjects(i, j);
+                            if (i == j) continue;
+                            if (ImGui.MenuItem($"Lane {j}", $"ALT + {i} + {j}"))
+                            {
+                                Screen.SwapSelectedObjects(i, j);
+                            }
                         }
+
+                        ImGui.EndMenu();
                     }
                 }
                 ImGui.EndMenu();

--- a/Quaver.Shared/Screens/Edit/UI/Panels/EditorPanelDetails.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Panels/EditorPanelDetails.cs
@@ -15,6 +15,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap;
 using Wobble.Audio.Tracks;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -99,6 +100,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
+            ActionManager.LanesSwapped += OnLanesSwapped;
             ActionManager.HitObjectsReversed += OnHitObjectsReversed;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
             ActionManager.HitObjectsResnapped += OnHitObjectsResnapped;
@@ -120,6 +122,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
             ActionManager.HitObjectBatchPlaced -= OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved -= OnHitObjectBatchRemoved;
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
+            ActionManager.LanesSwapped -= OnLanesSwapped;
             ActionManager.HitObjectsReversed -= OnHitObjectsReversed;
             ActionManager.HitObjectsMoved -= OnHitObjectsMoved;
             ActionManager.HitObjectsResnapped -= OnHitObjectsResnapped;
@@ -297,6 +300,13 @@ namespace Quaver.Shared.Screens.Edit.UI.Panels
         /// <param name="e"></param>
         /// <exception cref="NotImplementedException"></exception>
         private void OnHitObjectsFlipped(object sender, EditorHitObjectsFlippedEventArgs e) => UpdateObjects();
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        private void OnLanesSwapped(object sender, EditorLanesSwappedEventArgs e) => UpdateObjects();
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -25,6 +25,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap;
 using Quaver.Shared.Screens.Edit.Actions.Timing.Add;
 using Quaver.Shared.Screens.Edit.Actions.Timing.AddBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpm;
@@ -358,6 +359,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
+            ActionManager.LanesSwapped += OnLanesSwapped;
             ActionManager.HitObjectsReversed += OnHitObjectsReversed;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
             ActionManager.HitObjectsResnapped += OnHitObjectsResnapped;
@@ -465,6 +467,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ActionManager.HitObjectBatchRemoved -= OnHitObjectBatchRemoved;
             ActionManager.HitObjectBatchPlaced -= OnHitObjectBatchPlaced;
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
+            ActionManager.LanesSwapped -= OnLanesSwapped;
             ActionManager.HitObjectsReversed -= OnHitObjectsReversed;
             ActionManager.HitObjectsMoved -= OnHitObjectsMoved;
             ActionManager.HitObjectsResnapped -= OnHitObjectsResnapped;
@@ -983,6 +986,19 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnHitObjectsFlipped(object sender, EditorHitObjectsFlippedEventArgs e)
+        {
+            if (IsUneditable)
+                return;
+
+            RefreshHitObjectBatch(e.HitObjects);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        /// <exception cref="NotImplementedException"></exception>
+        private void OnLanesSwapped(object sender, EditorLanesSwappedEventArgs e)
         {
             if (IsUneditable)
                 return;

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Seek/EditorDifficultySeekBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Seek/EditorDifficultySeekBar.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.Remove;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap;
 using Wobble.Audio.Tracks;
 using Wobble.Graphics;
 
@@ -30,6 +31,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Seek
             ActionManager.HitObjectRemoved += OnHitObjectRemoved;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
+            ActionManager.LanesSwapped += OnLanesSwapped;
             ActionManager.HitObjectsReversed += OnHitObjectsReversed;
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
@@ -45,6 +47,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Seek
             ActionManager.HitObjectRemoved -= OnHitObjectRemoved;
             ActionManager.HitObjectsMoved -= OnHitObjectsMoved;
             ActionManager.HitObjectsFlipped -= OnHitObjectsFlipped;
+            ActionManager.LanesSwapped -= OnLanesSwapped;
             ActionManager.HitObjectsReversed -= OnHitObjectsReversed;
             ActionManager.HitObjectBatchPlaced -= OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved -= OnHitObjectBatchRemoved;
@@ -61,6 +64,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Seek
         private void OnHitObjectsMoved(object sender, EditorHitObjectsMovedEventArgs e) => Refresh();
 
         private void OnHitObjectsFlipped(object sender, EditorHitObjectsFlippedEventArgs e) => Refresh();
+
+        private void OnLanesSwapped(object sender, EditorLanesSwappedEventArgs e) => Refresh();
 
         private void OnHitObjectsReversed(object sender, EditorHitObjectsReversedEventArgs e) => Refresh();
 

--- a/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
@@ -9,6 +9,7 @@ using Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Resnap;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse;
+using Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap;
 using Quaver.Shared.Screens.Edit.Actions.SV.Add;
 using Quaver.Shared.Screens.Edit.Actions.SV.AddBatch;
 using Quaver.Shared.Screens.Edit.Actions.SV.ChangeMultiplierBatch;
@@ -58,6 +59,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
             ActionManager.HitObjectRemoved += OnHitObjectRemoved;
             ActionManager.HitObjectsMoved += OnHitObjectsMoved;
             ActionManager.HitObjectsFlipped += OnHitObjectsFlipped;
+            ActionManager.LanesSwapped += OnLanesSwapped;
             ActionManager.HitObjectsReversed += OnHitObjectsReversed;
             ActionManager.HitObjectBatchPlaced += OnHitObjectBatchPlaced;
             ActionManager.HitObjectBatchRemoved += OnHitObjectBatchRemoved;
@@ -135,6 +137,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
         private void OnHitObjectsMoved(object sender, EditorHitObjectsMovedEventArgs e) => Refresh();
 
         private void OnHitObjectsFlipped(object sender, EditorHitObjectsFlippedEventArgs e) => Refresh();
+
+        private void OnLanesSwapped(object sender, EditorLanesSwappedEventArgs e) => Refresh();
 
         private void OnHitObjectsReversed(object sender, EditorHitObjectsReversedEventArgs e) => Refresh();
 


### PR DESCRIPTION
Use `<alt>+<number1>+<number2>` to swap lanes of selected notes. This can also be triggered in the menu.