### PR TITLE
Update multiplayer mods when using mirror toggle keybind

### DIFF
--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -287,9 +287,9 @@ namespace Quaver.Shared.Screens.Multi
                 if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyToggleMirror.Value))
                 {
                     if (ModManager.IsActivated(ModIdentifier.Mirror))
-                        ModManager.RemoveMod(ModIdentifier.Mirror);
+                        ModManager.RemoveMod(ModIdentifier.Mirror, true);
                     else
-                        ModManager.AddMod(ModIdentifier.Mirror);
+                        ModManager.AddMod(ModIdentifier.Mirror, true);
                 }
             }
         }


### PR DESCRIPTION
Toggling mirror mods didn't get synced to multiplayer lobby mods. This PR fixed that.