### PR TITLE
Improvements on Spectrogram

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -559,6 +559,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<EditorPlayfieldSpectrogramFrequencyScale> EditorSpectrogramFrequencyScale { get; private set; }
         
         internal static BindableInt EditorSpectrogramFftSize { get; private set; }
+        
+        /// <summary>
+        ///     The number of times the song's fft will be taken. Linearly increases the time to load
+        /// </summary>
+        internal static BindableInt EditorSpectrogramInterleaveCount { get; private set; }
 
         /// <summary>
         /// </summary>
@@ -1135,6 +1140,7 @@ namespace Quaver.Shared.Config
             EditorSpectrogramIntensityFactor = ReadValue("EditorSpectrogramIntensityFactor", 9.5f, data);
             EditorSpectrogramFrequencyScale = ReadValue("EditorSpectrogramFrequencyScale", EditorPlayfieldSpectrogramFrequencyScale.Linear, data);
             EditorSpectrogramFftSize = ReadInt(@"EditorSpectrumFftSize", 512, 256, 16384, data);
+            EditorSpectrogramInterleaveCount = ReadInt(@"EditorSpectrogramInterleaveCount", 4, 1, 16, data);
             EditorAudioDirection = ReadValue(@"EditorAudioDirection", EditorPlayfieldWaveformAudioDirection.Both, data);
             EditorWaveformColorR = ReadInt(@"EditorWaveformColorR", 0, 0, 255, data);
             EditorWaveformColorG = ReadInt(@"EditorWaveformColorG", 200, 0, 255, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -1134,7 +1134,7 @@ namespace Quaver.Shared.Config
             EditorShowWaveform = ReadValue(@"EditorShowWaveform", true, data);
             EditorShowSpectrogram = ReadValue(@"EditorShowSpectrogram", false, data);
             EditorSpectrogramMaximumFrequency = ReadInt(@"EditorSpectrogramMaximumFrequency", 7000, 5000, 10000, data);
-            EditorSpectrogramMinimumFrequency = ReadInt("EditorSpectrogramMinimumFrequency", 250, 0, 1500, data);
+            EditorSpectrogramMinimumFrequency = ReadInt("EditorSpectrogramMinimumFrequency", 125, 0, 1500, data);
             EditorSpectrogramLayer = ReadValue("EditorSpectrogramLayer", EditorPlayfieldSpectrogramLayer.BehindTimingLines, data);
             EditorSpectrogramCutoffFactor = ReadValue("EditorSpectrogramCutoffFactor", 0.34f, data);
             EditorSpectrogramIntensityFactor = ReadValue("EditorSpectrogramIntensityFactor", 9.5f, data);

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -535,6 +535,19 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
 
                     ImGui.EndMenu();
                 }
+                
+                if (ImGui.BeginMenu("Precision"))
+                {
+                    for (var interleaveCount = 1; interleaveCount <= 16; interleaveCount *= 2)
+                    {
+                        if (ImGui.MenuItem($"{interleaveCount}x", "",
+                                ConfigManager.EditorSpectrogramInterleaveCount.Value == interleaveCount))
+                        {
+                            ConfigManager.EditorSpectrogramInterleaveCount.Value = interleaveCount;
+                        }
+                    }
+                    ImGui.EndMenu();
+                }
 
                 if (ImGui.BeginMenu("FFT Size"))
                 {

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -416,6 +416,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ConfigManager.EditorSpectrogramCutoffFactor.ValueChanged += OnSpectrogramCutoffFactorChanged;
             ConfigManager.EditorSpectrogramIntensityFactor.ValueChanged += OnSpectrogramIntensityFactorChanged;
             ConfigManager.EditorSpectrogramFrequencyScale.ValueChanged += OnSpectrogramFrequencyScaleChanged;
+            ConfigManager.EditorSpectrogramInterleaveCount.ValueChanged += OnSpectrogramInterleaveCountChanged;
         }
 
         /// <inheritdoc />
