### PR TITLE
Attempt to fix score retrieving error when entering multiplayer gameplay 

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -1958,13 +1958,13 @@ namespace Quaver.Shared.Online
         /// <returns></returns>
         private static List<Score> GetScoresFromMultiplayerUsers()
         {
-            var users = OnlineUsers.ToList();
-
-            var playingUsers = users.FindAll(x =>
-                CurrentGame.PlayerIds.Contains(x.Value.OnlineUser.Id) &&
-                !CurrentGame.PlayersWithoutMap.Contains(x.Value.OnlineUser.Id) &&
-                CurrentGame.RefereeUserId != x.Value.OnlineUser.Id &&
-                x.Value != Self);
+            
+            var playingUsers = CurrentGame.Players.FindAll(x =>
+                x.Id != CurrentGame.RefereeUserId &&
+                !CurrentGame.PlayersWithoutMap.Contains(x.Id) &&
+                CurrentGame.PlayerIds.Contains(x.Id) &&
+                x.Id != Self.OnlineUser.Id
+            );
 
             var scores = new List<Score>();
 
@@ -1972,10 +1972,10 @@ namespace Quaver.Shared.Online
             {
                 scores.Add(new Score
                 {
-                    PlayerId = x.Key,
-                    SteamId = x.Value.OnlineUser.SteamId,
-                    Name = x.Value.OnlineUser.Username,
-                    Mods = (long) GetUserActivatedMods(x.Value.OnlineUser.Id),
+                    PlayerId = x.Id,
+                    SteamId = x.SteamId,
+                    Name = x.Username,
+                    Mods = (long) GetUserActivatedMods(x.Id),
                     IsMultiplayer = true,
                     IsOnline = true
                 });


### PR DESCRIPTION
Use CurrentGame.Players instead of finding from OnlineUsers in OnlineManager.GetScoresFromMultiplayerUsers

Alternative to #4153 