### PR TITLE
Footer background

### DIFF
--- a/Quaver.Shared/Graphics/Menu/Border/MenuBorder.cs
+++ b/Quaver.Shared/Graphics/Menu/Border/MenuBorder.cs
@@ -52,7 +52,15 @@ namespace Quaver.Shared.Graphics.Menu.Border
             RightAlignedItems = rightAligned;
 
             Size = new ScalableVector2(WindowManager.Width, HEIGHT);
-            Image = SkinManager.Skin?.MenuBorder?.Background ?? UserInterface.MenuBorderBackground;
+            
+            if (type == MenuBorderType.Footer)
+            {
+                Image = SkinManager.Skin?.MenuBorder?.BackgroundFooter ?? SkinManager.Skin?.MenuBorder?.Background ?? UserInterface.MenuBorderBackground;
+            }
+            else
+            {
+                Image = SkinManager.Skin?.MenuBorder?.Background ?? UserInterface.MenuBorderBackground;
+            }
 
             CreateForegroundLine();
             CreateAnimatedLine();

--- a/Quaver.Shared/Skinning/Menus/SkinMenuBorder.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenuBorder.cs
@@ -18,6 +18,8 @@ namespace Quaver.Shared.Skinning.Menus
 
         public Texture2D Background { get; private set; }
 
+        public Texture2D BackgroundFooter { get; private set; }
+
         public SkinMenuBorder(SkinStore store, IniData config) : base(store, config)
         {
         }
@@ -42,6 +44,7 @@ namespace Quaver.Shared.Skinning.Menus
         protected override void LoadElements()
         {
             Background = LoadSkinElement("MenuBorder", "menu-border-background.png");
+            BackgroundFooter = LoadSkinElement("MenuBorder", "menu-border-background-footer.png");
         }
     }
 }


### PR DESCRIPTION
Added option to load `menu-border-background-footer.png` if available, otherwise it will default to `menu-border-background.png` or the one from Quaver.Resources.