@@ -565,6 +566,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ConfigManager.EditorSpectrogramCutoffFactor.ValueChanged -= OnSpectrogramCutoffFactorChanged;
             ConfigManager.EditorSpectrogramIntensityFactor.ValueChanged -= OnSpectrogramIntensityFactorChanged;
             ConfigManager.EditorSpectrogramFrequencyScale.ValueChanged -= OnSpectrogramFrequencyScaleChanged;
+            ConfigManager.EditorSpectrogramInterleaveCount.ValueChanged -= OnSpectrogramInterleaveCountChanged;
 
             base.Destroy();
         }
@@ -1664,6 +1666,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             => ReloadSpectrogram();
         
         private void OnSpectrogramFrequencyScaleChanged(object sender, BindableValueChangedEventArgs<EditorPlayfieldSpectrogramFrequencyScale> e)
+            => ReloadSpectrogram();
+        
+        private void OnSpectrogramInterleaveCountChanged(object sender, BindableValueChangedEventArgs<int> e)
             => ReloadSpectrogram();
 
         private void ReloadWaveform()

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1681,7 +1681,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         private void ReloadSpectrogram()
         {
             Spectrogram?.Destroy();
-            LoadingWaveform.FadeIn();
+            LoadingSpectrogram.FadeIn();
             SpectrogramLoadTask.Run(0);
         }
     }

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogram.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogram.cs
@@ -105,20 +105,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             for (var fftRound = 0; fftRound < FftRoundsTaken; fftRound +=FftPerSlice)
             {
                 var t = (int)(fftRound * millisecondPerFft);
-                var trackSliceData = new float[InterleavedFftPerSlice, FftResultCount];
-                for (var y = 0; y < InterleavedFftPerSlice; y++)
-                {
-                    var currentFftIndex = fftRound * InterleaveCount + y;
-                    if (currentFftIndex >= TrackData.GetLength(0))
-                        break;
-                    for (var x = 0; x < FftResultCount; x++)
-                    {
-                        trackSliceData[y, x] = TrackData[currentFftIndex, x];
-                    }
-                }
+                var trackDataYOffset = fftRound * InterleaveCount;
 
                 var slice = new EditorPlayfieldSpectrogramSlice(this, Playfield, (float)millisecondPerSlice, InterleavedFftPerSlice,
-                    trackSliceData, t, sampleRate);
+                    TrackData, trackDataYOffset, t, sampleRate);
                 tempSlices.Add(slice);
             }
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
@@ -36,6 +36,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
         private readonly int _minimumFrequency;
         private readonly int _maximumFrequency;
 
