### PR TITLE
Attempt to fix score retrieving error when entering multiplayer gameplay

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -1961,6 +1961,7 @@ namespace Quaver.Shared.Online
             var users = OnlineUsers.ToList();
 
             var playingUsers = users.FindAll(x =>
+                x.Value.OnlineUser != null &&
                 CurrentGame.PlayerIds.Contains(x.Value.OnlineUser.Id) &&
                 !CurrentGame.PlayersWithoutMap.Contains(x.Value.OnlineUser.Id) &&
                 CurrentGame.RefereeUserId != x.Value.OnlineUser.Id &&


### PR DESCRIPTION
Don't include players that we have not received info for when retrieving scores

This error might happen when: When the player retrieves the list, there happens to be an online user that we haven't retrieved an information for.