### PR TITLE
Detect OSX command key

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -661,8 +661,7 @@ namespace Quaver.Shared
         /// </summary>
         private void HandleKeyPressCtrlO()
         {
-            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
-                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (!KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.O))
@@ -692,7 +691,7 @@ namespace Quaver.Shared
         private void HandleKeyPressCtrlS()
         {
             // Check for modifier keys
-            if (!(KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
+            if (!KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.S))

--- a/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
+++ b/Quaver.Shared/Screens/Downloading/DownloadingScreen.cs
@@ -327,7 +327,7 @@ namespace Quaver.Shared.Screens.Downloading
         {
             var state = KeyboardManager.CurrentState;
 
-            if (state.IsKeyUp(Keys.LeftControl) && state.IsKeyUp(Keys.RightControl))
+            if (!KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.P))

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -404,7 +404,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 if (ImGui.Button($"{TimeSpan.FromMilliseconds(sv.StartTime):mm\\:ss\\.fff}"))
                 {
                     // User holds down control, so add/remove it from the currently list of selected points
-                    if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                    if (KeyboardManager.IsCtrlDown())
                     {
                         if (isSelected)
                             SelectedScrollVelocities.Remove(sv);
@@ -463,8 +463,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             if (!IsWindowHovered)
                 return;
 
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
-                KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
             {
                 // Select all
                 if (KeyboardManager.IsUniqueKeyPress(Keys.A))

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -441,7 +441,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                 if (ImGui.Button($"{TimeSpan.FromMilliseconds(point.StartTime):mm\\:ss\\.fff}"))
                 {
                     // User holds down control, so add/remove it from the currently list of selected points
-                    if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                    if (KeyboardManager.IsCtrlDown())
                     {
                         if (isSelected)
                             SelectedTimingPoints.Remove(point);
@@ -510,8 +510,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             if (!IsWindowHovered)
                 return;
 
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
-                KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
             {
                 // Select all
                 if (KeyboardManager.IsUniqueKeyPress(Keys.A))

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1371,7 +1371,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (Tool.Value != EditorCompositionTool.Select)
                 return;
 
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
             {
                 if (SelectedHitObjects.Value.Contains(hoveredObject.Info))
                     SelectedHitObjects.Remove(hoveredObject.Info);

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
@@ -135,7 +135,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
             if (!GraphicsHelper.RectangleContains(clickArea, MouseManager.CurrentState.Position))
                 return;
 
-            if (KeyboardManager.CurrentState.IsKeyUp(Keys.LeftControl) && KeyboardManager.CurrentState.IsKeyUp(Keys.RightControl))
+            if (!KeyboardManager.IsCtrlDown())
                 SelectedHitObjects.Clear();
 
             IsSelecting = true;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -600,8 +600,7 @@ namespace Quaver.Shared.Screens.Gameplay
                 ConfigManager.ScoreboardVisible.Value = !ConfigManager.ScoreboardVisible.Value;
 
             // CTRL+ input while play testing
-            if (!IsSongSelectPreview && IsPlayTesting && (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
-                                  KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl)))
+            if (!IsSongSelectPreview && IsPlayTesting && KeyboardManager.IsCtrlDown())
             {
                 if (KeyboardManager.IsUniqueKeyPress(Keys.P))
                 {
@@ -1626,8 +1625,7 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!IsSongSelectPreview && Ruleset.Screen.Timing.Time <= 5000 || Ruleset.Screen.EligibleToSkip)
             {
                 var change = 5;
-                if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) ||
-                    KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+                if (KeyboardManager.IsCtrlDown())
                 {
                     change = 1;
                 }

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -148,7 +148,7 @@ namespace Quaver.Shared.Screens.Main
         ///	</summary>
         private void HandleKeyPressF5()
         {
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -320,7 +320,7 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         private void HandleKeyPressF3()
         {
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F3))
@@ -336,7 +336,7 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         private void HandleKeyPressF4()
         {
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F4))
@@ -353,7 +353,7 @@ namespace Quaver.Shared.Screens.Selection
         ///	</summary>
         private void HandleKeyPressF5()
         {
-            if (KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (KeyboardManager.IsCtrlDown())
                 return;
 
             if (!KeyboardManager.IsUniqueKeyPress(Keys.F5))
@@ -427,8 +427,7 @@ namespace Quaver.Shared.Screens.Selection
         /// </summary>
         private void HandleKeyPressControlInput()
         {
-            if (!KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) &&
-                !KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            if (!KeyboardManager.IsCtrlDown())
                 return;
 
             var shiftHeld = KeyboardManager.IsShiftDown();

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetScrollContainer.cs
@@ -192,7 +192,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 ScrollToSelected();
             }
             // Move to the next difficulty of a mapset
-            else if ((KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            else if (KeyboardManager.IsCtrlDown()
                 && KeyboardManager.IsUniqueKeyPress(Keys.PageDown))
             {
                 InputEnabled = false;
@@ -223,7 +223,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 }
             }
             // Move to the previous difficulty of a mapset
-            else if ((KeyboardManager.CurrentState.IsKeyDown(Keys.LeftControl) || KeyboardManager.CurrentState.IsKeyDown(Keys.RightControl))
+            else if (KeyboardManager.IsCtrlDown()
                 && KeyboardManager.IsUniqueKeyPress(Keys.PageUp))
             {
                 InputEnabled = false;


### PR DESCRIPTION
**Requires** https://github.com/Quaver/Wobble/pull/141

This PR first replaces all manual `ctrl` detection with `KeyboardManager.IsCtrlDown()`.

Then, an option is added so that OSX users can use `Command` keys in place of `ctrl`. It is designed that both `ctrl + C` and `cmd + C` triggers the desired copy action, for example, since there exists default keybinds that would trigger a window action on OSX (for example, the mirror keybind on OSX would be `cmd + H`, and would cause the game window to hide instead)