### PR TITLE
Save and reapply speed mods when exiting and reentering song select

### DIFF
--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -124,11 +124,12 @@ namespace Quaver.Shared.Screens.Selection
                 return;
             }
 
-            if (IsMultiplayer)
+            if (IsMultiplayer) {
                 OnlineManager.Client?.SetGameCurrentlySelectingMap(true);
-            else
+            } else {
                 ModManager.AddSpeedMods(LastSpeedRate);
                 SetRichPresence();
+            }
 
             InitializeSearchQueryBindable();
             InitializeAvailableMapsetsBindable();

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -124,9 +124,10 @@ namespace Quaver.Shared.Screens.Selection
                 return;
             }
 
-            if (IsMultiplayer) {
+            if (IsMultiplayer)
                 OnlineManager.Client?.SetGameCurrentlySelectingMap(true);
-            } else {
+            else
+            {
                 ModManager.AddSpeedMods(LastSpeedRate);
                 SetRichPresence();
             }

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -105,6 +105,12 @@ namespace Quaver.Shared.Screens.Selection
         public Bindable<bool> IsPlayTestingInPreview { get; private set; }
 
         /// <summary>
+        ///     A capture of the last speed rate so that the user can go back
+        ///     to singleplayer without having to change their speed rate again.
+        /// </summary>
+        private static float LastSpeedRate { get; set; } = 1.0f;
+
+        /// <summary>
         /// </summary>
         public SelectionScreen()
         {
@@ -121,6 +127,7 @@ namespace Quaver.Shared.Screens.Selection
             if (IsMultiplayer)
                 OnlineManager.Client?.SetGameCurrentlySelectingMap(true);
             else
+                ModManager.AddSpeedMods(LastSpeedRate);
                 SetRichPresence();
 
             InitializeSearchQueryBindable();
@@ -690,7 +697,7 @@ namespace Quaver.Shared.Screens.Selection
                     OnlineManager.Client?.SetGameCurrentlySelectingMap(false);
                     return new MultiplayerGameScreen();
                 }
-
+                LastSpeedRate = ModHelper.GetRateFromMods(ModManager.Mods);
                 return new MainMenuScreen();
             });
         }


### PR DESCRIPTION

https://github.com/Quaver/Quaver/assets/71964154/66cc4964-7d8f-40e0-a945-b66bc8878580

Saves the speed mods in memory before the player exits the screen and reapplies them when they reopen it.