### PR TITLE
Add option to scale ImGui in editor

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -1069,7 +1069,7 @@ namespace Quaver.Shared.Config
             TapToRestart = ReadValue(@"TapToRestart", false, data);
             DisplayFailedLocalScores = ReadValue(@"DisplayFailedLocalScores", true, data);
             EditorScrollSpeedKeys = ReadInt(@"EditorScrollSpeedKeys", 16, 5, 100, data);
-            EditorImGuiScalePercentage = ReadInt(@"EditorImGuiScalePercentage", 100, 25, 400, data);
+            EditorImGuiScalePercentage = ReadInt(@"EditorImGuiScalePercentage", 100, 25, 300, data);
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -352,6 +352,11 @@ namespace Quaver.Shared.Config
         /// <summary>
         /// </summary>
         internal static Bindable<bool> DisplayComboAlerts { get; private set; }
+        
+        /// <summary>
+        ///     Scaling of ImGui windows and texts
+        /// </summary>
+        internal static BindableInt EditorImGuiScalePercentage { get; private set; }
 
         /// <summary>
         ///     The scroll speed used in the editor.
@@ -1064,6 +1069,7 @@ namespace Quaver.Shared.Config
             TapToRestart = ReadValue(@"TapToRestart", false, data);
             DisplayFailedLocalScores = ReadValue(@"DisplayFailedLocalScores", true, data);
             EditorScrollSpeedKeys = ReadInt(@"EditorScrollSpeedKeys", 16, 5, 100, data);
+            EditorImGuiScalePercentage = ReadInt(@"EditorImGuiScalePercentage", 100, 25, 400, data);
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);
             KeyEditorIncreaseAudioRate = ReadValue(@"KeyEditorIncreaseAudioRate", Keys.OemPlus, data);

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -234,6 +234,13 @@ namespace Quaver.Shared.Screens.Edit
         public Bindable<EditorLayerInfo> SelectedLayer { get; } = new Bindable<EditorLayerInfo>(null);
 
         /// <summary>
+        ///     The fraction scaling of ImGui Windows.
+        ///     Do NOT use bindable from this. We expect the user to leave and reenter the screen to see the effect
+        ///     Since <see cref="Wobble.Graphics.ImGUI.ImGuiRenderer.RebuildFontAtlas"/> needs to be called to update font sizes
+        /// </summary>
+        public float ImGuiScale { get; } = ConfigManager.EditorImGuiScalePercentage?.Value / 100f ?? 1f;
+
+        /// <summary>
         ///     Objects that are currently copied
         /// </summary>
         public List<HitObjectInfo> Clipboard { get; } = new List<HitObjectInfo>();
@@ -247,6 +254,7 @@ namespace Quaver.Shared.Screens.Edit
             Hidden = false,
             ColorRgb = "255,255,255"
         };
+
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using ImGuiNET;
 using Microsoft.Xna.Framework.Input;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Config;
 using Wobble;
 using Wobble.Graphics.ImGUI;
 using Wobble.Input;
@@ -71,7 +72,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorScrollVelocityPanel(EditScreen screen) : base(false, GetOptions())
+        public EditorScrollVelocityPanel(EditScreen screen) : base(false, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -72,7 +72,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorScrollVelocityPanel(EditScreen screen) : base(false, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
+        public EditorScrollVelocityPanel(EditScreen screen) : base(false, GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -75,7 +75,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorTimingPointPanel(EditScreen screen) : base(false, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
+        public EditorTimingPointPanel(EditScreen screen) : base(false, GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -6,6 +6,7 @@ using ImGuiNET;
 using Microsoft.Xna.Framework.Input;
 using Quaver.API.Enums;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Edit.Actions.Timing.AddBatch;
 using TagLib.Matroska;
 using TagLib.Riff;
@@ -74,7 +75,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorTimingPointPanel(EditScreen screen) : base(false, GetOptions())
+        public EditorTimingPointPanel(EditScreen screen) : base(false, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -59,7 +59,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         private static bool DestroyContext { get; } = true;
 #endif
 
-        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions()) => Screen = screen;
+        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f) => Screen = screen;
 
 
         /// <inheritdoc />
@@ -67,9 +67,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         /// </summary>
         protected override void RenderImguiLayout()
         {
-            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2);
-            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 10));
-            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(12, 4));
+            var scale = ConfigManager.EditorImGuiScalePercentage.Value / 100f;
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2 * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 10) * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(12, 4) * scale);
             ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0, 24, 0));
             ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0, 0, 24, 0));
 

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -59,7 +59,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         private static bool DestroyContext { get; } = true;
 #endif
 
-        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f) => Screen = screen;
+        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions(), screen.ImGuiScale) => Screen = screen;
 
 
         /// <inheritdoc />
@@ -67,10 +67,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         /// </summary>
         protected override void RenderImguiLayout()
         {
-            var scale = ConfigManager.EditorImGuiScalePercentage.Value / 100f;
-            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2 * scale);
-            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 10) * scale);
-            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(12, 4) * scale);
+            ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 2 * Screen.ImGuiScale);
+            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 10) * Screen.ImGuiScale);
+            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(12, 4) * Screen.ImGuiScale);
             ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0, 24, 0));
             ImGui.PushStyleColor(ImGuiCol.WindowBg, new Vector4(0, 0, 24, 0));
 

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -408,7 +408,8 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Prefer Wayland", ConfigManager.PreferWayland)
                         {
                             Tags = new List<string> {"linux"}
-                        }
+                        },
+                        new OptionsSlider(containerRect, "Editor ImGui Scale", ConfigManager.EditorImGuiScalePercentage)
                     }),
                     new OptionsSubcategory("Audio", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -7,6 +7,7 @@ using ImGuiNET;
 using Microsoft.Xna.Framework.Input;
 using MoonSharp.Interpreter;
 using Quaver.API.Maps.Structures;
+using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Edit.UI.Menu;
 using Wobble;
 using Wobble.Graphics.ImGUI;
@@ -45,7 +46,7 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         /// <param name="filePath"></param>
         /// <param name="isResource"></param>
-        public LuaImGui(string filePath, bool isResource = false) : base(false, EditorFileMenuBar.GetOptions())
+        public LuaImGui(string filePath, bool isResource = false) : base(false, EditorFileMenuBar.GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
         {
             FilePath = filePath;
             IsResource = isResource;


### PR DESCRIPTION
Requires https://github.com/Quaver/Wobble/pull/139

The only issue I see with this is this:

![image](https://github.com/Quaver/Quaver/assets/32996262/cc156e92-be9a-4899-9918-db896acb9024)

There is a little gap between the menu bar and its options.