### PR TITLE
Migrate to .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Checkout submodules
       run: git submodule update --init --recursive
     - name: Restore dependencies

--- a/Quaver.Shared/Helpers/ObjectHelper.cs
+++ b/Quaver.Shared/Helpers/ObjectHelper.cs
@@ -6,7 +6,7 @@
 */
 
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
+using System.Xml.Serialization;
 
 namespace Quaver.Shared.Helpers
 {
@@ -22,7 +22,7 @@ namespace Quaver.Shared.Helpers
         {
             using (var ms = new MemoryStream())
             {
-                var formatter = new BinaryFormatter();
+                var formatter = new XmlSerializer(typeof(T));
                 formatter.Serialize(ms, obj);
                 ms.Position = 0;
 

--- a/Quaver/Quaver.csproj
+++ b/Quaver/Quaver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <Description>
     </Description>

--- a/Quaver/Quaver.csproj
+++ b/Quaver/Quaver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <Description>


### PR DESCRIPTION
This pull request migrates the project to .NET 8, making the same change of swapping `BinaryFormatter` with `XmlSerializer` in a copy of the function. (see https://github.com/Quaver/Quaver.API/pull/153)

Compiled successfully and ran without issues on Linux. Performance should theoretically be improved, but I haven't noticed so far.