### PR TITLE
Add periodic editor map backups

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -81,7 +81,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     The temp directory
         /// </summary>
-        internal static string ChartBackupDirectory => Path.Join(BackupDirectory, "Charts");
+        internal static string MapBackupDirectory => Path.Join(BackupDirectory, "Maps");
 
         /// <summary>
         ///     The temp directory

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -76,6 +76,16 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     The temp directory
         /// </summary>
+        internal static string BackupDirectory => Path.Join(DataDirectory.Value, "Backups");
+
+        /// <summary>
+        ///     The temp directory
+        /// </summary>
+        internal static string ChartBackupDirectory => Path.Join(BackupDirectory, "Charts");
+
+        /// <summary>
+        ///     The temp directory
+        /// </summary>
         internal static string TempDirectory => Path.Join(DataDirectory.Value, "Temp");
 
         /// <summary>
@@ -288,7 +298,7 @@ namespace Quaver.Shared.Config
         ///     If true, hitsounds in gameplay will be played.
         /// </summary>
         internal static Bindable<bool> EnableHitsounds { get; private set; }
-        
+
         /// <summary>
         ///     If true, a hitsound will be played when releasing a long note
         /// </summary>
@@ -352,7 +362,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         /// </summary>
         internal static Bindable<bool> DisplayComboAlerts { get; private set; }
-        
+
         /// <summary>
         ///     Scaling of ImGui windows and texts
         /// </summary>
@@ -362,9 +372,9 @@ namespace Quaver.Shared.Config
         ///     The scroll speed used in the editor.
         /// </summary>
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
-        
+
         internal static Bindable<bool> EditorLiveMapSnap { get; private set; }
-        
+
         internal static BindableInt EditorLiveMapOffset { get; private set; }
 
         /// <summary>
@@ -554,19 +564,19 @@ namespace Quaver.Shared.Config
         /// <summary>
         /// </summary>
         internal static Bindable<bool> EditorShowSpectrogram { get; private set; }
-        
+
         internal static Bindable<int> EditorSpectrogramMaximumFrequency { get; private set; }
-        
+
         internal static Bindable<int> EditorSpectrogramMinimumFrequency { get; private set; }
-        
+
         internal static Bindable<float> EditorSpectrogramCutoffFactor { get; private set; }
-        
+
         internal static Bindable<float> EditorSpectrogramIntensityFactor { get; private set; }
-        
+
         internal static Bindable<EditorPlayfieldSpectrogramFrequencyScale> EditorSpectrogramFrequencyScale { get; private set; }
-        
+
         internal static BindableInt EditorSpectrogramFftSize { get; private set; }
-        
+
         /// <summary>
         ///     The number of times the song's fft will be taken. Linearly increases the time to load
         /// </summary>
@@ -812,7 +822,7 @@ namespace Quaver.Shared.Config
         /// </summary>
         internal static Bindable<Keys> KeyIncreaseMapOffset { get; private set; }
         internal static Bindable<Keys> KeyDecreaseMapOffset { get; private set; }
-        
+
         /// <summary>
         ///     The keys to toggle autoplay during playtesting
         /// </summary>
@@ -1184,7 +1194,7 @@ namespace Quaver.Shared.Config
 
             // Bind global inverted scrolling so ScrollContainers get InvertScrolling setting too
             ScrollContainer.GlobalInvertedScrolling = InvertScrolling;
-            
+
             // Have to do this manually.
             if (string.IsNullOrEmpty(Username.Value))
                 Username.Value = "Player";

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -322,8 +322,6 @@ namespace Quaver.Shared.Database.Maps
                 var mapsetPath = Path.Combine(ConfigManager.SongDirectory.Value, map.Mapset.Directory);
                 var path = Path.Combine(mapsetPath, map.Path);
 
-                // TODO: Consider moving the file instead to the trash, once a cross-platform solution is made available.
-                // Do not consider `Microsoft.VisualBasic.FileIO.FileSystem`; It is not cross-platform!
                 File.Delete(path);
                 MapDatabaseCache.RemoveMap(map);
             }
@@ -374,8 +372,6 @@ namespace Quaver.Shared.Database.Maps
             {
                 var directory = Path.Combine(ConfigManager.SongDirectory.Value, mapset.Directory);
 
-                // TODO: Consider moving the directory instead to the trash, once a cross-platform solution is made available.
-                // Do not consider `Microsoft.VisualBasic.FileIO.FileSystem`; It is not cross-platform!
                 Directory.Delete(directory, true);
             }
             catch (Exception e)

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -366,7 +366,7 @@ namespace Quaver.Shared.Database.Maps
 
                 AudioEngine.Track = new AudioTrackVirtual(300000);
 
