### PR TITLE
Add an Option to Play Hitsound at Long Note Release

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -286,6 +286,11 @@ namespace Quaver.Shared.Config
         ///     If true, hitsounds in gameplay will be played.
         /// </summary>
         internal static Bindable<bool> EnableHitsounds { get; private set; }
+        
+        /// <summary>
+        ///     If true, a hitsound will be played when releasing a long note
+        /// </summary>
+        internal static Bindable<bool> EnableLongNoteReleaseHitsounds { get; private set; }
 
         /// <summary>
         ///     If true, keysounds in gameplay will be played.
@@ -933,6 +938,7 @@ namespace Quaver.Shared.Config
             DisplayTimingLines = ReadValue(@"DisplayTimingLines", true, data);
             DisplayMenuAudioVisualizer = ReadValue(@"DisplayMenuAudioVisualizer", true, data);
             EnableHitsounds = ReadValue(@"EnableHitsounds", true, data);
+            EnableLongNoteReleaseHitsounds = ReadValue(@"EnableLongNoteReleaseHitsounds", false, data);
             EnableKeysounds = ReadValue(@"EnableKeysounds", true, data);
             KeyNavigateLeft = ReadValue(@"KeyNavigateLeft", Keys.Left, data);
             KeyNavigateRight = ReadValue(@"KeyNavigateRight", Keys.Right, data);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -281,6 +281,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // If LN has been released during a window
             if (judgement != Judgement.Ghost)
             {
+                var game = GameBase.Game as QuaverGame;
+                if (game?.CurrentScreen?.Type != QuaverScreenType.Editor)
+                {
+                    if (ConfigManager.EnableHitsounds.Value && ConfigManager.EnableLongNoteReleaseHitsounds.Value)
+                        HitObjectManager.PlayObjectHitSounds(info.HitObjectInfo);
+                }
+
                 // Update stats
                 Ruleset.ScoreProcessor.Stats.Add(
                     new HitStat(

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -208,6 +208,7 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("Sound", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Enable Hitsounds", ConfigManager.EnableHitsounds),
+                        new OptionsItemCheckbox(containerRect, "Enable Long Note Release Hitsounds", ConfigManager.EnableLongNoteReleaseHitsounds),
                         new OptionsItemCheckbox(containerRect, "Enable Keysounds", ConfigManager.EnableKeysounds)
                     }),
                     new OptionsSubcategory("Input", new List<OptionsItem>()


### PR DESCRIPTION
Resolves #934 
I didn't let it play LN release hitsounds in editor, as I don't see a purpose.
Should we add separate release hitsound field for notes?