### PR TITLE
Fix order of parameters of Vector4 in CLR <-> Lua script conversion

### DIFF
--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -256,21 +256,21 @@ namespace Quaver.Shared.Scripting
             Script.GlobalOptions.CustomConverters.SetScriptToClrCustomConversion(DataType.Table, typeof(Vector4),
                 dynVal => {
                     var table = dynVal.Table;
-                    var w = (float)((double)table[1]);
-                    var x = (float)((double)table[2]);
-                    var y = (float)((double)table[3]);
-                    var z = (float)((double)table[4]);
-                    return new Vector4(w, x, y, z);
+                    var x = (float)((double)table[1]);
+                    var y = (float)((double)table[2]);
+                    var z = (float)((double)table[3]);
+                    var w = (float)((double)table[4]);
+                    return new Vector4(x, y, z, w);
                 }
             );
 
             Script.GlobalOptions.CustomConverters.SetClrToScriptCustomConversion<Vector4>(
                 (script, vector) => {
-                    var w = DynValue.NewNumber(vector.W);
                     var x = DynValue.NewNumber(vector.X);
                     var y = DynValue.NewNumber(vector.Y);
                     var z = DynValue.NewNumber(vector.Z);
-                    var dynVal = DynValue.NewTable(script, w, x, y, z);
+                    var w = DynValue.NewNumber(vector.W);
+                    var dynVal = DynValue.NewTable(script, x, y, z, w);
                     return dynVal;
                 }
             );


### PR DESCRIPTION
Resolves #3998 
The order of Vector4 constructor is `x, y, z, w` and in lua conversion it constructs it as `w, x, y, z` instead. This makes the parameters keep cycling around and causes the issue. I fixed the ordering of the parameters.