### PR TITLE
Do not cull compact non-measure lines

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -290,19 +290,21 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// <param name="gameTime"></param>
         private void DrawLines(GameTime gameTime)
         {
-            const float minimumDistanceToDraw = 10;
+            const float minimumDistanceToDraw = 8;
 
             for (var i = 0; i < LinePool.Count; i++)
             {
                 var line = LinePool[i];
+                var previous = LinePool.FindLastIndex(i, i, x => x.IsMeasureLine);
+                var next = LinePool.FindIndex(i + 1, LinePool.Count - i - 1, x => x.IsMeasureLine);
                 line.SetPosition();
                 line.Tint = GetLineColor(line.Index % BeatSnap.Value, line.Index);
 
                 if (line.IsOnScreen() &&
-                    (i is 0 ||
-                        LinePool[i - 1].Y - line.Y > minimumDistanceToDraw ||
-                        i == LinePool.Count - 1 ||
-                        line.Y - LinePool[i + 1].Y > minimumDistanceToDraw))
+                    (previous is -1 ||
+                        next is -1 ||
+                        LinePool[previous].Y - line.Y > minimumDistanceToDraw ||
+                        line.Y - LinePool[next].Y > minimumDistanceToDraw))
                     line.Draw(gameTime);
             }
         }


### PR DESCRIPTION
Fixes #4093 while still culling BPM lines.

Preview:

![image](https://github.com/Quaver/Quaver/assets/14614115/c9f25b1a-7ca6-4202-8982-70f19fcbe903)
