### PR TITLE
Make right click options scrollable

### DIFF
--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -100,6 +100,21 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <summary>
         /// </summary>
         private int MaxHeight { get; }
+        
+        /// <summary>
+        ///     The height of the dropdown when opened
+        /// </summary>
+        public int OpenHeight
+        {
+            get
+            {
+                var height = (int) Height * Options.Count;
+
+                if (MaxHeight != 0 && height >= MaxHeight)
+                    height = MaxHeight;
+                return height;
+            }
+        }
 
         /// <inheritdoc />
         /// <summary>
@@ -270,10 +285,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
 
             ItemContainer.ClearAnimations();
 
-            var height = (int) Height * Options.Count;
-
-            if (MaxHeight != 0 && height >= MaxHeight)
-                height = MaxHeight;
+            var height = OpenHeight;
 
             ItemContainer.ChangeHeightTo(height, Easing.OutQuint, time);
 

--- a/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/RightClick/RightClickOptions.cs
@@ -19,7 +19,11 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns.RightClick
         /// <param name="options"></param>
         /// <param name="size"></param>
         /// <param name="fontSize"></param>
-        public RightClickOptions(Dictionary<string, Color> options, ScalableVector2 size, int fontSize) : base(options.Keys.ToList(), size, fontSize, Color.White)
+        /// <param name="maxWidth"></param>
+        /// <param name="maxHeight"></param>
+        public RightClickOptions(Dictionary<string, Color> options, ScalableVector2 size, int fontSize, 
+            int maxWidth = 0, int maxHeight = 0) 
+            : base(options.Keys.ToList(), size, fontSize, Color.White, 0, maxWidth, maxHeight)
         {
             Options = options;
 

--- a/Quaver.Shared/Screens/QuaverScreen.cs
+++ b/Quaver.Shared/Screens/QuaverScreen.cs
@@ -140,7 +140,7 @@ namespace Quaver.Shared.Screens
                 WindowManager.Width - ActiveRightClickOptions.Width);
 
             var y = MathHelper.Clamp(MouseManager.CurrentState.Y, 0,
-                WindowManager.Height - ActiveRightClickOptions.Items.Count * ActiveRightClickOptions.Items.First().Height - 60);
+                WindowManager.Height - ActiveRightClickOptions.OpenHeight - 60);
 
             ActiveRightClickOptions.Position = new ScalableVector2(x, y);
 


### PR DESCRIPTION
This PR tries to make right click options scrollable, which can then be used to resolve the scrolling problem in #3964.

The constructor of `RightClickOptions` now allows the specification of `maxWidth` and `maxHeight` just like `Dropdown`.

`OpenHeight` is added to `Dropdown`, which evaluates to the height of the dropdown when opened. The right click menu's Y coordinate is no longer calculated by the number of items but `OpenHeight`, which fixes the weird positioning when right click menu is made scrollable.

There seems to be a known bug that scrolling in editor when hovering on options penetrates through and gets detected by the note scrolling. Making right click options scrollable does not resolve this issue.

I'm not at all familiar to this API, so please feel free criticise my working however you like. 