### PR TITLE
Hot Reload Skin on Change

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -634,6 +634,10 @@ namespace Quaver.Shared.Config
 
         /// <summary>
         /// </summary>
+        internal static Bindable<bool> ReloadSkinOnChange { get; private set; }
+
+        /// <summary>
+        /// </summary>
         internal static Bindable<bool> EnableRealtimeOnlineScoreboard { get; private set; }
 
         /// <summary>
@@ -1160,6 +1164,7 @@ namespace Quaver.Shared.Config
             TintHitLightingBasedOnJudgementColor = ReadValue(@"TintHitLightingBasedOnJudgementColor", false, data);
             Display1v1TournamentOverlay = ReadValue(@"Display1v1TournamentOverlay", true, data);
             TournamentDisplay1v1PlayfieldScores = ReadValue(@"TournamentDisplay1v1PlayfieldScores", true, data);
+            ReloadSkinOnChange = ReadValue(@"ReloadSkinOnChange", false, data);
             EnableRealtimeOnlineScoreboard = ReadValue(@"EnableRealtimeOnlineScoreboard", false, data);
             ScratchLaneLeft4K = ReadValue(@"ScratchLaneLeft4K", true, data);
             ScratchLaneLeft7K = ReadValue(@"ScratchLaneLeft7K", true, data);

--- a/Quaver.Shared/Helpers/StringHelper.cs
+++ b/Quaver.Shared/Helpers/StringHelper.cs
@@ -5,6 +5,8 @@
  * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
 */
 
+using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -81,6 +83,40 @@ namespace Quaver.Shared.Helpers
                     return num + "th";
             }
 
+        }
+        
+        /// <summary>
+        ///     Checks whether the candidate is a subdirectory of the other, recursively.
+        ///     Adapted from https://stackoverflow.com/a/23354773/23723435
+        /// </summary>
+        /// <param name="candidate"></param>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public static bool IsSubDirectoryOf(this string candidate, string other)
+        {
+            var isChild = false;
+            try
+            {
+                var candidateInfo = new DirectoryInfo(candidate);
+                var otherInfo = new DirectoryInfo(other);
+
+                while (candidateInfo.Parent != null)
+                {
+                    if (candidateInfo.Parent.FullName == otherInfo.FullName)
+                    {
+                        isChild = true;
+                        break;
+                    }
+                    candidateInfo = candidateInfo.Parent;
+                }
+            }
+            catch (Exception error)
+            {
+                var message = $"Unable to check directories {candidate} and {other}: {error}";
+                Trace.WriteLine(message);
+            }
+
+            return isChild;
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayAudioTiming.cs
@@ -50,7 +50,7 @@ namespace Quaver.Shared.Screens.Gameplay
         {
             Screen = screen;
 
-            if (Screen.IsSongSelectPreview)
+            if (Screen.IsSongSelectPreview || Screen.UseExistingAudioTime)
                 return;
 
             try

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -496,6 +496,9 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!InReplayMode && ConfigManager.LockWinkeyDuringGameplay.Value)
                 Utils.NativeUtils.DisableWindowsKey();
 
+            if (InReplayMode)
+                SkinManager.StartWatching();
+
             base.OnFirstUpdate();
         }
 
@@ -562,6 +565,7 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             Metronome?.Dispose();
+            SkinManager.StopWatching();
             IsDisposed = true;
             base.Destroy();
         }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -496,7 +496,7 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!InReplayMode && ConfigManager.LockWinkeyDuringGameplay.Value)
                 Utils.NativeUtils.DisableWindowsKey();
 
-            if (InReplayMode && !IsPlayTesting)
+            if (InReplayMode && !IsPlayTesting && !IsSongSelectPreview && !IsCalibratingOffset)
             {
                 SkinManager.StartWatching();
                 ScreenExiting += (_, _) => SkinManager.StopWatching();

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -496,8 +496,11 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!InReplayMode && ConfigManager.LockWinkeyDuringGameplay.Value)
                 Utils.NativeUtils.DisableWindowsKey();
 
-            if (InReplayMode)
+            if (InReplayMode && !IsPlayTesting)
+            {
                 SkinManager.StartWatching();
+                ScreenExiting += (_, _) => SkinManager.StopWatching();
+            }
 
             base.OnFirstUpdate();
         }
