### PR TITLE
Display plugin errors

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -24,9 +24,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// </summary>
         public bool IsWindowHovered { get; set; }
 
-        /// <summary>
-        /// </summary>
-        public string Name { get; set; }
+        /// <inheritdoc/>
+        public override string Name { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -134,7 +134,6 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         protected override void RenderImguiLayout()
         {
-            // Prevents exception spam
             // Prevents exception spam: No one needs more than 10 hot reloads per second.
             if (DateTime.Now - LastException < TimeSpan.FromMilliseconds(100))
                 return;

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -309,7 +309,7 @@ namespace Quaver.Shared.Scripting
             };
 
             var callStack = (e as InterpreterException)?.CallStack is { } list
-                ? $"\nCall stack:\n{string.Join("\n", list.Select(x => $"{x.Name}{(x.Location is { } location ? $"at {FormatSource(location)}" : "")}"))}"
+                ? $"\nCall stack:\n{string.Join("\n", list.Select(x => $"{x.Name}{(x.Location is { } location ? $" at {FormatSource(location)}" : "")}"))}"
                 : "";
 
             NotificationManager.Show(NotificationLevel.Error, $"Plugin {name} caused {summary} error{message}{callStack}");

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Numerics;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using ImGuiNET;
 using Microsoft.Xna.Framework.Input;
 using MoonSharp.Interpreter;
@@ -134,7 +135,8 @@ namespace Quaver.Shared.Scripting
         protected override void RenderImguiLayout()
         {
             // Prevents exception spam
-            if (DateTime.Now - LastException < TimeSpan.FromSeconds(1))
+            // Prevents exception spam: No one needs more than 10 hot reloads per second.
+            if (DateTime.Now - LastException < TimeSpan.FromMilliseconds(100))
                 return;
 
             try
@@ -210,7 +212,7 @@ namespace Quaver.Shared.Scripting
                 }
                 else
                 {
-                    Thread.Sleep(1);
+                    Thread.Sleep(10);
                     ScriptText = File.ReadAllText(FilePath);
                 }
 

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -134,8 +134,8 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         protected override void RenderImguiLayout()
         {
-            // Prevents exception spam: No one needs more than 10 hot reloads per second.
-            if (DateTime.Now - LastException < TimeSpan.FromMilliseconds(100))
+            // Prevents exception spam: No one needs more than 2 hot reloads per second.
+            if (DateTime.Now - LastException < TimeSpan.FromMilliseconds(500))
                 return;
 
             try
@@ -311,6 +311,9 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         private void HandleLuaException(Exception e)
         {
+            if (DateTime.Now - LastException < TimeSpan.FromMilliseconds(100))
+            	return;
+
             LastException = DateTime.Now;
             Logger.Error(e, LogType.Runtime);
 

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -30,9 +30,13 @@ namespace Quaver.Shared.Scripting
         private string FilePath { get; }
 
         // <summary>
-        // Gets the name of the plugin
+        // Gets or sets the name of the plugin
         // </summary>
-        private string Name => Path.GetFileName(Path.GetDirectoryName(FilePath));
+        public virtual string Name
+        {
+        	get => Path.GetFileName(Path.GetDirectoryName(FilePath));
+        	set { }
+        }
 
         // <summary>
         // Determines whether an exception has occured.

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -147,7 +147,6 @@ namespace Quaver.Shared.Scripting
             }
             catch (Exception e)
             {
-                CausedException = true;
                 HandleLuaException(e);
             }
         }
@@ -310,6 +309,7 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         private void HandleLuaException(Exception e)
         {
+            CausedException = true;
             Logger.Error(e, LogType.Runtime);
 
     	    var summary = e switch

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -28,6 +28,11 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         private string FilePath { get; }
 
+        // <summary>
+        // Determines whether an exception has occured.
+        // </summary>
+        private bool CausedException { get; set; }
+
         /// <summary>
         /// </summary>
         private bool IsResource { get; }
@@ -117,6 +122,10 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         protected override void RenderImguiLayout()
         {
+            // Prevents exception spam
+            if (CausedException)
+                return;
+
             try
             {
                 SetFrameState();
@@ -125,6 +134,7 @@ namespace Quaver.Shared.Scripting
             }
             catch (Exception e)
             {
+                CausedException = true;
                 HandleLuaException(e);
             }
         }
@@ -176,6 +186,7 @@ namespace Quaver.Shared.Scripting
         /// </summary>
         private void LoadScript()
         {
+            CausedException = false;
             WorkingScript = new Script(CoreModules.Preset_HardSandbox);
 
             try

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -139,7 +139,10 @@ namespace Quaver.Shared.Scripting
             try
             {
                 SetFrameState();
-                WorkingScript.Call(WorkingScript.Globals["draw"]);
+
+                if (WorkingScript.Globals["draw"] is Closure draw)
+                    WorkingScript.Call(draw);
+
                 AfterRender();
             }
             catch (Exception e)

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -210,6 +210,7 @@ namespace Quaver.Shared.Scripting
                 }
                 else
                 {
+                    Thread.Sleep(1);
                     ScriptText = File.ReadAllText(FilePath);
                 }
 


### PR DESCRIPTION
Extensive error handler to format and display error messages to the user. Here are some example messages:

- Syntax errors
![image](https://github.com/Quaver/Quaver/assets/14614115/716d3968-43ff-4932-a335-79209d33c178)

- `Nil` dereference
![image](https://github.com/Quaver/Quaver/assets/14614115/b4ea43ef-e439-431c-83d5-d4a41311470b)
![image](https://github.com/Quaver/Quaver/assets/14614115/7919b926-db02-43ad-b201-fbbc435ee22c)

- Explicit `error` calls
![image](https://github.com/Quaver/Quaver/assets/14614115/dd4df328-2f9a-4247-8a16-08b49be56479)

- Stack overflow (unfortunately due to the way the lua engine works, a call stack *cannot* be produced)
![image](https://github.com/Quaver/Quaver/assets/14614115/376ab225-d7b9-4474-8721-7aa0afeaaf2e)

Additionally adds a custom override for `print`. Instead of printing to the console, which isn't how anyone runs the application, it is shown as a notification element.
![image](https://github.com/Quaver/Quaver/assets/14614115/80400236-1183-4489-8a72-8e857e08f682)
