### PR TITLE
[1.5.0] Add a search filter for scroll velocity changes

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -214,6 +214,11 @@ namespace Quaver.Shared.Database.Maps
         public int OnlineOffset { get; set; }
 
         /// <summary>
+        ///     Returns the amount of times the scroll velocity changes in a map
+        /// </summary>
+        public int ScrollVelocityChanges { get; set; }
+
+        /// <summary>
         ///    Returns the notes per second a map has
         /// </summary>
         [Ignore]
@@ -335,7 +340,8 @@ namespace Quaver.Shared.Database.Maps
                 Mode = qua.Mode,
                 RegularNoteCount = qua.HitObjects.Count(x => !x.IsLongNote),
                 LongNoteCount = qua.HitObjects.Count(x => x.IsLongNote),
-                HasScratchKey = qua.HasScratchKey
+                HasScratchKey = qua.HasScratchKey,
+                ScrollVelocityChanges = qua.SliderVelocities.Count
             };
 
             if (!skipPathSetting)

--- a/Quaver.Shared/Database/Maps/MapsetHelper.cs
+++ b/Quaver.Shared/Database/Maps/MapsetHelper.cs
@@ -513,15 +513,16 @@ namespace Quaver.Shared.Database.Maps
             // for "difficulty" (backwards-compatibility) and "du" searches for duration.
             var options = new Dictionary<SearchFilterOption, (string Shortest, string Longest)>
             {
-                { SearchFilterOption.BPM,        ("b", "bpm") },
-                { SearchFilterOption.Difficulty, ("d", "difficulty") },
-                { SearchFilterOption.Length,     ("l", "length") },
-                { SearchFilterOption.Keys,       ("k", "keys") },
-                { SearchFilterOption.Status,     ("s", "status") },
-                { SearchFilterOption.LNs,        ("ln", "lns") },
-                { SearchFilterOption.NPS,        ("n", "nps") },
-                { SearchFilterOption.Game,       ("g", "game") },
-                { SearchFilterOption.TimesPlayed, ("t", "timesplayed") }
+                { SearchFilterOption.BPM,         ("b", "bpm") },
+                { SearchFilterOption.Difficulty,  ("d", "difficulty") },
+                { SearchFilterOption.Length,      ("l", "length") },
+                { SearchFilterOption.Keys,        ("k", "keys") },
+                { SearchFilterOption.Status,      ("s", "status") },
+                { SearchFilterOption.LNs,         ("ln", "lns") },
+                { SearchFilterOption.NPS,         ("n", "nps") },
+                { SearchFilterOption.Game,        ("g", "game") },
+                { SearchFilterOption.TimesPlayed, ("t", "timesplayed") },
+                { SearchFilterOption.SVChanges,   ("svc", "svchanges") }
             };
 
             // Stores a dictionary of the found pairs in the search query
@@ -697,7 +698,13 @@ namespace Quaver.Shared.Database.Maps
 
                                 if (!CompareValues(valueToCompareTo, value, searchQuery.Operator))
                                     exitLoop = true;
+                                break;
+                            case SearchFilterOption.SVChanges:
+                                if (!float.TryParse(searchQuery.Value, out var valSvChanges))
+                                    exitLoop = true;
 
+                                if (!CompareValues(map.ScrollVelocityChanges, valSvChanges, searchQuery.Operator))
+                                    exitLoop = true;
                                 break;
                         }
 
@@ -879,6 +886,11 @@ namespace Quaver.Shared.Database.Maps
         /// <summary>
         ///     The amount of times the user has played the map
         /// </summary>
-        TimesPlayed
+        TimesPlayed,
+
+        /// <summary>
+        ///     The amount of times the velocity changes in the map
+        /// </summary>
+        SVChanges
     }
 }


### PR DESCRIPTION
This pr adds a search filter for the amount of slider velocity changes in a map. Its short name is `svc`. Must refresh beatmaps before results show up :)