@@ -565,7 +568,6 @@ namespace Quaver.Shared.Screens.Gameplay
             }
 
             Metronome?.Dispose();
-            SkinManager.StopWatching();
             IsDisposed = true;
             base.Destroy();
         }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -334,6 +334,12 @@ namespace Quaver.Shared.Screens.Gameplay
         ///     If true, the gameplay screen is solely for song select preview usage
         /// </summary>
         public bool IsSongSelectPreview { get; }
+        
+        /// <summary>
+        ///     If true, the gameplay screen won't seek to the start when loaded.
+        ///     This is used for skin hot-reloading.
+        /// </summary>
+        public bool UseExistingAudioTime { get; }
 
         /// <summary>
         ///     Used to reset the input manager when toggling autoplay on/off.
@@ -371,9 +377,10 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <param name="options"></param>
         /// <param name="isSongSelectPreview"></param>
         /// <param name="isTestPlayingInNewEditor"></param>
+        /// <param name="useExistingAudioTime"></param>
         public GameplayScreen(Qua map, string md5, List<Score> scores, Replay replay = null, bool isPlayTesting = false, double playTestTime = 0,
             bool isCalibratingOffset = false, SpectatorClient spectatorClient = null, TournamentPlayerOptions options = null, bool isSongSelectPreview = false,
-            bool isTestPlayingInNewEditor = false)
+            bool isTestPlayingInNewEditor = false, bool useExistingAudioTime = false)
         {
             if (isPlayTesting && !isSongSelectPreview)
             {
@@ -398,6 +405,7 @@ namespace Quaver.Shared.Screens.Gameplay
             SpectatorClient = spectatorClient;
             TournamentOptions = options;
             IsSongSelectPreview = isSongSelectPreview;
+            UseExistingAudioTime = useExistingAudioTime;
 
             if (TournamentOptions != null && !(this is TournamentGameplayScreen))
                 throw new InvalidOperationException("Cannot provide tournament options for a non-tournament gameplay screen");

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -97,6 +97,7 @@ namespace Quaver.Shared.Screens.Main
             GameBase.Game.GlobalUserInterface.Cursor.Show(1);
             GameBase.Game.GlobalUserInterface.Cursor.Alpha = 1;
             SkinManager.StartWatching();
+            ScreenExiting += (_, _) => SkinManager.StopWatching();
 
             base.OnFirstUpdate();
         }
@@ -111,7 +112,6 @@ namespace Quaver.Shared.Screens.Main
         {
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged -= OnAutoLoadOsuBeatmapsChanged;
             TheaterCheat.Destroy();
-            SkinManager.StopWatching();
             base.Destroy();
         }
 

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -23,6 +23,7 @@ using Quaver.Shared.Screens.Menu;
 using Quaver.Shared.Screens.MultiplayerLobby;
 using Quaver.Shared.Screens.Selection;
 using Quaver.Shared.Screens.Selection.UI.Dialogs;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Dialogs;
@@ -95,6 +96,7 @@ namespace Quaver.Shared.Screens.Main
 
             GameBase.Game.GlobalUserInterface.Cursor.Show(1);
             GameBase.Game.GlobalUserInterface.Cursor.Alpha = 1;
+            SkinManager.StartWatching();
 
             base.OnFirstUpdate();
         }
@@ -109,6 +111,7 @@ namespace Quaver.Shared.Screens.Main
         {
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged -= OnAutoLoadOsuBeatmapsChanged;
             TheaterCheat.Destroy();
+            SkinManager.StopWatching();
             base.Destroy();
         }
 

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -430,7 +430,8 @@ namespace Quaver.Shared.Screens.Options
                     new OptionsSubcategory("Skin", new List<OptionsItem>()
                     {
                         new OptionsItemCheckbox(containerRect, "Display 1v1 Tournament Overlay", ConfigManager.Display1v1TournamentOverlay),
-                        new OptionsItemCheckbox(containerRect, "Display 1v1 Playfield Scores", ConfigManager.TournamentDisplay1v1PlayfieldScores)
+                        new OptionsItemCheckbox(containerRect, "Display 1v1 Playfield Scores", ConfigManager.TournamentDisplay1v1PlayfieldScores),
+                        new OptionsItemCheckbox(containerRect, "Reload Skin On Change", ConfigManager.ReloadSkinOnChange)
                     }),
                     new OptionsSubcategory("Input", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -151,6 +151,7 @@ namespace Quaver.Shared.Screens.Selection
             FadeAudioTrackIn();
 
             SkinManager.StartWatching();
+            ScreenExiting += (_, _) => SkinManager.StopWatching();
 
             base.OnFirstUpdate();
         }

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -37,6 +37,7 @@ using Quaver.Shared.Screens.Selection.UI.Leaderboard;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;
 using Quaver.Shared.Screens.Tournament;