+        private readonly float _cutoffFactor;
+        private readonly float _intensityFactor;
+
         public EditorPlayfieldSpectrogramSlice(EditorPlayfieldSpectrogram spectrogram, EditorPlayfield playfield,
             float lengthMs, int sliceSize,
             float[][] sliceData,
@@ -50,6 +53,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             _sampleRate = sampleRate;
             _referenceWidth = spectrogram.FftCount;
             _trackDataYOffset = trackDataYOffset;
+            _cutoffFactor = ConfigManager.EditorSpectrogramCutoffFactor.Value;
+            _intensityFactor = ConfigManager.EditorSpectrogramIntensityFactor.Value;
 
             _frequencyTransform = ConfigManager.EditorSpectrogramFrequencyScale.Value switch
             {
@@ -142,11 +147,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             var db = MathF.Abs(rawIntensity) < 1e-4f ? -100 : 20 * MathF.Log10(rawIntensity);
             var intensity = Math.Clamp(1 + db / 100, 0f, 1f);
 
-            var cutoffFactor = ConfigManager.EditorSpectrogramCutoffFactor.Value;
-            intensity = MathF.Max(intensity, cutoffFactor);
-            intensity = (intensity - cutoffFactor) * (1 - cutoffFactor);
+            intensity = MathF.Max(intensity, _cutoffFactor);
+            intensity = (intensity - _cutoffFactor) * (1 - _cutoffFactor);
 
-            intensity *= intensity * ConfigManager.EditorSpectrogramIntensityFactor.Value;
+            intensity *= intensity * _intensityFactor;
             intensity = Sigmoid(Math.Clamp(intensity, 0, 1));
             return intensity;
         }

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
@@ -28,6 +28,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
         private int SampleRate { get; set; }
 
         private int ReferenceWidth { get; }
+        
+        private int TrackDataYOffset { get; }
 
         private Func<float, float> FrequencyTransform =>
             ConfigManager.EditorSpectrogramFrequencyScale.Value switch
@@ -42,6 +44,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
         public EditorPlayfieldSpectrogramSlice(EditorPlayfieldSpectrogram spectrogram, EditorPlayfield playfield,
             float lengthMs, int sliceSize,
             float[,] sliceData,
+            int trackDataYOffset,
             double sliceTime, int sampleRate)
         {
             Spectrogram = spectrogram;
@@ -51,6 +54,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             LengthMs = lengthMs;
             SampleRate = sampleRate;
             ReferenceWidth = spectrogram.FftCount;
+            TrackDataYOffset = trackDataYOffset;
 
             CreateSlice(sliceData);
         }
@@ -176,7 +180,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
         private float GetAverageData(float[,] data, int y, int x)
         {
-            return data[y, x];
+            if (TrackDataYOffset + y >= data.GetLength(0)) return 0;
+            return data[TrackDataYOffset + y, x];
         }
 
         private int DataColorIndex(int textureHeight, int y, int x)

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
@@ -12,34 +12,29 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 {
     public class EditorPlayfieldSpectrogramSlice : Sprite
     {
-        private EditorPlayfield Playfield { get; set; }
-        private EditorPlayfieldSpectrogram Spectrogram { get; set; }
+        private readonly EditorPlayfield _playfield;
+        private readonly EditorPlayfieldSpectrogram _spectrogram;
 
         private Sprite SliceSprite { get; set; }
 
-        private int SliceSize { get; }
+        private readonly int _sliceSize;
 
-        private double SliceTimeMilliSeconds { get; }
+        private readonly double _sliceTimeMilliSeconds;
 
         private Texture2D SliceTexture { get; set; }
 
-        private float LengthMs { get; set; }
+        private readonly float _lengthMs;
 
-        private int SampleRate { get; set; }
+        private readonly int _sampleRate;
 
-        private int ReferenceWidth { get; }
-        
-        private int TrackDataYOffset { get; }
+        private readonly int _referenceWidth;
 
-        private Func<float, float> FrequencyTransform =>
-            ConfigManager.EditorSpectrogramFrequencyScale.Value switch
-            {
-                EditorPlayfieldSpectrogramFrequencyScale.Mel => Mel,
-                EditorPlayfieldSpectrogramFrequencyScale.Erb1 => Erb1,
-                EditorPlayfieldSpectrogramFrequencyScale.Erb2 => Erb2,
-                EditorPlayfieldSpectrogramFrequencyScale.Linear => Linear,
-                _ => throw new ArgumentOutOfRangeException()
-            };
+        private readonly int _trackDataYOffset;
+
+        private readonly Func<float, float> _frequencyTransform;
+
+        private readonly int _minimumFrequency;
+        private readonly int _maximumFrequency;
 
         public EditorPlayfieldSpectrogramSlice(EditorPlayfieldSpectrogram spectrogram, EditorPlayfield playfield,
             float lengthMs, int sliceSize,
@@ -47,14 +42,27 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             int trackDataYOffset,
             double sliceTime, int sampleRate)
         {
-            Spectrogram = spectrogram;
-            Playfield = playfield;
-            SliceSize = sliceSize;
-            SliceTimeMilliSeconds = sliceTime;
-            LengthMs = lengthMs;
-            SampleRate = sampleRate;
-            ReferenceWidth = spectrogram.FftCount;
-            TrackDataYOffset = trackDataYOffset;
+            _spectrogram = spectrogram;
+            _playfield = playfield;
+            _sliceSize = sliceSize;
+            _sliceTimeMilliSeconds = sliceTime;
+            _lengthMs = lengthMs;
+            _sampleRate = sampleRate;
+            _referenceWidth = spectrogram.FftCount;
+            _trackDataYOffset = trackDataYOffset;
+
+            _frequencyTransform = ConfigManager.EditorSpectrogramFrequencyScale.Value switch
+            {
+                EditorPlayfieldSpectrogramFrequencyScale.Mel => Mel,
+                EditorPlayfieldSpectrogramFrequencyScale.Erb1 => Erb1,
+                EditorPlayfieldSpectrogramFrequencyScale.Erb2 => Erb2,
+                EditorPlayfieldSpectrogramFrequencyScale.Linear => Linear,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+            
+            
+            _minimumFrequency = (int)_frequencyTransform(ConfigManager.EditorSpectrogramMinimumFrequency.Value);
+            _maximumFrequency = (int)_frequencyTransform(ConfigManager.EditorSpectrogramMaximumFrequency.Value);
 
             CreateSlice(sliceData);
         }
@@ -68,10 +76,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
         public override void Draw(GameTime gameTime)
         {
-            SliceSprite.X = Playfield.ScreenRectangle.X;
-            SliceSprite.Y = Playfield.HitPositionY - (float)(SliceTimeMilliSeconds + LengthMs) * Playfield.TrackSpeed -
+            SliceSprite.X = _playfield.ScreenRectangle.X;
+            SliceSprite.Y = _playfield.HitPositionY - (float)(_sliceTimeMilliSeconds + _lengthMs) * _playfield.TrackSpeed -
                             Height;
-            SliceSprite.Height = LengthMs * Playfield.TrackSpeed;
+            SliceSprite.Height = _lengthMs * _playfield.TrackSpeed;
             SliceSprite.Tint = new Color(
                 1.0f,
                 1.0f,
@@ -90,32 +98,30 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
             base.Destroy();
         }
-
-        public void UpdatePlayfield(EditorPlayfield playfield) => Playfield = playfield;
-
+        
         private void CreateSlice(float[,] sliceData)
         {
             SliceSprite = new Sprite { Alpha = 0 };
 
-            SliceTexture = new Texture2D(GameBase.Game.GraphicsDevice, ReferenceWidth, SliceSize);
+            SliceTexture = new Texture2D(GameBase.Game.GraphicsDevice, _referenceWidth, _sliceSize);
 
-            var dataColors = new Color[ReferenceWidth * SliceSize];
+            var dataColors = new Color[_referenceWidth * _sliceSize];
 
-            for (var y = 0; y < SliceSize; y++)
+            for (var y = 0; y < _sliceSize; y++)
             {
-                for (var x = 0; x < Spectrogram.FftCount; x++)
+                for (var x = 0; x < _spectrogram.FftCount; x++)
                 {
-                    var textureX = CalculateTextureX(x, FrequencyTransform);
+                    var textureX = CalculateTextureX(x);
                     if (textureX == -1) continue;
                     var intensity = GetIntensity(sliceData, y, x);
-                    var index = DataColorIndex(SliceSize, y, textureX);
-                    var nextTextureX = CalculateTextureX(x + 1, FrequencyTransform);
-                    if (nextTextureX == -1) nextTextureX = ReferenceWidth - 1;
-                    var nextIntensity = x == Spectrogram.FftCount - 1
+                    var index = DataColorIndex(_sliceSize, y, textureX);
+                    var nextTextureX = CalculateTextureX(x + 1);
+                    if (nextTextureX == -1) nextTextureX = _referenceWidth - 1;
+                    var nextIntensity = x == _spectrogram.FftCount - 1
                         ? intensity
                         : GetIntensity(sliceData, y, x + 1);
                     var curColor = SpectrogramColormap.GetColor(intensity);
-                    var nextDataColorIndex = DataColorIndex(SliceSize, y, nextTextureX);
+                    var nextDataColorIndex = DataColorIndex(_sliceSize, y, nextTextureX);
                     for (var i = index; i < nextDataColorIndex && i < dataColors.Length; i++)
                     {
                         dataColors[i] = curColor;
@@ -125,8 +131,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
             SliceTexture.SetData(dataColors);
             SliceSprite.Image = SliceTexture;
-            SliceSprite.Width = (int)Playfield.Width;
-            SliceSprite.Height = LengthMs;
+            SliceSprite.Width = (int)_playfield.Width;
+            SliceSprite.Height = _lengthMs;
             SliceSprite.FadeTo(1, Easing.Linear, 250);
         }
 
@@ -145,14 +151,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             return intensity;
         }
 
-        private int CalculateTextureX(int x, Func<float, float> transform)
+        private int CalculateTextureX(int x)
         {
-            var minFrequency = transform(ConfigManager.EditorSpectrogramMinimumFrequency.Value);
-            var maxFrequency = transform(ConfigManager.EditorSpectrogramMaximumFrequency.Value);
-            var frequency = (float)x * SampleRate / Spectrogram.FftCount;
-            var transformedFrequency = transform(frequency);
-            if (transformedFrequency > maxFrequency || transformedFrequency < minFrequency) return -1;
-            return (int)((transformedFrequency - minFrequency) / (maxFrequency - minFrequency) * ReferenceWidth);
+            var frequency = (float)x * _sampleRate / _spectrogram.FftCount;
+            var transformedFrequency = _frequencyTransform(frequency);
+            if (transformedFrequency > _maximumFrequency || transformedFrequency < _minimumFrequency) return -1;
+            return (int)((transformedFrequency - _minimumFrequency) / (_maximumFrequency - _minimumFrequency) * _referenceWidth);
         }
 
         private float Linear(float x) => x;
@@ -180,13 +184,13 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
         private float GetAverageData(float[,] data, int y, int x)
         {
-            if (TrackDataYOffset + y >= data.GetLength(0)) return 0;
-            return data[TrackDataYOffset + y, x];
+            if (_trackDataYOffset + y >= data.GetLength(0)) return 0;
+            return data[_trackDataYOffset + y, x];
         }
 
         private int DataColorIndex(int textureHeight, int y, int x)
         {
-            return (textureHeight - y - 1) * ReferenceWidth + x;
+            return (textureHeight - y - 1) * _referenceWidth + x;
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Spectrogram/EditorPlayfieldSpectrogramSlice.cs
@@ -38,7 +38,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
 
         public EditorPlayfieldSpectrogramSlice(EditorPlayfieldSpectrogram spectrogram, EditorPlayfield playfield,
             float lengthMs, int sliceSize,
-            float[,] sliceData,
+            float[][] sliceData,
             int trackDataYOffset,
             double sliceTime, int sampleRate)
         {
@@ -99,7 +99,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             base.Destroy();
         }
         
-        private void CreateSlice(float[,] sliceData)
+        private void CreateSlice(float[][] sliceData)
         {
             SliceSprite = new Sprite { Alpha = 0 };
 
@@ -136,7 +136,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
             SliceSprite.FadeTo(1, Easing.Linear, 250);
         }
 
-        private float GetIntensity(float[,] sliceData, int y, int x)
+        private float GetIntensity(float[][] sliceData, int y, int x)
         {
             var rawIntensity = GetAverageData(sliceData, y, x);
             var db = MathF.Abs(rawIntensity) < 1e-4f ? -100 : 20 * MathF.Log10(rawIntensity);
@@ -182,10 +182,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram
         }
 
 
-        private float GetAverageData(float[,] data, int y, int x)
+        private float GetAverageData(float[][] data, int y, int x)
         {
-            if (_trackDataYOffset + y >= data.GetLength(0)) return 0;
-            return data[_trackDataYOffset + y, x];
+            if (_trackDataYOffset + y >= data.Length) return 0;
+            return data[_trackDataYOffset + y][x];
         }
 
         private int DataColorIndex(int textureHeight, int y, int x)


### PR DESCRIPTION
+ [x] Store things using attributes instead of properties
+ [x] Avoid array copying using jagged array
+ [x] Allow interleaved fft sampling (n times reading of the music) to increase precision of spectrogram, defaulting to 4
+ [x] Waveform loading wheel won't disappear after spectrogram reloads
+ [x] Refuse to load if it requires too much memory