### PR TITLE
Fix race conditions

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -472,11 +472,11 @@ namespace Quaver.Shared.Screens.Edit
             // To not conflict with the volume controller
             if (!KeyboardManager.IsAltDown() && !KeyboardManager.IsCtrlDown())
             {
-                var dropdownHovered = ButtonManager.Buttons.Any(
+                var dropdownHovered = ButtonManager.Buttons.Find(
                     x => x is DropdownItem item &&
                         GraphicsHelper.RectangleContains(x.ScreenRectangle, MouseManager.CurrentState.Position) &&
                         item.Dropdown.Opened
-                );
+                ) is not null;
 
                 if (!dropdownHovered)
                 {

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
@@ -126,7 +126,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
             if (Playfield.GetHoveredHitObject() != null)
                 return;
 
-            if (ButtonManager.Buttons.Any(x => x.IsHovered) && ! Playfield.Button.IsHovered)
+            if (ButtonManager.Buttons.Find(x => x.IsHovered) is not null && ! Playfield.Button.IsHovered)
                 return;
 
             var clickArea = new RectangleF(Playfield.ScreenRectangle.X - 300, Playfield.ScreenRectangle.Y,

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTableItem.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTableItem.cs
@@ -173,7 +173,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
         /// </summary>
         private void HandleClick()
         {
-            if (!IsHovered() || IsSelectorHovered() || DialogManager.Dialogs.Count != 0 || ButtonManager.Buttons.Any(x => x.IsHovered))
+            if (!IsHovered() || IsSelectorHovered() || DialogManager.Dialogs.Count != 0 || ButtonManager.Buttons.Find(x => x.IsHovered) is not null)
                 return;
 
             if (!MouseManager.IsUniqueClick(MouseButton.Left))

--- a/Quaver.Shared/Screens/Options/Content/OptionsContentContainer.cs
+++ b/Quaver.Shared/Screens/Options/Content/OptionsContentContainer.cs
@@ -54,9 +54,9 @@ namespace Quaver.Shared.Screens.Options.Content
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            var dropdownHovered = ButtonManager.Buttons.Any(x => x is DropdownItem item &&
+            var dropdownHovered = ButtonManager.Buttons.Find(x => x is DropdownItem item &&
                                                  GraphicsHelper.RectangleContains(x.ScreenRectangle, MouseManager.CurrentState.Position) &&
-                                                 item.Dropdown.Opened);
+                                                 item.Dropdown.Opened) is not null;
 
             InputEnabled = GraphicsHelper.RectangleContains(ScreenRectangle, MouseManager.CurrentState.Position)
                            && !KeyboardManager.CurrentState.IsKeyDown(Keys.LeftAlt)


### PR DESCRIPTION
[`List<T>.Find`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.find?view=net-8.0) doesn't do "version-checking" like [`Enumerable.Any`](https://learn.microsoft.com/en-us/dotnet/api/System.Linq.Enumerable.Any?view=netstandard-2.0) or any enumeration-based approach for [`List<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1?view=net-8.0) does. Given that in this case we don't care if the buffer moves or the array suddenly expands since we are simply checking in the moment for every element, this should be totally fine.

Fixes the following stack trace:
```
[8:00:00] - RUNTIME - ERROR: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Quaver.Shared.Screens.Edit.EditScreen.HandleInput() in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Edit\EditScreen.cs:line 491
   at Quaver.Shared.Screens.Edit.EditScreen.Update(GameTime gameTime) in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Edit\EditScreen.cs:line 335
   at Wobble.Screens.ScreenManager.Update(GameTime gameTime) in D:\QuaverDeploy\Quaver\Wobble\Wobble\Screens\ScreenManager.cs:line 61
   at Wobble.WobbleGame.Update(GameTime gameTime) in D:\QuaverDeploy\Quaver\Wobble\Wobble\WobbleGame.cs:line 183
   at Quaver.Shared.QuaverGame.Update(GameTime gameTime) in D:\QuaverDeploy\Quaver\Quaver.Shared\QuaverGame.cs:line 342
   at Microsoft.Xna.Framework.Game.DoUpdate(GameTime gameTime) in D:\QuaverDeploy\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 681
   at Microsoft.Xna.Framework.Game.Tick() in D:\QuaverDeploy\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 494
   at Microsoft.Xna.Framework.SdlGamePlatform.RunLoop() in D:\QuaverDeploy\Quaver\Wobble\MonoGame\MonoGame.Framework\Platform\SDL\SDLGamePlatform.cs:line 194
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior) in D:\QuaverDeploy\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 424
   at Microsoft.Xna.Framework.Game.Run() in D:\QuaverDeploy\Quaver\Wobble\MonoGame\MonoGame.Framework\Game.cs:line 394
   at Quaver.Program.Run() in D:\QuaverDeploy\Quaver\Quaver\Program.cs:line 115
   at Quaver.Program.Main(String[] args) in D:\QuaverDeploy\Quaver\Quaver\Program.cs:line 63
```