### PR TITLE
Prevent imgui input interfering with editor playfield

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -1275,6 +1275,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (DialogManager.Dialogs.Count != 0 || IsUneditable)
                 return;
 
+            var view = (EditScreenView)ActionManager.EditScreen.View;
+            if (view.IsImGuiHovered)
+                return;
+
             if (!Button.IsHeld)
             {
                 // Create an action for the long note resizing when the user lets go


### PR DESCRIPTION
This PR prevents inputs to ImGui windows from reaching to the Editor Playfield.