### PR TITLE
[1.5.0] Add a toggle for deleting original file after it is imported

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -230,6 +230,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> AutoLoadOsuBeatmaps { get; private set; }
 
         /// <summary>
+        ///     Delete the original mapset file after importing
+        /// </summary>
+        internal static Bindable<bool> DeleteOriginalFileAfterImport { get; private set; }
+
+        /// <summary>
         ///     If the scoreboard is currently visible.
         /// </summary>
         internal static Bindable<bool> ScoreboardVisible { get; private set; }
@@ -1011,6 +1016,7 @@ namespace Quaver.Shared.Config
             OsuDbPath = ReadSpecialConfigType(SpecialConfigType.Path, @"OsuDbPath", "", data);
             EtternaDbPath = ReadSpecialConfigType(SpecialConfigType.Path, @"EtternaDbPath", "", data);
             AutoLoadOsuBeatmaps = ReadValue(@"AutoLoadOsuBeatmaps", false, data);
+            DeleteOriginalFileAfterImport = ReadValue(@"DeleteOriginalFileAfterImport", true, data);
             AutoLoginToServer = ReadValue(@"AutoLoginToServer", true, data);
             DisplayTimingLines = ReadValue(@"DisplayTimingLines", true, data);
             DisplayMenuAudioVisualizer = ReadValue(@"DisplayMenuAudioVisualizer", true, data);

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -327,15 +327,16 @@ namespace Quaver.Shared.Database.Maps
 
                 try
                 {
+                    var deleteOriginalFile = false;
                     if (file.EndsWith(".qp"))
                     {
                         ExtractQuaverMapset(file, extractDirectory);
-                        File.Delete(file);
+                        deleteOriginalFile = true;
                     }
                     else if (file.EndsWith(".osz"))
                     {
                         Osu.ConvertOsz(file, extractDirectory);
-                        File.Delete(file);
+                        deleteOriginalFile = true;
                     }
                     else if (file.EndsWith(".sm"))
                         Stepmania.ConvertFile(file, extractDirectory);
@@ -344,8 +345,11 @@ namespace Quaver.Shared.Database.Maps
                     else if (file.EndsWith(".mcz"))
                     {
                         Malody.ExtractZip(file, extractDirectory);
-                        File.Delete(file);
+                        deleteOriginalFile = true;
                     }
+
+                    if (deleteOriginalFile && ConfigManager.DeleteOriginalFileAfterImport.Value)
+                        File.Delete(file);
 
                     selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
 

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -447,6 +447,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Display Warning For Failing", ConfigManager.DisplayFailWarning),
                         new OptionsItemCheckbox(containerRect, "Display Menu Audio Visualizer", ConfigManager.DisplayMenuAudioVisualizer),
                         new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores),
+                        new OptionsItemCheckbox(containerRect, "Delete Original File After Import", ConfigManager.DeleteOriginalFileAfterImport)
                     }),
                 }),
             };


### PR DESCRIPTION
Added a toggle so that you can keep the mapset files after importing them.

**TODO** Delete the file anyways if we are doing in-game download and import