### PR TITLE
Fix grid lines in rating graphs being drawn at incorrect Y value

### DIFF
--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Rating/RatingGraph.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/Rating/RatingGraph.cs
@@ -50,7 +50,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Rating
         /// <summary>
         ///     How many grid lines to draw in total
         /// </summary>
-        private int GridLineCount => (int) Math.Floor((MaxRating - RatingStart) / RatingStep);
+        private int GridLineCount => (int) Math.Ceiling((MaxRating - RatingStart) / RatingStep);
 
         /// <summary>
         ///     The lower bound of the graph
@@ -221,8 +221,8 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs.Rating
             // <= because we also want to draw the final line
             for (var i = 1; i <= GridLineCount; i++)
             {
-                var relativeY = (float) i / GridLineCount;
                 var rating = Math.Round(RatingStart + (GridLineCount - i) * RatingStep, 2);
+                var relativeY = (float) (1 - (rating - RatingStart) / (MaxRating - RatingStart));
                 var isSubGridLine = RatingStep < 0.25 && rating % 0.5 > 0 ||
                                     RatingStep >= 0.25 && RatingStep < 1 && rating % 1 > 0 ||
                                     RatingStep >= 1 && RatingStep < 5 && rating % 5 > 0 ||


### PR DESCRIPTION
Resolves #4119 

Example replay: 

[Map link](https://quavergame.com/mapset/map/96040)

[WilliamQiufeng - crafter2011 - fall damage - jindax's expert.zip](https://github.com/Quaver/Quaver/files/15315776/WilliamQiufeng.-.crafter2011.-.fall.damage.-.jindax.s.expert.zip)

Remember to click `CONVERT SCORE` to Standard* once. There seems to be a visual bug about judgement window display (Check #4127).

Before:
![image](https://github.com/Quaver/Quaver/assets/32996262/a89d214e-f556-409d-8ce0-dd6790afc115)


After:
![image](https://github.com/Quaver/Quaver/assets/32996262/b5e3c416-d171-4e71-896e-2cbba5ba2087)

Observe that before the rating between 43.50 - 43.67 is evenly spaced as 43.40 - 43.50