### PR TITLE
Improve tooltip clamping

### DIFF
--- a/Quaver.Shared/Screens/QuaverScreen.cs
+++ b/Quaver.Shared/Screens/QuaverScreen.cs
@@ -221,8 +221,8 @@ namespace Quaver.Shared.Screens
             if (ActiveTooltip == null)
                 return;
 
-            ActiveTooltip.X = MathHelper.Clamp(MouseManager.CurrentState.X - ActiveTooltip.Width, 5, WindowManager.Width - 5);
-            ActiveTooltip.Y = MathHelper.Clamp(MouseManager.CurrentState.Y - ActiveTooltip.Height - 2, 5, WindowManager.Height - 5);
+            ActiveTooltip.X = MathHelper.Clamp(MouseManager.CurrentState.X - ActiveTooltip.Width / 2.0f, 5, WindowManager.Width - ActiveTooltip.Width - 5);
+            ActiveTooltip.Y = MathHelper.Clamp(MouseManager.CurrentState.Y - ActiveTooltip.Height - 2, 5, WindowManager.Height - ActiveTooltip.Height - 5);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
@@ -14,6 +14,7 @@ using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Input;
+using Wobble.Window;
 
 namespace Quaver.Shared.Screens.Selection.UI.Modifiers
 {
@@ -187,8 +188,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
             if (ActiveTooltip == null)
                 return;
 
-            ActiveTooltip.X = MouseManager.CurrentState.X - AbsolutePosition.X - ActiveTooltip.Width / 2f;
-            ActiveTooltip.Y = MouseManager.CurrentState.Y - AbsolutePosition.Y - ActiveTooltip.Height - 2;
+            ActiveTooltip.X = MathHelper.Clamp(MouseManager.CurrentState.X - AbsolutePosition.X - ActiveTooltip.Width / 2f, 5, Width - ActiveTooltip.Width - 5);
+            ActiveTooltip.Y = MathHelper.Clamp(MouseManager.CurrentState.Y - AbsolutePosition.Y - ActiveTooltip.Height - 2, 5, Height - ActiveTooltip.Height - 5);
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
@@ -14,7 +14,6 @@ using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Input;
-using Wobble.Window;
 
 namespace Quaver.Shared.Screens.Selection.UI.Modifiers
 {


### PR DESCRIPTION
This pr clamps the tooltips from the main menu and the mod selection menu to the edges of the screen.
I've also improved the position of the tooltip in the main menu.

![Main menu after change](https://github.com/Quaver/Quaver/assets/71964154/7c13d366-ae7c-4cfa-8abb-63e5e4068bfb)
![Mod select after change](https://github.com/Quaver/Quaver/assets/71964154/3e516051-2901-4df6-8ccd-b3290741cc75)

The mod select tooltip clamps to the little menu drawable, I thought it looked nicer that way.