### PR TITLE
Avoid exceptions

### DIFF
--- a/Quaver.Shared/Audio/AudioEngine.cs
+++ b/Quaver.Shared/Audio/AudioEngine.cs
@@ -65,12 +65,12 @@ namespace Quaver.Shared.Audio
                 Track = newTrack;
                 Track.ApplyRate(ConfigManager.Pitched.Value);
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException)
             {
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                if (Track != null && !Track.IsDisposed)
+                if (Track is { IsDisposed: false })
                     Track.Dispose();
 
                 Track = new AudioTrackVirtual(time);
@@ -108,7 +108,7 @@ namespace Quaver.Shared.Audio
                         Track?.Play();
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // ignored
             }

--- a/Quaver.Shared/Config/ConfigHelper.cs
+++ b/Quaver.Shared/Config/ConfigHelper.cs
@@ -9,39 +9,13 @@ using System;
 using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Quaver.API.Helpers;
 using Wobble.Graphics;
 
 namespace Quaver.Shared.Config
 {
     public static class ConfigHelper
     {
-        readonly ref struct Drain<T>
-            where T : IEquatable<T>
-        {
-            readonly ReadOnlySpan<T> _remaining;
-
-            readonly T _separator;
-
-            public Drain(ReadOnlySpan<T> remaining, T separator)
-            {
-                _remaining = remaining;
-                _separator = separator;
-            }
-
-            public void Deconstruct(out ReadOnlySpan<T> next, out Drain<T> rest)
-            {
-                if (_remaining.IndexOf(_separator) is not -1 and var i)
-                {
-                    next = _remaining[..i];
-                    rest = new(_remaining[(i + 1)..], _separator);
-                    return;
-                }
-
-                next = _remaining;
-                rest = default;
-            }
-        }
-
         /// <summary>
         ///     Reads a string and checks if it's a valid directory.
         /// </summary>

--- a/Quaver.Shared/Config/ConfigHelper.cs
+++ b/Quaver.Shared/Config/ConfigHelper.cs
@@ -39,20 +39,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static byte ReadPercentage(byte defaultVal, string newVal)
-        {
-            // Try to parse the byte value, if the value is greater than 100 (%),
-            // return the default percentage.
-            try
-            {
-                var newPercentage = byte.Parse(newVal);
-                return newPercentage > 100 ? defaultVal : newPercentage;
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static byte ReadPercentage(byte defaultVal, string newVal) =>
+            byte.TryParse(newVal, out var newOne) && newOne <= 100 ? newOne : defaultVal;
 
         /// <summary>
         ///     Responsible for reading any Int32
@@ -60,17 +48,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static int ReadInt32(int defaultVal, string newVal)
-        {
-            try
-            {
-                return int.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static int ReadInt32(int defaultVal, string newVal) =>
+            int.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Responsible for reading float values
@@ -78,17 +57,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static float ReadFloat(float defaultVal, string newVal)
-        {
-            try
-            {
-                return float.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static float ReadFloat(float defaultVal, string newVal) =>
+            float.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Responsible for reading boolean values from the config file.
@@ -96,17 +66,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static bool ReadBool(bool defaultVal, string newVal)
-        {
-            try
-            {
-                return bool.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static bool ReadBool(bool defaultVal, string newVal) =>
+            bool.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Reads string values from the config file
@@ -115,10 +76,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static string ReadString(string defaultVal, string newVal)
-        {
-            return string.IsNullOrWhiteSpace(newVal) ? defaultVal : newVal;
-        }
+        internal static string ReadString(string defaultVal, string newVal) =>
+            string.IsNullOrWhiteSpace(newVal) ? defaultVal : newVal;
 
         /// <summary>
         ///     Reads Int16 values from the config file.
@@ -126,17 +85,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static short ReadInt16(short defaultVal, string newVal)
-        {
-            try
-            {
-                return short.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static short ReadInt16(short defaultVal, string newVal) =>
+            short.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Reads a byte from the config file
@@ -144,17 +94,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static byte ReadByte(byte defaultVal, string newVal)
-        {
-            try
-            {
-                return byte.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static byte ReadByte(byte defaultVal, string newVal) =>
+            byte.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Reads a signed byte from the config file
@@ -162,17 +103,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVal"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static sbyte ReadSignedByte(sbyte defaultVal, string newVal)
-        {
-            try
-            {
-                return sbyte.Parse(newVal);
-            }
-            catch (Exception e)
-            {
-                return defaultVal;
-            }
-        }
+        internal static sbyte ReadSignedByte(sbyte defaultVal, string newVal) =>
+            sbyte.TryParse(newVal, out var newOne) ? newOne : defaultVal;
 
         /// <summary>
         ///     Reads the skin value from the config file.
@@ -180,10 +112,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultSkin"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static string ReadSkin(string defaultSkin, string newVal)
-        {
-            return Directory.Exists(ConfigManager.SkinDirectory + "/" + newVal) ? newVal : defaultSkin;
-        }
+        internal static string ReadSkin(string defaultSkin, string newVal) =>
+            Directory.Exists(ConfigManager.SkinDirectory + "/" + newVal) ? newVal : defaultSkin;
 
         /// <summary>
         ///     Responsible for reading a path from config
@@ -191,10 +121,8 @@ namespace Quaver.Shared.Config
         /// <param name="defaultPath"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static string ReadPath(string defaultPath, string newVal)
-        {
-            return File.Exists(newVal) ? newVal : defaultPath;
-        }
+        internal static string ReadPath(string defaultPath, string newVal) =>
+            File.Exists(newVal) ? newVal : defaultPath;
 
         /// <summary>
         ///     Reads an XNA Key value from a string.
@@ -210,24 +138,19 @@ namespace Quaver.Shared.Config
         /// <param name="defaultColor"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static Color ReadColor(Color defaultColor, string newVal)
-        {
-            try
-            {
-                var colorSplit = newVal.Split(',');
-
-                if (colorSplit.Length > 3)
-                {
-                    return new Color(byte.Parse(colorSplit[0]), byte.Parse(colorSplit[1]), byte.Parse(colorSplit[2]), byte.Parse(colorSplit[3]));
-                }
-
-                return new Color(byte.Parse(colorSplit[0]), byte.Parse(colorSplit[1]), byte.Parse(colorSplit[2]));
-            }
-            catch (Exception)
-            {
-                return defaultColor;
-            }
-        }
+        internal static Color ReadColor(Color defaultColor, string newVal) =>
+            // Incredibly intense Color parser.
+            newVal is null ||
+            newVal.AsSpan() is var span &&
+            span.IndexOf(',') is var first &&
+            first is -1 ||
+            span[..first] is var rText && !byte.TryParse(rText, out var r) ||
+            span[(first + 1)..].IndexOf(',') is var second && second is -1 ||
+            span[..second] is var gText && !byte.TryParse(gText, out var g) ||
+            span[(second + 1)..].IndexOf(',') is var third && third is -1 ||
+            span[..third] is var bText && !byte.TryParse(bText, out var b) ? defaultColor :
+            span[(third + 1)..].IndexOf(',') is not (var a and not -1) ? new Color(r, g, b, byte.MaxValue) :
+            span[(a + 1)..].IndexOf(',') is -1 ? defaultColor : new Color(r, g, b, a);
 
         /// <summary>
         ///     Reads an XNA Vector2 from a string
@@ -235,18 +158,16 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVector2"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static Vector2 ReadVector2(Vector2 defaultVector2, string newVal)
-        {
-            try
-            {
-                var vectorSplit = newVal.Split(',');
-                return new Vector2(int.Parse(vectorSplit[0]), int.Parse(vectorSplit[1]));
-            }
-            catch (Exception)
-            {
-                return defaultVector2;
-            }
-        }
+        internal static Vector2 ReadVector2(Vector2 defaultVector2, string newVal) =>
+            newVal is null ||
+            newVal.AsSpan() is var span &&
+            span.IndexOf(',') is var first &&
+            first is -1 ||
+            span[..first] is var rText && !int.TryParse(rText, out var x) ||
+            span[(first + 1)..].IndexOf(',') is var second && second is -1 ||
+            span[..second] is var gText && !int.TryParse(gText, out var y)
+                ? defaultVector2
+                : new Vector2(x, y);
 
         /// <summary>
         ///     Reads a ScalableVector2 from a string
@@ -254,18 +175,16 @@ namespace Quaver.Shared.Config
         /// <param name="defaultVector2"></param>
         /// <param name="newVal"></param>
         /// <returns></returns>
-        internal static ScalableVector2? ReadVector2(ScalableVector2 defaultVector2, string newVal)
-        {
-            try
-            {
-                var vectorSplit = newVal.Split(',');
-                return new ScalableVector2(int.Parse(vectorSplit[0]), int.Parse(vectorSplit[1]));
-            }
-            catch (Exception)
-            {
-                return defaultVector2;
-            }
-        }
+        internal static ScalableVector2? ReadVector2(ScalableVector2 defaultVector2, string newVal) =>
+            newVal is null ||
+            newVal.AsSpan() is var span &&
+            span.IndexOf(',') is var first &&
+            first is -1 ||
+            span[..first] is var rText && !int.TryParse(rText, out var x) ||
+            span[(first + 1)..].IndexOf(',') is var second && second is -1 ||
+            span[..second] is var gText && !int.TryParse(gText, out var y)
+                ? defaultVector2
+                : new ScalableVector2(x, y);
 
         /// <summary>
         ///     Reads an enum.
@@ -274,9 +193,8 @@ namespace Quaver.Shared.Config
         /// <param name="newVal"></param>
         /// <typeparam name="TEnum"></typeparam>
         /// <returns></returns>
-        internal static TEnum ReadEnum<TEnum>(TEnum defaultVal, string newVal) where TEnum: struct
-        {
-            return Enum.TryParse(newVal, out TEnum newOne) ? newOne : defaultVal;
-        }
+        internal static TEnum ReadEnum<TEnum>(TEnum defaultVal, string newVal)
+            where TEnum : struct =>
+            Enum.TryParse(newVal, out TEnum newOne) ? newOne : defaultVal;
     }
 }

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -1227,17 +1227,7 @@ namespace Quaver.Shared.Config
         private static BindableInt ReadInt(string name, int defaultVal, int min, int max, KeyDataCollection ini)
         {
             var binded = new BindableInt(name, defaultVal, min, max);
-
-            // Try to read the int.
-            try
-            {
-                binded.Value = int.Parse(ini[name]);
-            }
-            catch (Exception e)
-            {
-                binded.Value = defaultVal;
-            }
-
+            binded.Value = int.TryParse(ini[name], out var value) ? value : defaultVal;
             binded.ValueChanged += AutoSaveConfiguration;
             return binded;
         }
@@ -1265,20 +1255,18 @@ namespace Quaver.Shared.Config
                         {
                             // Make sure the default directory is created.
                             Directory.CreateDirectory(defaultVal);
-                            throw new ArgumentException();
+                            binded.Value = defaultVal;
                         }
 
                         break;
                     case SpecialConfigType.Path:
-                        if (File.Exists(parsedVal))
-                            binded.Value = parsedVal;
-                        else
-                            throw new ArgumentException();
+                        binded.Value = File.Exists(parsedVal) ? parsedVal : defaultVal;
                         break;
                     case SpecialConfigType.Skin:
                         break;
                     default:
-                        throw new InvalidEnumArgumentException();
+                        binded.Value = defaultVal;
+                        break;
                 }
             }
             catch (Exception e)
@@ -1299,6 +1287,7 @@ namespace Quaver.Shared.Config
             var binded = new Bindable<GenericKey>(name, defaultVal);
 
             GenericKey key;
+
             if (GenericKey.TryParse(ini[name], out key))
                 binded.Value = key;
 

--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -1109,7 +1109,7 @@ namespace Quaver.Shared.Online
             if (CurrentGame == null)
                 return;
 
-            Console.WriteLine($"NEW PLAYHER COUJNT: " + e.MaxPlayers);
+            Logger.Important($"New player count: {e.MaxPlayers}", LogType.Network);
             CurrentGame.MaxPlayers = e.MaxPlayers;
         }
 

--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -559,8 +559,8 @@ namespace Quaver.Shared.Online
                 map.OnlineOffset = e.Response.OnlineOffset;
                 MapDatabaseCache.UpdateMap(map);
 
-                var game = GameBase.Game as QuaverGame;
-
+                // var game = GameBase.Game as QuaverGame;
+                //
                 // // If in song select, update the banner of the currently selected map.
                 // if (game.CurrentScreen is SelectScreen screen)
                 // {

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -779,8 +779,11 @@ namespace Quaver.Shared
                         var request = new APIRequestImgurUpload(path);
                         var response = request.ExecuteRequest();
 
-                        if (response == null)
-                            throw new Exception("Failed to upload screenshot to imgur");
+                        if (response is null)
+                        {
+                            Logger.Error("Failed to upload screenshot to imgur", LogType.Network);
+                            NotificationManager.Show(NotificationLevel.Error, "Failed to upload screenshot!");
+                        }
 
                         Clipboard.NativeClipboard.SetText(response);
                         BrowserHelper.OpenURL(response, true);
@@ -795,7 +798,7 @@ namespace Quaver.Shared
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Logger.Error(e, LogType.Runtime);
                 throw;
             }
         }

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -257,6 +257,7 @@ namespace Quaver.Shared
 #endif
         {
             Content.RootDirectory = "Content";
+            Logger.MinimumLogLevel = IsDeployedBuild ? LogLevel.Important : LogLevel.Debug;
         }
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -146,8 +146,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             }
             catch (Exception e)
             {
-                // ignored
-                Console.WriteLine(e);
+                Logger.Error(e, LogType.Runtime);
             }
             finally
             {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/GameplayRulesetKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/GameplayRulesetKeys.cs
@@ -135,10 +135,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys
             processor.SteamId = SteamUser.GetSteamID().m_SteamID;
             processor.UserId = OnlineManager.Self?.OnlineUser?.Id ?? 0;
 
-            Logger.Important($"---- Health Weighting ----", LogType.Runtime);
+            Logger.Debug("---- Health Weighting ----", LogType.Runtime);
 
             foreach (var weight in processor.JudgementHealthWeighting)
-                Logger.Important($"{weight.Key}: {weight.Value}", LogType.Runtime);
+                Logger.Debug($"{weight.Key}: {weight.Value}", LogType.Runtime);
 
             return processor;
         }

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Games/MultiplayerGameScrollContainer.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Games/MultiplayerGameScrollContainer.cs
@@ -18,6 +18,7 @@ using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Input;
+using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Games
@@ -174,7 +175,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Games
         {
             if (!MultiplayerLobbyFilterPanel.GameMeetsFilterRequirements(game, SearchQuery.Value))
             {
-                Console.WriteLine("Game didnt meet match requirements");
+                Logger.Important("Game didn't meet match requirements", LogType.Runtime);
                 return;
             }
 

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Accuracy/CachedAccuracyGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Accuracy/CachedAccuracyGraph.cs
@@ -112,7 +112,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Accuracy
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
                     AccuracyGraph.Draw(new GameTime());
-                    GameBase.Game.SpriteBatch.End();
+                    _ = GameBase.Game.TryEndBatch();
 
                     GameBase.Game.GraphicsDevice.SetRenderTarget(null);
                     CachedSprite.Image = RenderTarget;

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/CachedHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/CachedHitDifferenceGraph.cs
@@ -96,7 +96,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Deviance
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
                     HitDifferenceGraph.Draw(new GameTime());
-                    GameBase.Game.SpriteBatch.End();
+                    _ = GameBase.Game.TryEndBatch();
 
                     GameBase.Game.GraphicsDevice.SetRenderTarget(null);
                     CachedSprite.Image = RenderTarget;

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/ResultHitDifferenceGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Deviance/ResultHitDifferenceGraph.cs
@@ -276,10 +276,7 @@ namespace Quaver.Shared.Screens.Result.UI
         private void CreateMissLines()
         {
             foreach (var miss in Processor.Stats.FindAll(s => s.Judgement == Judgement.Miss))
-            {
-                Console.WriteLine(miss);
-                // ReSharper disable once ObjectCreationAsStatement
-                new Sprite
+                _ = new Sprite
                 {
                     Parent = this,
                     Alpha = 0.35f,
@@ -289,7 +286,6 @@ namespace Quaver.Shared.Screens.Result.UI
                     Y = 0,
                     Size = new ScalableVector2(MissLineWidth, Height)
                 };
-            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Health/CachedHealthGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Health/CachedHealthGraph.cs
@@ -87,7 +87,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Health
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
                     HealthGraph.Draw(new GameTime());
-                    GameBase.Game.SpriteBatch.End();
+                    _ = GameBase.Game.TryEndBatch();
 
                     GameBase.Game.GraphicsDevice.SetRenderTarget(null);
                     CachedSprite.Image = RenderTarget;

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Rating/CachedRatingGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Rating/CachedRatingGraph.cs
@@ -112,7 +112,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Rating
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
                     RatingGraph.Draw(new GameTime());
-                    GameBase.Game.SpriteBatch.End();
+                    _ = GameBase.Game.TryEndBatch();
 
                     GameBase.Game.GraphicsDevice.SetRenderTarget(null);
                     CachedSprite.Image = RenderTarget;

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -154,6 +154,7 @@ namespace Quaver.Shared.Screens.Selection
         public override void Draw(GameTime gameTime)
         {
             GameBase.Game.GraphicsDevice.Clear(ColorHelper.HexToColor("#2F2F2F"));
+            _ = GameBase.Game.TryBeginBatch();
             Container?.Draw(gameTime);
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
@@ -177,19 +177,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 LoadingWheel.Animations.RemoveAll(x => x.Properties != AnimationProperty.Rotation);
                 LoadingWheel.FadeTo(1, Easing.Linear, 250);
                 FadeStatusTextOut();
-
-                try
-                {
-                    foreach (var x in new List<Drawable>(Pool))
-                        x.Destroy();
-
-                    Pool?.Clear();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
-
+                ClearPool();
                 ContentContainer.Height = Height;
 
                 SnapToTop();
@@ -393,18 +381,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         {
             ScheduleUpdate(() =>
             {
-                try
-                {
-                    foreach (var x in new List<Drawable>(Pool))
-                        x.Destroy();
-
-                    Pool?.Clear();
-                }
-                catch (Exception)
-                {
-                    // ignored
-                }
-
+                ClearPool();
                 SnapToTop();
 
                 AvailableItems = e.Result.Scores;
@@ -450,6 +427,24 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             PreviousTargetY = PreviousContentContainerY;
 
             PoolStartingIndex = 0;
+        }
+
+        private void ClearPool()
+        {
+            if (Pool is null)
+                return;
+
+            try
+            {
+                foreach (var x in new List<Drawable>(Pool))
+                    x.Destroy();
+
+                Pool.Clear();
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/LeaderboardScoresContainer.cs
@@ -295,7 +295,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 return;
 
             // If the last score is empty, cut off the content container so it doesn't scroll.
-            if (Pool.Last().Item.IsEmptyScore)
+            if (Pool.LastOrDefault()?.Item.IsEmptyScore ?? false)
                 ContentContainer.Height = Height;
         }
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -318,8 +318,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
         /// <param name="e"></param>
         private void OnFetchedScores(object sender, TaskCompleteEventArgs<Map, FetchedScoreStore> e)
         {
-            Logger.Important($"Fetched {e.Result.Scores?.Count} {ConfigManager.LeaderboardSection?.Value} scores for map: {e?.Input} | " +
-                             $"Has PB: {e.Result.PersonalBest != null}", LogType.Runtime);
+            Logger.Debug($"Fetched {e.Result.Scores?.Count} {ConfigManager.LeaderboardSection?.Value} scores for map: {e.Input} | " +
+                         $"Has PB: {e.Result.PersonalBest != null}", LogType.Runtime);
 
             StopLoading();
 

--- a/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/CachedDifficultyBarDisplay.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/CachedDifficultyBarDisplay.cs
@@ -117,6 +117,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps.Components.Difficulty
                     GameBase.Game.GraphicsDevice.SetRenderTarget(RenderTarget);
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 
+                    _ = GameBase.Game.TryBeginBatch();
                     DifficultyBar.Draw(new GameTime());
                     GameBase.Game.SpriteBatch.End();
 

--- a/Quaver.Shared/Screens/Tests/FilterPanel/FilterPanelTestScreenView.cs
+++ b/Quaver.Shared/Screens/Tests/FilterPanel/FilterPanelTestScreenView.cs
@@ -86,11 +86,6 @@ namespace Quaver.Shared.Screens.Tests.FilterPanel
                     ModManager.RemoveAllMods();
             }
 
-            if (KeyboardManager.IsUniqueKeyPress(Keys.D3))
-            {
-                Console.WriteLine(MapManager.Mapsets.Count);
-            }
-
             if (KeyboardManager.IsUniqueKeyPress(Keys.Home))
                 Bg.Visible = !Bg.Visible;
 

--- a/Quaver.Shared/Skinning/Menus/SkinMenu.cs
+++ b/Quaver.Shared/Skinning/Menus/SkinMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using IniFileParser.Model;
 using Microsoft.Xna.Framework.Graphics;
 using Wobble.Assets;
@@ -43,7 +44,8 @@ namespace Quaver.Shared.Skinning.Menus
         {
             try
             {
-                return AssetLoader.LoadTexture2DFromFile($@"{Store.Dir}/{folder}/{file}");
+                var path = $"{Store.Dir}/{folder}/{file}";
+                return File.Exists(path) ? AssetLoader.LoadTexture2DFromFile(path) : null;
             }
             catch (Exception)
             {

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -363,11 +363,11 @@ namespace Quaver.Shared.Skinning
 
             try
             {
-                return File.Exists(path)
-                    ? AssetLoader.LoadTexture2DFromFile(path)
-                    : AssetLoader.LoadTexture2D(GameBase.Game.Resources.Get(resource));
+                return File.Exists(path) ? AssetLoader.LoadTexture2DFromFile(path) :
+                    GameBase.Game.Resources.Get(resource) is { } buffer ? AssetLoader.LoadTexture2D(buffer) :
+                    UserInterface.BlankBox;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Logger.Warning($"Failed to load: {resource}. Using default!", LogType.Runtime, false);
                 return UserInterface.BlankBox;

--- a/Quaver/Program.cs
+++ b/Quaver/Program.cs
@@ -51,7 +51,7 @@ namespace Quaver
             {
                 if(!mutex.WaitOne(0, false))
                 {
-                    Console.WriteLine("Quaver is already running");
+                    Logger.Error("Quaver is already running", LogType.Runtime);
 
                     // Send to running instance only if we have actual data to send
                     if (args.Length > 0)
@@ -156,7 +156,7 @@ namespace Quaver
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.ToString());
+                Logger.Error(e, LogType.Runtime);
             }
         }
 


### PR DESCRIPTION
Depends on [this](https://github.com/Quaver/Quaver.API/pull/166) and [this](https://github.com/Quaver/Wobble/pull/142).

This PR prevents lots of exceptions from happening. Observed to go from 1400 down to 2 (both cancelled tasks, unavoidable) over a span of 30 seconds.

In theory, this should noticeably reduce lag spikes, and we should be able to deploy with optimizations again. Further testing and benchmarking — preferably on all major operating systems — is needed before we make a decision.