### PR TITLE
Show proper results from a replay

### DIFF
--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -214,23 +214,9 @@ namespace Quaver.Shared.Screens.Results
             Replay = replay;
             Map = map;
             ScreenType = ResultsScreenType.Replay;
-
             Processor = new Bindable<ScoreProcessor>(new ScoreProcessorKeys(replay));
 
-            try
-            {
-                var qua = map.LoadQua();
-                qua.ApplyMods(replay.Mods);
-
-                var virtualPlayer = new VirtualReplayPlayer(replay, qua);
-                virtualPlayer.PlayAllFrames();
-
-                Processor.Value.Stats = virtualPlayer.ScoreProcessor.Stats;
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, LogType.Runtime);
-            }
+            ConvertScoreToJudgementWindows(null);
 
             View = new ResultsScreenView(this);
         }
@@ -610,7 +596,7 @@ namespace Quaver.Shared.Screens.Results
 
         private void InitializeScoreResultsScreen()
         {
-             Processor = new Bindable<ScoreProcessor>(new ScoreProcessorKeys(Score.ToReplay()))
+            Processor = new Bindable<ScoreProcessor>(new ScoreProcessorKeys(Score.ToReplay()))
             {
                 Value =
                 {

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -625,10 +625,14 @@ namespace Quaver.Shared.Screens.Results
                 {
                     try
                     {
+                        var replay = new Replay(path);
+
                         var qua = MapManager.Selected.Value.LoadQua();
                         qua.ApplyMods((ModIdentifier) Score.Mods);
-
-                        var replay = new Replay(path);
+                        if (replay.Mods.HasFlag(ModIdentifier.Randomize))
+                        {
+                            qua.RandomizeLanes(replay.RandomizeModifierSeed);
+                        }
 
                         var virtualPlayer = new VirtualReplayPlayer(replay, qua, Processor.Value.Windows);
                         virtualPlayer.PlayAllFrames();
@@ -910,6 +914,10 @@ namespace Quaver.Shared.Screens.Results
                 {
                     var qua = Map.LoadQua();
                     qua.ApplyMods(Replay.Mods);
+                    if (Replay.Mods.HasFlag(ModIdentifier.Randomize))
+                    {
+                        qua.RandomizeLanes(Replay.RandomizeModifierSeed);
+                    }
 
                     var virtualPlayer = new VirtualReplayPlayer(Replay, qua, windows, true);
 


### PR DESCRIPTION
When dragging a replay into the window, or exiting to results screen from viewing replays in Gameplay, the replay loaded is not guaranteed to have values (e.g. perfect count, accuracy) in standard window. Since the replay itself doesn't contain information on judgement window, this gives the wrong information about accuracy and such at the beginning, unless clicking `CONVERT SCORE` later. This PR fixes this issue.

Example replay (Test by dragging the file into the window, or later `WATCH REPLAY` and see the result):

[Map link](https://quavergame.com/mapset/map/96040)

[WilliamQiufeng - crafter2011 - fall damage - jindax's expert.zip](https://github.com/Quaver/Quaver/files/15315776/WilliamQiufeng.-.crafter2011.-.fall.damage.-.jindax.s.expert.zip)

Before:
![image](https://github.com/Quaver/Quaver/assets/32996262/1fcaa141-b563-4d38-821d-4d08b27524d3)

After:
![image](https://github.com/Quaver/Quaver/assets/32996262/333a8d1e-7cf9-4f79-8708-c02795b13a5b)

Another issue fixed in this PR is the randomizer seed not being applied properly in replays with RND mod.
Check this replay with RND on for comparison:

[1.zip](https://github.com/Quaver/Quaver/files/15338258/1.zip)
