### PR TITLE
Improvements to MapsetImporter

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -139,6 +139,8 @@ namespace Quaver.Shared.Database.Maps
         /// <param name="path"></param>
         private static void AddMapImportToQueue(string path)
         {
+            // Only one .mc file under the same directory should be imported
+            // since .mc import 
             if (Path.GetExtension(path) == ".mc")
             {
                 foreach (var scheduledPath in Queue)
@@ -146,6 +148,7 @@ namespace Quaver.Shared.Database.Maps
                     if (Path.GetDirectoryName(scheduledPath) == Path.GetDirectoryName(path)) return;
                 }
             }
+
             NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
             Queue.Add(path);
             PostMapQueue();
@@ -311,8 +314,9 @@ namespace Quaver.Shared.Database.Maps
             {
                 var file = Queue[i];
                 var extension = Path.GetExtension(file);
+                // Use directory of .sm files, because during scheduled bulk import, there can be multiple files named file.sm, for example
                 var isPartOfMapset = extension == ".sm";
-                var time = (long) DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
+                var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
 
                 var folderName = isPartOfMapset
                     ? Path.GetFileName(Path.GetDirectoryName(file))

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -94,35 +94,34 @@ namespace Quaver.Shared.Database.Maps
              var screen = game.CurrentScreen;
 
              if (screen.Exiting)
-                    return;
+                 return;
 
-                if (screen.Type == QuaverScreenType.Select)
-                {
-                    if (OnlineManager.CurrentGame != null)
-                    {
-                        var select = game.CurrentScreen as SelectionScreen;
-                        screen.Exit(() => new ImportingScreen(null, true));
-                        return;
-                    }
+             if (screen.Type == QuaverScreenType.Select)
+             {
+                 if (OnlineManager.CurrentGame != null)
+                 {
+                     var select = game.CurrentScreen as SelectionScreen;
+                     screen.Exit(() => new ImportingScreen(null, true));
+                     return;
+                 }
 
-                    screen.Exit(() => new ImportingScreen());
-                    return;
-                }
+                 screen.Exit(() => new ImportingScreen());
+                 return;
+             }
 
-                if (screen.Type == QuaverScreenType.Music)
-                {
-                    screen.Exit(() => new ImportingScreen());
-                    return;
-                }
+             if (screen.Type == QuaverScreenType.Music)
+             {
+                 screen.Exit(() => new ImportingScreen());
+                 return;
+             }
 
-                if (screen.Type == QuaverScreenType.Multiplayer)
-                {
-                    var multi = (MultiplayerGameScreen)screen;
-                    multi.DontLeaveGameUponScreenSwitch = true;
+             if (screen.Type == QuaverScreenType.Multiplayer)
+             {
+                 var multi = (MultiplayerGameScreen)screen;
+                 multi.DontLeaveGameUponScreenSwitch = true;
 
-                    screen.Exit(() => new ImportingScreen());
-                    return;
-                }
+                 screen.Exit(() => new ImportingScreen());
+             }
         }
 
         /// <summary>

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -140,6 +140,13 @@ namespace Quaver.Shared.Database.Maps
         /// <param name="path"></param>
         private static void AddMapImportToQueue(string path)
         {
+            if (Path.GetExtension(path) == ".mc")
+            {
+                foreach (var scheduledPath in Queue)
+                {
+                    if (Path.GetDirectoryName(scheduledPath) == Path.GetDirectoryName(path)) return;
+                }
+            }
             NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
             Queue.Add(path);
             PostMapQueue();

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -135,6 +135,17 @@ namespace Quaver.Shared.Database.Maps
         }
 
         /// <summary>
+        ///     Adds the map dragged into the window to be scheduled to import
+        /// </summary>
+        /// <param name="path"></param>
+        private static void AddMapImportToQueue(string path)
+        {
+            NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
+            Queue.Add(path);
+            PostMapQueue();
+        }
+
+        /// <summary>
         ///     Tries to import the given file, be it a map, a replay, a skin, etc.
         ///     <param name="path">path to the file to import</param>
         /// </summary>
@@ -146,12 +157,7 @@ namespace Quaver.Shared.Database.Maps
             // Mapset files (or directory of Mapset files)
             if (AcceptedMapType(path))
             {
-                Queue.Add(path);
-
-                var log = $"Scheduled {Path.GetFileName(path)} to be imported!";
-                NotificationManager.Show(NotificationLevel.Info, log);
-
-                PostMapQueue();
+                AddMapImportToQueue(path);
             }
             // Quaver Replay
             else if (path.EndsWith(".qr"))
@@ -271,8 +277,7 @@ namespace Quaver.Shared.Database.Maps
                 {
                     if (AcceptedMapType(subPath))
                     {
-                        NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(subPath)} to be imported!");
-                        Queue.Add(subPath);
+                        AddMapImportToQueue(subPath);
                     }
                 }
                 foreach (var subDir in dirs)

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -299,9 +299,13 @@ namespace Quaver.Shared.Database.Maps
             Parallel.For(0, Queue.Count, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
             {
                 var file = Queue[i];
+                var extension = Path.GetExtension(file);
+                var isPartOfMapset = extension == ".sm";
                 var time = (long) DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
 
-                var folderName = Path.GetFileNameWithoutExtension(file);
+                var folderName = isPartOfMapset
+                    ? Path.GetFileName(Path.GetDirectoryName(file))
+                    : Path.GetFileNameWithoutExtension(file);
                 folderName = folderName.Substring(0, Math.Min(folderName.Length, 100));
 
                 var extractDirectory = $@"{ConfigManager.SongDirectory}/{folderName} - {time}/";


### PR DESCRIPTION
Resolves #4037 and #4052

`.mc` file import actually imports every other `.mc` files present under the same directory, so I made it to import only one of them. This improves the importing speed of e.g. dan mapsets.

If there are multiple StepMania mapsets being imported and they all have a file named `file.sm`, when bulk importing they are placed in the same directory (`file - 123` where 123 is replaced by the current millisecond). This PR changes this logic so it instead uses the directory name of the `.sm` files.
