### PR TITLE
Fix logic for adding players

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -1172,7 +1172,7 @@ namespace Quaver.Shared.Online
             if (CurrentGame == null)
                 return;
 
-            if (CurrentGame.Players.Any(x => x.Id != e.UserId))
+            if (CurrentGame.Players.All(x => x.Id != e.UserId))
                 CurrentGame.Players.Add(OnlineUsers[e.UserId].OnlineUser);
 
             if (!CurrentGame.PlayerIds.Contains(e.UserId))


### PR DESCRIPTION
Using `Any()` guard means the new player will be added whenever there is a player in the room that has a different ID than themselves. Instead, `All()` is used so the new player will only be added if all players in the room does not have the same ID as the new player.