### PR TITLE
Editor plugin QOL enhancements

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -24,9 +24,6 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// </summary>
         public bool IsWindowHovered { get; set; }
 
-        /// <inheritdoc/>
-        public override string Name { get; set; }
-
         /// <summary>
         /// </summary>
         public string Author { get; set; }
@@ -58,10 +55,9 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <param name="directory"></param>
         /// <param name="isWorkshop"></param>
         public EditorPlugin(EditScreen editScreen, string name, string author, string description, string filePath,
-            bool isResource = false, string directory = null, bool isWorkshop = false) : base(filePath, isResource)
+            bool isResource = false, string directory = null, bool isWorkshop = false) : base(filePath, isResource, name)
         {
             Editor = editScreen;
-            Name = name;
             Author = author;
             Description = description;
             IsBuiltIn = isResource;


### PR DESCRIPTION
This PR adds a number of quality of life features and bug fixes:

- The plugin reloading system is more aggressive, attempting multiple times instead of just once in case a file lock is held for a significant time. This should fix most issues regarding different programs writing to `plugin.lua` at once.

- An additional check is placed to ensure that the reloaded string contains valid syntax, since it is possible for text to be partially written to, which previously caused a false error to show up, which confused some plugin developers.

- Fix a bug where the name of the plugin wasn't shown when a runtime script error (not syntax error) occurred during initialization.

- Several guards are added to ensure that exception spamming is less likely, while still keeping relevant information. One of these guards is that subsequent calls to `draw` that produce the same error message repeatedly do not get shown until it is called successfully once, or a different error message shows up, or the file gets reloaded.

![image](https://github.com/Quaver/Quaver/assets/14614115/15a96e27-63b0-4c6b-9c8f-cd4931d3fda7)

- Better feedback is given if the file gets renamed.

![image](https://github.com/Quaver/Quaver/assets/14614115/9784d5bd-cff3-4217-80c3-a61b8422c034)

- You get explicit feedback for a plugin being reloaded.

![image](https://github.com/Quaver/Quaver/assets/14614115/2bd1ee8b-1561-40ce-9b7b-f3c0ecff1ca5)

- You can now log in various levels.

![image](https://github.com/Quaver/Quaver/assets/14614115/f31065d2-c7b9-4e6f-af25-b0f8a752fe7f)

- You can now `eval`, this is very useful for input boxes that would accept a formula. This is similar to the `dynamic` module, however the module is not used directly due to it leaking exceptions. The `eval` has the same amount of permissions as the script, except it is also unable to make function calls.

![image](https://github.com/Quaver/Quaver/assets/14614115/bc46e369-ea0c-42cf-9852-ea35af934e78)
