### PR TITLE
Allow for temporary disconnection

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -413,15 +413,18 @@ namespace Quaver.Shared.Online
 
             lock (OnlineUsers)
             {
-                ClearOnlineData();
                 OnlineUsers[e.Self.OnlineUser.Id] = e.Self;
-                Spectators.Clear();
-                SpectatorClients.Clear();
-                MultiplayerGames.Clear();
-                ListeningParty = null;
-                FriendsList.Clear();
-                SpectatorClients = new Dictionary<int, SpectatorClient>();
-                Spectators = new Dictionary<int, User>();
+                if (!Client.IsTemporaryReconnection)
+                {
+                    ClearOnlineData();
+                    Spectators.Clear();
+                    SpectatorClients.Clear();
+                    MultiplayerGames.Clear();
+                    ListeningParty = null;
+                    FriendsList.Clear();
+                    SpectatorClients = new Dictionary<int, SpectatorClient>();
+                    Spectators = new Dictionary<int, User>();
+                }
             }
 
             // Make sure the config username is changed.


### PR DESCRIPTION
Requires https://github.com/Quaver/Z/pull/32 and https://github.com/Quaver/Quaver.Server.Client/pull/21

* Upon a temporary reconnection, after logging in we should not clear anything