### PR TITLE
Check if CurrentGame is null before logging

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -752,9 +752,7 @@ namespace Quaver.Shared.Online
             game.CurrentScreen.Exit(() =>
             {
                 if (CurrentGame is not null)
-                    Logger.Important(
-                        $"Successfully joined game: {CurrentGame.Id} | {CurrentGame.Name} | {CurrentGame.HasPassword}",
-                        LogType.Network);
+                    Logger.Important($"Successfully joined game: {CurrentGame.Id} | {CurrentGame.Name} | {CurrentGame.HasPassword}", LogType.Network);
                 
                 return new MultiplayerGameScreen();
             });


### PR DESCRIPTION
Prevents game from going to blackscreen when joining. 
This is an temporary fix and should be fixed properly by preventing multiple join lobby packets.

![image](https://github.com/Quaver/Quaver/assets/3695158/038e1cbd-2f6b-49fa-ba36-b9b93c7ea559)
