### PR TITLE
Fix visual and logical bugs in accuracy, score and rating display in tournament spectating

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -200,11 +200,6 @@ namespace Quaver.Shared.Screens.Gameplay
         /// </summary>
         private ReplayController ReplayController { get; }
 
-        private ScoreProcessor DisplayScoreProcessor =>
-            ConfigManager.DisplayRankedAccuracy.Value || Screen.IsSpectatingTournament
-                ? Screen.Ruleset.StandardizedReplayPlayer.ScoreProcessor
-                : Screen.Ruleset.ScoreProcessor;
-
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -461,11 +456,13 @@ namespace Quaver.Shared.Screens.Gameplay
         public void UpdateScoreAndAccuracyDisplays()
         {
             // Update score and accuracy displays
-            var displayScoreProcessor = DisplayScoreProcessor;
+            ScoreDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Score);
 
-            ScoreDisplay.UpdateValue(displayScoreProcessor.Score);
-            RatingDisplay.UpdateValue(RatingProcessor.CalculateRating(displayScoreProcessor.Accuracy));
-            AccuracyDisplay.UpdateValue(displayScoreProcessor.Accuracy);
+            RatingDisplay.UpdateValue(RatingProcessor.CalculateRating(Screen.Ruleset.StandardizedReplayPlayer.ScoreProcessor.Accuracy));
+            if (ConfigManager.DisplayRankedAccuracy.Value || Screen.IsSpectatingTournament)
+                AccuracyDisplay.UpdateValue(Screen.Ruleset.StandardizedReplayPlayer.ScoreProcessor.Accuracy);
+            else
+                AccuracyDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Accuracy);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Replays/ReplayCapturer.cs
+++ b/Quaver.Shared/Screens/Gameplay/Replays/ReplayCapturer.cs
@@ -88,10 +88,11 @@ namespace Quaver.Shared.Screens.Gameplay.Replays
                 var inputManager = (KeysInputManager) Screen.Ruleset.InputManager;
                 var replayInputManager = inputManager.ReplayInputManager;
 
-                if (Screen.Ruleset.StandardizedReplayPlayer.Replay.Frames.Count == replayInputManager.CurrentFrame + 1)
-                    return;
-
-                for (var i = Screen.Ruleset.StandardizedReplayPlayer.Replay.Frames.Count; i < replayInputManager.CurrentFrame + 1; i++)
+                // Sync up to current frame
+                // i is frame index of ReplayInputManager
+                // There is one more frame -10000 added in the constructor of ReplayCapturer than ReplayInputManager,
+                // so we start with i = count - 1
+                for (var i = Replay.Frames.Count - 1; i < replayInputManager.CurrentFrame + 1; i++)
                 {
                     if (i >= replayInputManager.VirtualPlayer.Replay.Frames.Count)
                         break;


### PR DESCRIPTION
### Fix off-by-one error in ReplayCapturer
This happens **exclusively** on multiplayer tournament spectating, because otherwise `StandardizedReplayPlayer` has a different frame adding logic.
Below is the frame adding behavior before this fix. Notice the skipping of some frames. *There are two players, so there are two instances of `ReplayCapturer` and `StandardizedReplayPlayer` running at the same time.*
![image](https://github.com/Quaver/Quaver/assets/32996262/b37fcd58-bbac-418f-ad09-8d6fbf7a6518)
Below is the corrected behavior:
![image](https://github.com/Quaver/Quaver/assets/32996262/c7f4621a-5007-413c-9081-bf2595da5dd3)

Notice that the frame adding is no longer skipping.

### Fix display of score, accuracy and rating

Reverted the changes to their display. Now it will only display the standardized accuracy in tournament. 