+using Quaver.Shared.Skinning;
 using Wobble;
 using Wobble.Audio.Tracks;
 using Wobble.Bindables;
@@ -148,6 +149,9 @@ namespace Quaver.Shared.Screens.Selection
         {
             GameBase.Game.GlobalUserInterface.Cursor.Alpha = 1;
             FadeAudioTrackIn();
+
+            SkinManager.StartWatching();
+
             base.OnFirstUpdate();
         }
 
@@ -180,6 +184,7 @@ namespace Quaver.Shared.Screens.Selection
             MapManager.MapDeleted -= OnMapDeleted;
             MapManager.MapUpdated -= OnMapUpdated;
             MapManager.SongRequestPlayed -= OnSongRequestPlayed;
+            SkinManager.StopWatching();
 
             // ReSharper disable once DelegateSubtraction
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged -= OnAutoLoadOsuBeatmapsChanged;

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -98,6 +98,7 @@ namespace Quaver.Shared.Skinning
             };
             Watcher.Changed += (sender, args) =>
             {
+                if (TimeSkinReloadRequested != 0) return;
                 Logger.Important($"Skin change detected. Reloading", LogType.Runtime);
                 TimeSkinReloadRequested = GameBase.Game.TimeRunning;
                 if (Skin.Dir.IsSubDirectoryOf(ConfigManager.SteamWorkshopDirectory.Value))

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -16,6 +16,7 @@ using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Gameplay;
 using Quaver.Shared.Screens.Main;
 using Quaver.Shared.Screens.Selection;
+using Quaver.Shared.Screens.Tournament.Gameplay;
 using SharpCompress.Archives;
 using SharpCompress.Common;
 using SharpCompress.Writers.Zip;
@@ -120,6 +121,18 @@ namespace Quaver.Shared.Skinning
                         break;
                     case QuaverScreenType.Select:
                         game.CurrentScreen.Exit(() => new SelectionScreen());
+                        break;
+                    case QuaverScreenType.Gameplay when 
+                        game.CurrentScreen is GameplayScreen gameplayScreen and not TournamentGameplayScreen
+                        && gameplayScreen.InReplayMode:
+                        game.CurrentScreen.Exit(() =>
+                        {
+                            var newScreen = new GameplayScreen(gameplayScreen.Map, gameplayScreen.MapHash,
+                                gameplayScreen.LocalScores, gameplayScreen.LoadedReplay,
+                                useExistingAudioTime: true);
+                            newScreen.HandleReplaySeeking();
+                            return newScreen;
+                        });
                         break;
                 }
 

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -142,6 +142,7 @@ namespace Quaver.Shared.Skinning
                 Load();
                 TimeSkinReloadRequested = 0;
                 SkinLoaded?.Invoke(typeof(SkinManager), new SkinReloadedEventArgs());
+                var showLoadedNotification = true;
 
                 var game = (QuaverGame) GameBase.Game;
 
@@ -156,6 +157,7 @@ namespace Quaver.Shared.Skinning
                     case QuaverScreenType.Gameplay when 
                         game.CurrentScreen is GameplayScreen gameplayScreen and not TournamentGameplayScreen
                         && gameplayScreen.InReplayMode:
+                        showLoadedNotification = ConfigManager.DisplayNotificationsInGameplay.Value;
                         game.CurrentScreen.Exit(() =>
                         {
                             var newScreen = new GameplayScreen(gameplayScreen.Map, gameplayScreen.MapHash,
@@ -171,7 +173,9 @@ namespace Quaver.Shared.Skinning
                 ThreadScheduler.RunAfter(() =>
                 {
                     Transitioner.FadeOut();
-                    NotificationManager.Show(NotificationLevel.Success, "Skin has been successfully loaded!");
+                    if (showLoadedNotification)
+                        NotificationManager.Show(NotificationLevel.Success, "Skin has been successfully loaded!",
+                            forceShow: true);
                 }, 200);
             }
         }

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -81,6 +81,9 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         public static void StartWatching()
         {
+            if (!ConfigManager.ReloadSkinOnChange.Value)
+                return;
+
             if (Watcher != null)
             {
                 Logger.Important($"Skin manager started watching skin.ini", LogType.Runtime);

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -129,6 +129,7 @@ namespace Quaver.Shared.Skinning
                         {
                             var newScreen = new GameplayScreen(gameplayScreen.Map, gameplayScreen.MapHash,
                                 gameplayScreen.LocalScores, gameplayScreen.LoadedReplay,
+                                spectatorClient: gameplayScreen.SpectatorClient,
                                 useExistingAudioTime: true);
                             newScreen.HandleReplaySeeking();
                             return newScreen;

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -11,6 +11,7 @@ using IniFileParser;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Graphics.Transitions;
+using Quaver.Shared.Helpers;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Gameplay;
@@ -99,6 +100,12 @@ namespace Quaver.Shared.Skinning
             {
                 Logger.Important($"Skin change detected. Reloading", LogType.Runtime);
                 TimeSkinReloadRequested = GameBase.Game.TimeRunning;
+                if (Skin.Dir.IsSubDirectoryOf(ConfigManager.SteamWorkshopDirectory.Value))
+                {
+                    NotificationManager.Show(NotificationLevel.Warning,
+                        $"You are making changes to a workshop skin! Changes to workshop skins might be lost when the skin updates!",
+                        forceShow: true);
+                }
             };
         }
 

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -64,22 +64,6 @@ namespace Quaver.Shared.Skinning
         public static void Load()
         {
             Skin = new SkinStore();
-            Watcher?.Dispose();
-            var path = Path.Combine(Skin.Dir, "skin.ini");
-            if (File.Exists(path))
-            {
-                Watcher = new FileSystemWatcher(Path.GetDirectoryName(path))
-                {
-                    NotifyFilter = NotifyFilters.LastWrite,
-                    EnableRaisingEvents = true,
-                    Filter = Path.GetFileName(path)
-                };
-                Watcher.Changed += (sender, args) =>
-                {
-                    Logger.Important($"Skin change detected. Reloading", LogType.Runtime);
-                    TimeSkinReloadRequested = GameBase.Game.TimeRunning;
-                };
-            }
 
             if (ConfigManager.TournamentPlayer2Skin.Value == null ||
                 ConfigManager.TournamentPlayer2Skin.Value == ConfigManager.Skin.Value)
@@ -89,6 +73,45 @@ namespace Quaver.Shared.Skinning
             }
 
             TournamentPlayer2Skin = new SkinStore(ConfigManager.TournamentPlayer2Skin.Value);
+        }
+
+        /// <summary>
+        ///     Start watching for changes in skin.ini
+        /// </summary>
+        public static void StartWatching()
+        {
+            if (Watcher != null)
+            {
+                Logger.Important($"Skin manager started watching skin.ini", LogType.Runtime);
+                Watcher.EnableRaisingEvents = true;
+                return;
+            }
+            var path = Path.Combine(Skin.Dir, "skin.ini");
+            if (!File.Exists(path)) return;
+            Logger.Important($"Skin manager started watching skin.ini", LogType.Runtime);
+            Watcher = new FileSystemWatcher(Path.GetDirectoryName(path))
+            {
+                NotifyFilter = NotifyFilters.LastWrite,
+                EnableRaisingEvents = true,
+                Filter = Path.GetFileName(path)
+            };
+            Watcher.Changed += (sender, args) =>
+            {
+                Logger.Important($"Skin change detected. Reloading", LogType.Runtime);
+                TimeSkinReloadRequested = GameBase.Game.TimeRunning;
+            };
+        }
+
+        /// <summary>
+        ///     Stops watching skin.ini
+        /// </summary>
+        public static void StopWatching()
+        {
+            if (Watcher == null) return;
+            Logger.Important($"Skin manager stopped watching skin.ini", LogType.Runtime);
+            // Dispose of the watcher
+            Watcher.Dispose();
+            Watcher = null;
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #4040 

It completely reloads the replay screen when `skin.ini` change is detected, while still preserving audio time.

It won't reload if spectating a tournament.