### PR TITLE
Scale time threshold for detecting !mp end and returning to MultiplayerGameScreen by audio rate

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreenView.cs
@@ -883,7 +883,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             if (Screen is TournamentGameplayScreen)
             {
-                if (Screen.Map.Length - Screen.Timing.Time >= 10000)
+                if (Screen.Map.Length - Screen.Timing.Time >= 10000 * ModHelper.GetRateFromMods(ModManager.Mods))
                     Screen.Exit(() => new MultiplayerGameScreen());
                 return;
             }


### PR DESCRIPTION
When a rate is applied, e.g. 2.0x, then the spectator will return to the game lobby when it is at least 5 seconds behind, which makes it easier to unexpectedly quit. This PR applies rate to time detection to resolve this issue.