### PR TITLE
Allow custom divisions to be chosen when resnapping notes

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -115,6 +115,11 @@ namespace Quaver.Shared.Screens.Edit
         public static List<int> AvailableBeatSnaps { get; set; } = new List<int> { 1, 2, 3, 4, 6, 8, 12, 16 };
 
         /// <summary>
+        ///     In Menu -> Edit -> Resnap All/Selected Notes, the divisions to choose
+        /// </summary>
+        public static HashSet<int> CustomSnapDivisions { get; } = new HashSet<int> { 12, 16 };
+
+        /// <summary>
         /// </summary>
         private int BeatSnapIndex => AvailableBeatSnaps.FindIndex(x => x == BeatSnap.Value);
 

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -335,6 +335,36 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
                     Screen.ActionManager.ResnapNotes(new List<int> { Screen.BeatSnap.Value }, Screen.WorkingMap.HitObjects);
                 if (ImGui.MenuItem("Resnap to 1/16 and 1/12 snaps"))
                     Screen.ActionManager.ResnapNotes(new List<int> { 16, 12 }, Screen.WorkingMap.HitObjects);
+                if (ImGui.BeginMenu("Resnap to custom divisions"))
+                {
+                    if (ImGui.MenuItem("Resnap"))
+                    {
+                        if (EditScreen.CustomSnapDivisions.Count == 0)
+                            NotificationManager.Show(NotificationLevel.Warning,
+                                "You have not selected any divisions to snap!");
+                        else
+                            Screen.ActionManager.ResnapNotes(EditScreen.CustomSnapDivisions.ToList(),
+                                Screen.WorkingMap.HitObjects);
+                    }
+
+                    ImGui.Separator();
+                    foreach (var availableBeatSnap in EditScreen.AvailableBeatSnaps)
+                    {
+                        var color = ColorHelper.BeatSnapToColor(availableBeatSnap);
+                        ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(color.R / 255f, color.G / 255f, color.B / 255f, 1));
+
+                        if (ImGui.MenuItem($"1/{StringHelper.AddOrdinal(availableBeatSnap)}", "",
+                                EditScreen.CustomSnapDivisions.Contains(availableBeatSnap)))
+                        {
+                            if (!EditScreen.CustomSnapDivisions.Add(availableBeatSnap))
+                                EditScreen.CustomSnapDivisions.Remove(availableBeatSnap);
+                        }
+
+                        ImGui.PopStyleColor();
+                    }
+
+                    ImGui.EndMenu();
+                }
                 ImGui.EndMenu();
             }
 
@@ -344,6 +374,36 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
                     Screen.ActionManager.ResnapNotes(new List<int> { Screen.BeatSnap.Value }, Screen.SelectedHitObjects.Value);
                 if (ImGui.MenuItem("Resnap to 1/16 and 1/12 snaps"))
                     Screen.ActionManager.ResnapNotes(new List<int> { 16, 12 }, Screen.SelectedHitObjects.Value);
+                if (ImGui.BeginMenu("Resnap to custom divisions"))
+                {
+                    if (ImGui.MenuItem("Resnap"))
+                    {
+                        if (EditScreen.CustomSnapDivisions.Count == 0)
+                            NotificationManager.Show(NotificationLevel.Warning,
+                                "You have not selected any divisions to snap!");
+                        else
+                            Screen.ActionManager.ResnapNotes(EditScreen.CustomSnapDivisions.ToList(),
+                                Screen.SelectedHitObjects.Value);
+                    }
+
+                    ImGui.Separator();
+                    foreach (var availableBeatSnap in EditScreen.AvailableBeatSnaps)
+                    {
+                        var color = ColorHelper.BeatSnapToColor(availableBeatSnap);
+                        ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(color.R / 255f, color.G / 255f, color.B / 255f, 1));
+
+                        if (ImGui.MenuItem($"1/{StringHelper.AddOrdinal(availableBeatSnap)}", "",
+                                EditScreen.CustomSnapDivisions.Contains(availableBeatSnap)))
+                        {
+                            if (!EditScreen.CustomSnapDivisions.Add(availableBeatSnap))
+                                EditScreen.CustomSnapDivisions.Remove(availableBeatSnap);
+                        }
+
+                        ImGui.PopStyleColor();
+                    }
+
+                    ImGui.EndMenu();
+                }
                 ImGui.EndMenu();
             }
 


### PR DESCRIPTION
Resolves #4115 

Works better with #4128 for resnapping selected notes, as that button overlaps the editor playfield region.

Example:


https://github.com/Quaver/Quaver/assets/32996262/5aad0d67-eb03-45c3-af33-6cb0868ca8ba

