### PR TITLE
Account for sudden map deletion

### DIFF
--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -904,12 +904,12 @@ namespace Quaver.Shared.Screens.Selection
 
                 if (e.Index - 1 >= 0)
                     index = e.Index - 1;
-                ;
+
                 lock (AvailableMapsets.Value)
                     AvailableMapsets.Value = MapsetHelper.FilterMapsets(CurrentSearchQuery);
 
                 // Change the map
-                if (index != -1)
+                if (index >= 0 && index < AvailableMapsets.Value.Count)
                 {
                     MapManager.SelectMapFromMapset(AvailableMapsets.Value[index]);
                     return;


### PR DESCRIPTION
Current stable build can cause `ArgumentOutOfRangeException` if user deletes a chart, sometimes.

```
[1:55:21] - RUNTIME - DEBUG: Deleted map: 4f633542553b5667186a8cafad30ab2a (#5023) in the cache
[1:55:21] - RUNTIME - ERROR: System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.get_Item(Int32 index)
   at Quaver.Shared.Screens.Selection.SelectionScreen.<>c__DisplayClass77_0.<OnMapsetDeleted>b__0() in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Selection\SelectionScreen.cs:line 914
   at Quaver.Shared.Scheduling.ThreadScheduler.<>c__DisplayClass1_0.<Run>b__0() in D:\QuaverDeploy\Quaver\Quaver.Shared\Scheduling\ThreadScheduler.cs:line 38
```