### PR TITLE
Fix wrong map selected after playtesting after changing difficulty within editor

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1617,6 +1617,7 @@ namespace Quaver.Shared.Screens.Edit
             {
                 try
                 {
+                    MapManager.Selected.Value = map;
                     var track = AudioEngine.LoadMapAudioTrack(map);
 
                     Exit(() => new EditScreen(map, track));


### PR DESCRIPTION
If you start editing a difficulty A of the map and switch to difficulty B, after playtesting the screen returns to difficulty A. This PR fixes this.