-                if (oldTrack is { IsDisposed: false })
+                if (oldTrack != null && !oldTrack.IsDisposed)
                     oldTrack.Dispose();
             }
 

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Microsoft.Xna.Framework.Graphics;
@@ -24,12 +23,10 @@ using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
-using Quaver.Shared.Online;
 using Quaver.Shared.Online.API.Maps;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using RestSharp;
 using RestSharp.Extensions;
-using SQLite;
 using Wobble.Audio.Tracks;
 using Wobble.Bindables;
 using Wobble.Logging;
@@ -325,9 +322,9 @@ namespace Quaver.Shared.Database.Maps
                 var mapsetPath = Path.Combine(ConfigManager.SongDirectory.Value, map.Mapset.Directory);
                 var path = Path.Combine(mapsetPath, map.Path);
 
-                if (File.Exists(path))
-                    File.Delete(path);
-
+                // TODO: Consider moving the file instead to the trash, once a cross-platform solution is made available.
+                // Do not consider `Microsoft.VisualBasic.FileIO.FileSystem`; It is not cross-platform!
+                File.Delete(path);
                 MapDatabaseCache.RemoveMap(map);
             }
             catch (Exception e)
@@ -369,13 +366,17 @@ namespace Quaver.Shared.Database.Maps
 
                 AudioEngine.Track = new AudioTrackVirtual(300000);
 
