### PR TITLE
Fix audio seeking issues in map preview

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -75,6 +75,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         private Qua Map;
 
         /// <summary>
+        ///     Cached length of the map
+        /// </summary>
+        private int Length { get; set; }
+
+        /// <summary>
         ///     Number of lanes
         /// </summary>
         private int KeyCount { get; }
@@ -239,7 +244,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     return false;
 
                 // Wait for dead LNs to finish scrolling
-                return CurrentVisualAudioOffset > Map.Length;
+                return CurrentVisualAudioOffset > Length;
             }
         }
 
@@ -308,6 +313,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         {
             Ruleset = ruleset;
             Map = map.WithNormalizedSVs();
+            Length = Map.Length;
             KeyCount = Map.GetKeyCount(Map.HasScratchKey);
 
             // Initialize SV

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/Lines/TimingLineManager.cs
@@ -101,6 +101,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
             SpatialHashMap = new SpatialHashMap<TimingLineInfo>(HitObjectManager.RenderThreshold * 2);
 
             // Generate timing line info
+            var mapLength = map.Length;
             for (var i = 0; i < map.TimingPoints.Count; i++)
             {
                 if (map.TimingPoints[i].Hidden)
@@ -108,7 +109,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Lines
 
                 // Get target position and increment
                 // Target position has tolerance of 1ms so timing points dont overlap by chance
-                var target = i + 1 < map.TimingPoints.Count ? map.TimingPoints[i + 1].StartTime - 1 : map.Length;
+                var target = i + 1 < map.TimingPoints.Count ? map.TimingPoints[i + 1].StartTime - 1 : mapLength;
 
                 var signature = (int)map.TimingPoints[i].Signature;
 

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -77,7 +77,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         /// <summary>
         ///     The custom audio track for this container
         /// </summary>
-        private IAudioTrack Track { get; }
+        private IAudioTrack Track { get; set; }
 
         /// <summary>
         ///     The Qua that'll be used if one is passed in through the constructor
@@ -136,7 +136,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         {
             UpdateGameplayScreen(gameTime);
 
-            TrackInPreviousFrame = Track ?? AudioEngine.Track;
             base.Update(gameTime);
         }
 
@@ -358,6 +357,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                     if (SeekBar != null)
                         SeekBar.Track = AudioEngine.Track;
 
+                    Track = AudioEngine.Track;
+                    TrackInPreviousFrame = Track;
+                    
                     LoadedGameplayScreen?.HandleReplaySeeking();
                 }
 

--- a/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentSongLength.cs
+++ b/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentSongLength.cs
@@ -6,17 +6,17 @@ namespace Quaver.Shared.Screens.Tournament.Overlay.Components
 {
     public sealed class TournamentSongLength : TournamentOverlaySpriteText
     {
-        private Qua Qua { get; }
+        private int Length { get; }
 
         public TournamentSongLength(Qua qua, TournamentDrawableSettings settings) : base(settings)
         {
-            Qua = qua;
+            Length = qua.Length;
             SetText();
         }
 
         public override void UpdateState()
         {
-            Text = $"{TimeSpan.FromMilliseconds(Qua.Length):mm\\:ss}";
+            Text = $"{TimeSpan.FromMilliseconds(Length):mm\\:ss}";
             base.UpdateState();
         }
     }


### PR DESCRIPTION
* The audio track instance is not properly updated when the track ends. This causes the 2fps issue
*  * I think we should do some tests as to why this would cause the framedrop dramatically
* If dragging to the very end of the audio and not let go, the audio will keep being reloaded, seeked to the end and reloaded and so on and so forth. This also dramatically drops the fps. Now, we refuse to seek to within the last second of the audio in map preview seek bar.