### PR TITLE
Don't render BPMs that are too close together

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -290,13 +290,19 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// <param name="gameTime"></param>
         private void DrawLines(GameTime gameTime)
         {
+            const float minimumDistanceToDraw = 10;
+
             for (var i = 0; i < LinePool.Count; i++)
             {
                 var line = LinePool[i];
                 line.SetPosition();
                 line.Tint = GetLineColor(line.Index % BeatSnap.Value, line.Index);
 
-                if (line.IsOnScreen())
+                if (line.IsOnScreen() &&
+                    (i is 0 ||
+                        LinePool[i - 1].Y - line.Y > minimumDistanceToDraw ||
+                        i == LinePool.Count - 1 ||
+                        line.Y - LinePool[i + 1].Y > minimumDistanceToDraw))
                     line.Draw(gameTime);
             }
         }


### PR DESCRIPTION
<details>
    <summary>Before (very laggy)</summary>
    <img src="https://github.com/Quaver/Quaver/assets/14614115/965d0ed0-f63b-418a-9608-817ced197d05"/>
</details>
<details>
    <summary>After</summary>
    <img src="https://github.com/Quaver/Quaver/assets/14614115/f9e60514-9bf3-4b93-a964-57e37d389edd"/>
</details>
<details>
    <summary>After (zoomed in; this showcases that they render based on screen distance, not time-based)</summary>
    <img src="https://github.com/Quaver/Quaver/assets/14614115/40169fc1-ca17-41b4-87f4-b13baf9f4745"/>
</details>
