### PR TITLE
Use screen's md5 to look for the currently playing map, instead of the currently selected one

### DIFF
--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -130,7 +130,7 @@ namespace Quaver.Shared.Screens.Results
         {
             ScreenType = ResultsScreenType.Gameplay;
             Gameplay = screen;
-            Map = MapManager.Selected.Value;
+            Map = MapManager.FindMapFromMd5(screen.MapHash) ?? MapManager.Selected.Value;
 
             InitializeGameplayResultsScreen(screen);
             Replay = Gameplay.LoadedReplay ?? Gameplay.ReplayCapturer.Replay;
@@ -156,7 +156,7 @@ namespace Quaver.Shared.Screens.Results
         {
             ScreenType = ResultsScreenType.Gameplay;
             Gameplay = screen;
-            Map = MapManager.Selected.Value;
+            Map = MapManager.FindMapFromMd5(screen.MapHash) ?? MapManager.Selected.Value;
             MultiplayerGame = game;
             MultiplayerTeam1Users = team1;
             MultiplayerTeam2Users = team2;


### PR DESCRIPTION
This should fix the erroneous map info when immediately inputting something in the search box before starting the game