### PR TITLE
Shutdown SteamAPI on closing game

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -331,6 +331,7 @@ namespace Quaver.Shared
             DiscordHelper.Shutdown();
             base.UnloadContent();
             OnlineManager.Client?.Disconnect();
+            SteamAPI.Shutdown();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes an warning/error when closing the game.
"Trying to close low level socket support, but we still have sockets open!"