-                if (oldTrack != null && !oldTrack.IsDisposed)
+                if (oldTrack is { IsDisposed: false })
                     oldTrack.Dispose();
             }
 
             try
             {
-                Directory.Delete(Path.Combine(ConfigManager.SongDirectory.Value, mapset.Directory), true);
+                var directory = Path.Combine(ConfigManager.SongDirectory.Value, mapset.Directory);
+
+                // TODO: Consider moving the directory instead to the trash, once a cross-platform solution is made available.
+                // Do not consider `Microsoft.VisualBasic.FileIO.FileSystem`; It is not cross-platform!
+                Directory.Delete(directory, true);
             }
             catch (Exception e)
             {

--- a/Quaver.Shared/Screens/Edit/Dialogs/Metadata/EditorMetadataDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/Metadata/EditorMetadataDialog.cs
@@ -46,7 +46,7 @@ namespace Quaver.Shared.Screens.Edit.Dialogs.Metadata
         private LabelledCheckbox LegacyLNRendering { get; set; }
 
         private Tooltip LegacyLNRenderingTooltip { get; } = new(
-            "When set to ON, forces the use of the old LN renderer. If your chart has no Scroll\nVelocity changes, you can safely ignore this option. The current LN renderer places\nthe head and tail to the earliest and latest positions reached, respectively. The old LN\nrenderer instead places them both wherever the playfield happens to be at the time.",
+            "When set to ON, forces the use of the old LN renderer. If your map has no Scroll\nVelocity changes, you can safely ignore this option. The current LN renderer places\nthe head and tail to the earliest and latest positions reached, respectively. The old LN\nrenderer instead places them both wherever the playfield happens to be at the time.",
             Color.White
         );
 

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1891,7 +1891,7 @@ namespace Quaver.Shared.Screens.Edit
 
         void MakeScheduledChartBackup(object _)
         {
-            if (BackupQua.EqualByValue(WorkingMap))
+            if (BackupQua?.EqualByValue(WorkingMap) ?? false)
                 return;
 
             var chartDirectory = Path.Join(ConfigManager.ChartBackupDirectory, Path.GetFileNameWithoutExtension(Map.Path));

--- a/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
+++ b/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
@@ -87,20 +87,20 @@ namespace Quaver.Shared.Screens.Initialization
         {
             Logger.Important($"Game initialization task complete!", LogType.Runtime);
 
-            new Thread(CleanOldChartBackups).Start();
+            new Thread(CleanOldMapBackups).Start();
 #if !VISUAL_TESTS
             QuaverScreenManager.ScheduleScreenChange(() => new MainMenuScreen());
 #endif
         }
 
-        private static void CleanOldChartBackups()
+        private static void CleanOldMapBackups()
         {
-            Logger.Important("Removing old chart backups...", LogType.Runtime);
-            Directory.CreateDirectory(ConfigManager.ChartBackupDirectory);
+            Logger.Important("Removing old map backups...", LogType.Runtime);
+            Directory.CreateDirectory(ConfigManager.MapBackupDirectory);
             var deleted = 0;
             var kept = 0;
 
-            foreach (var path in Directory.GetFiles(ConfigManager.ChartBackupDirectory, "*.qua", SearchOption.AllDirectories))
+            foreach (var path in Directory.GetFiles(ConfigManager.MapBackupDirectory, "*.qua", SearchOption.AllDirectories))
             {
                 if (!DateTime.TryParse(Path.GetFileNameWithoutExtension(path).Replace('_', ':'), out var time) ||
                     DateTime.Now - time <= _removeBackupInterval)
@@ -114,13 +114,13 @@ namespace Quaver.Shared.Screens.Initialization
             }
 
             var emptyDirectories = Directory
-               .GetDirectories(ConfigManager.ChartBackupDirectory)
+               .GetDirectories(ConfigManager.MapBackupDirectory)
                .Where(path => !Directory.EnumerateFiles(path).Any());
 
             foreach (var directory in emptyDirectories)
                 Directory.Delete(directory);
 
-            Logger.Important($"Removed {deleted} chart backup(s) while keeping {kept}.", LogType.Runtime);
+            Logger.Important($"Removed {deleted} map backup(s) while keeping {kept}.", LogType.Runtime);
         }
 
         public override UserClientStatus GetClientStatus() => null;

--- a/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
+++ b/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
@@ -1,13 +1,13 @@
-﻿using System.Threading;
-using Microsoft.Xna.Framework;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using Quaver.Server.Common.Objects;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Transitions;
 using Quaver.Shared.Online;
-using Quaver.Shared.Scheduling;
-using Quaver.Shared.Screens.Beta;
 using Quaver.Shared.Screens.Main;
 using Quaver.Shared.Skinning;
 using Steamworks;
@@ -19,6 +19,8 @@ namespace Quaver.Shared.Screens.Initialization
 {
     public sealed class InitializationScreen : QuaverScreen
     {
+        static readonly TimeSpan _removeBackupInterval = TimeSpan.FromDays(2);
+
         public override QuaverScreenType Type { get; } = QuaverScreenType.Initialization;
 
         private TaskHandler<int, int> InitializationTask { get; }
@@ -85,9 +87,40 @@ namespace Quaver.Shared.Screens.Initialization
         {
             Logger.Important($"Game initialization task complete!", LogType.Runtime);
 
+            new Thread(CleanOldChartBackups).Start();
 #if !VISUAL_TESTS
             QuaverScreenManager.ScheduleScreenChange(() => new MainMenuScreen());
 #endif
+        }
+
+        private static void CleanOldChartBackups()
+        {
+            Logger.Important("Removing old chart backups...", LogType.Runtime);
+            Directory.CreateDirectory(ConfigManager.ChartBackupDirectory);
+            var deleted = 0;
+            var kept = 0;
+
+            foreach (var path in Directory.GetFiles(ConfigManager.ChartBackupDirectory, "*.qua", SearchOption.AllDirectories))
+            {
+                if (!DateTime.TryParse(Path.GetFileNameWithoutExtension(path).Replace('_', ':'), out var time) ||
+                    DateTime.Now - time <= _removeBackupInterval)
+                {
+                    kept++;
+                    continue;
+                }
+
+                deleted++;
+                File.Delete(path);
+            }
+
+            var emptyDirectories = Directory
+               .GetDirectories(ConfigManager.ChartBackupDirectory)
+               .Where(path => !Directory.EnumerateFiles(path).Any());
+
+            foreach (var directory in emptyDirectories)
+                Directory.Delete(directory);
+
+            Logger.Important($"Removed {deleted} chart backup(s) while keeping {kept}.", LogType.Runtime);
         }
 
         public override UserClientStatus GetClientStatus() => null;


### PR DESCRIPTION
This PR adds a backup system for charting.

- Every 5 minutes, a scheduler checks if any modifications have been made to the chart, and in which case an automatic copy is saved in the form of `./Data/Backups/Charts/<NameOfQua>/<Timestamp>.qua`.
- Additionally, a check is added on the game's startup to delete every chart backup older than 48 hours.

The exact time intervals are chosen arbitrarily, although I don't think it's worth adding a setting for.