### PR TITLE
[1.5.0] Guard against IO operations

### DIFF
--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -334,7 +334,15 @@ namespace Quaver.Shared.Database.Maps
                         "map",
                         () =>
                         {
-                            File.Delete(path);
+                            try
+                            {
+                                File.Delete(path);
+                            }
+                            catch (Exception ex)
+                            {
+                                Logger.Error(e, LogType.Runtime);
+                            }
+
                             MapDatabaseCache.RemoveMap(map);
                             map.Mapset.Maps.Remove(map);
 
@@ -403,7 +411,14 @@ namespace Quaver.Shared.Database.Maps
                     	"mapset",
                     	() =>
 	                    {
-                            Directory.Delete(directory, true);
+                            try
+                            {
+                                 Directory.Delete(directory, true);
+                            }
+                            catch (Exception e)
+                            {
+                                 Logger.Error(e, LogType.Runtime);
+                            }
 
                             try
                             {

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -338,7 +338,7 @@ namespace Quaver.Shared.Database.Maps
                             {
                                 File.Delete(path);
                             }
-                            catch (Exception ex)
+                            catch (Exception e)
                             {
                                 Logger.Error(e, LogType.Runtime);
                             }

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -426,7 +426,7 @@ namespace Quaver.Shared.Database.Maps
                                  Logger.Error(e, LogType.Runtime);
                             }
 
-                            if (Directory.Exists(path))
+                            if (Directory.Exists(directory))
                             {
                                 NotificationManager.Show(NotificationLevel.Error, "Unable to delete the mapset. Is the directory protected?");
                                 return;

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -343,6 +343,12 @@ namespace Quaver.Shared.Database.Maps
                                 Logger.Error(e, LogType.Runtime);
                             }
 
+                            if (File.Exists(path))
+                            {
+                                NotificationManager.Show(NotificationLevel.Error, "Unable to delete the map. Is the file protected?");
+                                return;
+                            }
+
                             MapDatabaseCache.RemoveMap(map);
                             map.Mapset.Maps.Remove(map);
 
@@ -418,6 +424,12 @@ namespace Quaver.Shared.Database.Maps
                             catch (Exception e)
                             {
                                  Logger.Error(e, LogType.Runtime);
+                            }
+
+                            if (Directory.Exists(path))
+                            {
+                                NotificationManager.Show(NotificationLevel.Error, "Unable to delete the mapset. Is the directory protected?");
+                                return;
                             }
 
                             try


### PR DESCRIPTION
When deleting charts, even if the file or directory cannot be trashed, and cannot be deleted, it will just remove it from the database and call it a day.