### PR TITLE
[1.6.0] Editor event system

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/Batch/EditorActionBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Batch/EditorActionBatch.cs
@@ -13,7 +13,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Batch
 
         private EditorActionManager ActionManager { get; }
 
-        private List<IEditorAction> EditorActions { get; }
+        public List<IEditorAction> EditorActions { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionBatch(EditorActionManager manager, List<IEditorAction> actions)

--- a/Quaver.Shared/Screens/Edit/Actions/Bookmarks/Add/EditorActionAddBookmark.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Bookmarks/Add/EditorActionAddBookmark.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Bookmarks.Add
 
         private Qua WorkingMap { get; }
 
-        private BookmarkInfo Bookmark { get; }
+        public BookmarkInfo Bookmark { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddBookmark(EditorActionManager manager, Qua map, BookmarkInfo bookmark)

--- a/Quaver.Shared/Screens/Edit/Actions/Bookmarks/AddBatch/EditorActionAddBookmarkBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Bookmarks/AddBatch/EditorActionAddBookmarkBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Bookmarks.AddBatch
 
         private Qua WorkingMap { get; }
 
-        private List<BookmarkInfo> Bookmarks { get; }
+        public List<BookmarkInfo> Bookmarks { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddBookmarkBatch(EditorActionManager manager, Qua workingMap, List<BookmarkInfo> bookmarks)

--- a/Quaver.Shared/Screens/Edit/Actions/Bookmarks/Offset/EditorActionChangeBookmarkOffsetBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Bookmarks/Offset/EditorActionChangeBookmarkOffsetBatch.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Bookmarks.Offset
 
         private Qua WorkingMap { get; }
 
-        private List<BookmarkInfo> Bookmarks { get; }
+        public List<BookmarkInfo> Bookmarks { get; }
 
         private int Offset { get; }
 

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -51,6 +51,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.Remove;
 using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.Reset;
 using Quaver.Shared.Screens.Edit.Components;
+using Quaver.Shared.Screens.Edit.LuaEvents;
 
 namespace Quaver.Shared.Screens.Edit.Actions
 {
@@ -88,6 +89,11 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     An action manager dedicated for lua plugins
         /// </summary>
         public EditorPluginActionManager PluginActionManager { get; }
+
+        /// <summary>
+        ///     This is signalled when a perform or an undo action is done so plugins can detect them
+        /// </summary>
+        public EditorEvents LuaEditorEvents { get; }
 
         /// <summary>
         ///     Event invoked when a HitObject has been placed
@@ -299,6 +305,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             EditScreen = screen;
             WorkingMap = workingMap;
             PluginActionManager = new EditorPluginActionManager(this);
+            LuaEditorEvents = new EditorEvents();
         }
 
         /// <summary>
@@ -310,6 +317,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             action.Perform();
             UndoStack.Push(action);
             RedoStack.Clear();
+            LuaEditorEvents[action.Type].Invoke(new EditorEventInstance(action, false));
         }
 
         /// <summary>
@@ -330,6 +338,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             action.Undo();
 
             RedoStack.Push(action);
+            LuaEditorEvents[action.Type].Invoke(new EditorEventInstance(action, true));
         }
 
         /// <summary>
@@ -344,6 +353,7 @@ namespace Quaver.Shared.Screens.Edit.Actions
             action.Perform();
 
             UndoStack.Push(action);
+            LuaEditorEvents[action.Type].Invoke(new EditorEventInstance(action, false));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Flip/EditorActionFlipHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Flip/EditorActionFlipHitObjects.cs
@@ -21,7 +21,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Flip
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Move/EditorActionMoveHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Move/EditorActionMoveHitObjects.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Move
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         ///     The value in which the objects lanes will be added to.

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Place/EditorActionPlaceHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Place/EditorActionPlaceHitObject.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Place
 
         /// <summary>
         /// </summary>
-        private HitObjectInfo HitObject { get; }
+        public HitObjectInfo HitObject { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/PlaceBatch/EditorActionPlaceHitObjectBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/PlaceBatch/EditorActionPlaceHitObjectBatch.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.PlaceBatch
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Remove/EditorActionRemoveHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Remove/EditorActionRemoveHitObject.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Remove
 
         /// <summary>
         /// </summary>
-        private HitObjectInfo HitObject { get; }
+        public HitObjectInfo HitObject { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/RemoveBatch/EditorActionRemoveHitObjectBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/RemoveBatch/EditorActionRemoveHitObjectBatch.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.RemoveBatch
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resize/EditorActionResizeLongNote.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Resize/EditorActionResizeLongNote.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Resize
 
         /// <summary>
         /// </summary>
-        private HitObjectInfo HitObject { get; }
+        public HitObjectInfo HitObject { get; }
 
         /// <summary>
         ///     The original end time of the long note

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Reverse/EditorActionReverseHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Reverse/EditorActionReverseHitObjects.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Reverse
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorActionSwapLanes.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Swap/EditorActionSwapLanes.cs
@@ -21,10 +21,10 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Swap
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
-        private int SwapLane1 { get; }
-        private int SwapLane2 { get; }
+        public int SwapLane1 { get; }
+        public int SwapLane2 { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Hitsounds/Add/EditorActionAddHitsound.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Hitsounds/Add/EditorActionAddHitsound.cs
@@ -19,11 +19,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Hitsounds.Add
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>
-        private HitSounds Sound { get; }
+        public HitSounds Sound { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Hitsounds/Remove/EditorActionRemoveHitsound.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Hitsounds/Remove/EditorActionRemoveHitsound.cs
@@ -18,11 +18,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Hitsounds.Remove
 
         /// <summary>
         /// </summary>
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
         /// <summary>
         /// </summary>
-        private HitSounds Sound { get; }
+        public HitSounds Sound { get; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Colors/EditorActionChangeLayerColor.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Colors/EditorActionChangeLayerColor.cs
@@ -16,11 +16,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Colors
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
-        private Color NewColor { get; }
+        public Color NewColor { get; }
 
-        private Color OriginalColor { get; }
+        public Color OriginalColor { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeLayerColor(EditorActionManager manager, Qua workingMap, EditorLayerInfo layer, Color color)

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Create/EditorActionCreateLayer.cs
@@ -16,11 +16,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Create
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
-        private BindableList<HitObjectInfo> SelectedHitObjects { get; }
+        public BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
-        private int Index { get; }
+        public int Index { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionCreateLayer(Qua workingMap, EditorActionManager actionManager, BindableList<HitObjectInfo> selectedHitObjects,

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Move/EditorActionMoveObjectsToLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Move/EditorActionMoveObjectsToLayer.cs
@@ -15,11 +15,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Move
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
-        private List<HitObjectInfo> HitObjects { get; }
+        public List<HitObjectInfo> HitObjects { get; }
 
-        private List<int> OriginalLayers { get; set; }
+        public List<int> OriginalLayers { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Remove/EditorActionRemoveLayer.cs
@@ -20,16 +20,16 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Remove
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
         /// <summary>
         ///     The list of objects that existed in this layer
         /// </summary>
-        private List<HitObjectInfo> HitObjectsInLayer { get; set; }
+        public List<HitObjectInfo> HitObjectsInLayer { get; set; }
 
-        private BindableList<HitObjectInfo> SelectedHitObjects { get; }
+        public BindableList<HitObjectInfo> SelectedHitObjects { get; }
 
-        private int Index { get; set; }
+        public int Index { get; set; }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorActionRenameLayer.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Rename/EditorActionRenameLayer.cs
@@ -14,11 +14,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Rename
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
-        private string Name { get; }
+        public string Name { get; }
 
-        private string Previous { get; set; }
+        public string Previous { get; set; }
 
         [MoonSharpVisible(false)]
         public EditorActionRenameLayer(EditorActionManager manager, Qua map, EditorLayerInfo layer, string name)

--- a/Quaver.Shared/Screens/Edit/Actions/Layers/Visibility/EditorActionToggleLayerVisibility.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Layers/Visibility/EditorActionToggleLayerVisibility.cs
@@ -14,7 +14,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Layers.Visibility
 
         private Qua WorkingMap { get; }
 
-        private EditorLayerInfo Layer { get; }
+        public EditorLayerInfo Layer { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionToggleLayerVisibility(EditorActionManager manager, Qua workingMap, EditorLayerInfo layer)

--- a/Quaver.Shared/Screens/Edit/Actions/Offset/EditorActionApplyOffset.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Offset/EditorActionApplyOffset.cs
@@ -20,7 +20,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Offset
 
         private Qua WorkingMap { get; }
 
-        private int Offset { get; }
+        public int Offset { get; }
 
         public EditorActionApplyOffset(EditorActionManager actiomManager, Qua workingMap, int offset)
         {

--- a/Quaver.Shared/Screens/Edit/Actions/SV/Add/EditorActionAddScrollVelocity.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/Add/EditorActionAddScrollVelocity.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.Add
 
         private Qua WorkingMap { get; }
 
-        private SliderVelocityInfo ScrollVelocity { get; }
+        public SliderVelocityInfo ScrollVelocity { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddScrollVelocity(EditorActionManager manager, Qua workingMap, SliderVelocityInfo sv)

--- a/Quaver.Shared/Screens/Edit/Actions/SV/AddBatch/EditorActionAddScrollVelocityBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/AddBatch/EditorActionAddScrollVelocityBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.AddBatch
 
         private Qua WorkingMap { get; }
 
-        private List<SliderVelocityInfo> ScrollVelocities { get; }
+        public List<SliderVelocityInfo> ScrollVelocities { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddScrollVelocityBatch(EditorActionManager manager, Qua workingMap, List<SliderVelocityInfo> svs)

--- a/Quaver.Shared/Screens/Edit/Actions/SV/ChangeMultiplierBatch/EditorActionChangeScrollVelocityMultiplierBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/ChangeMultiplierBatch/EditorActionChangeScrollVelocityMultiplierBatch.cs
@@ -15,11 +15,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.ChangeMultiplierBatch
 
         private Qua WorkingMap { get; }
 
-        private List<SliderVelocityInfo> ScrollVelocities { get; }
+        public List<SliderVelocityInfo> ScrollVelocities { get; }
 
-        private List<float> OriginalMultipliers { get; } = new List<float>();
+        public List<float> OriginalMultipliers { get; } = new List<float>();
 
-        private float Multiplier { get; }
+        public float Multiplier { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeScrollVelocityMultiplierBatch(EditorActionManager manager, Qua workingMap, List<SliderVelocityInfo> svs,

--- a/Quaver.Shared/Screens/Edit/Actions/SV/ChangeOffsetBatch/EditorActionChangeScrollVelocityOffsetBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/ChangeOffsetBatch/EditorActionChangeScrollVelocityOffsetBatch.cs
@@ -15,9 +15,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.ChangeOffsetBatch
 
         private Qua WorkingMap { get; }
 
-        private List<SliderVelocityInfo> ScrollVelocities { get; }
+        public List<SliderVelocityInfo> ScrollVelocities { get; }
 
-        private float Offset { get; }
+        public float Offset { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeScrollVelocityOffsetBatch(EditorActionManager manager, Qua workingMap, List<SliderVelocityInfo> svs,

--- a/Quaver.Shared/Screens/Edit/Actions/SV/Remove/EditorActionRemoveScrollVelocity.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/Remove/EditorActionRemoveScrollVelocity.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.Remove
 
         private Qua WorkingMap { get; }
 
-        private SliderVelocityInfo ScrollVelocity { get; }
+        public SliderVelocityInfo ScrollVelocity { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionRemoveScrollVelocity(EditorActionManager manager, Qua workingMap, SliderVelocityInfo sv)

--- a/Quaver.Shared/Screens/Edit/Actions/SV/RemoveBatch/EditorActionRemoveScrollVelocityBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SV/RemoveBatch/EditorActionRemoveScrollVelocityBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SV.RemoveBatch
 
         private Qua WorkingMap { get; }
 
-        private List<SliderVelocityInfo> ScrollVelocities { get; }
+        public List<SliderVelocityInfo> ScrollVelocities { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionRemoveScrollVelocityBatch(EditorActionManager manager, Qua workingMap, List<SliderVelocityInfo> svs)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/Add/EditorActionAddTimingPoint.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/Add/EditorActionAddTimingPoint.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.Add
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddTimingPoint(EditorActionManager manager, Qua workingMap, TimingPointInfo tp)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/AddBatch/EditorActionAddTimingPointBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/AddBatch/EditorActionAddTimingPointBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.AddBatch
 
         private Qua WorkingMap { get; }
 
-        private List<TimingPointInfo> TimingPoints { get; }
+        public List<TimingPointInfo> TimingPoints { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddTimingPointBatch(EditorActionManager manager, Qua workingMap, List<TimingPointInfo> tps)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeBpm/EditorActionChangeTimingPointBpm.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeBpm/EditorActionChangeTimingPointBpm.cs
@@ -14,11 +14,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpm
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
-        private float OriginalBpm { get; }
+        public float OriginalBpm { get; }
 
-        private float NewBpm { get; }
+        public float NewBpm { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointBpm(EditorActionManager manager, Qua workingMap, TimingPointInfo tp, float newBpm)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeBpmBatch/EditorActionChangeTimingPointBpmBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeBpmBatch/EditorActionChangeTimingPointBpmBatch.cs
@@ -16,11 +16,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeBpmBatch
 
         private Qua WorkingMap { get; }
 
-        private List<TimingPointInfo> TimingPoints { get; }
+        public List<TimingPointInfo> TimingPoints { get; }
 
-        private List<float> OriginalBpms { get; } = new List<float>();
+        public List<float> OriginalBpms { get; } = new List<float>();
 
-        private float NewBpm { get; }
+        public float NewBpm { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointBpmBatch(EditorActionManager manager, Qua workingMap, List<TimingPointInfo> tps,

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorActionChangeTimingPointHidden.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeHidden/EditorActionChangeTimingPointHidden.cs
@@ -11,11 +11,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeHidden
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
-        private bool OriginalHidden { get; }
+        public bool OriginalHidden { get; }
 
-        private bool NewHidden { get; }
+        public bool NewHidden { get; }
 
         public EditorActionChangeTimingPointHidden(EditorActionManager manager, Qua workingMap, TimingPointInfo tp, bool newHidden)
         {

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeOffset/EditorActionChangeTimingPointOffset.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeOffset/EditorActionChangeTimingPointOffset.cs
@@ -14,11 +14,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffset
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
-        private float OriginalOffset { get; }
+        public float OriginalOffset { get; }
 
-        private float NewOffset { get; }
+        public float NewOffset { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointOffset(EditorActionManager manager, Qua workingMap, TimingPointInfo tp, float newOffset)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeOffsetBatch/EditorActionChangeTimingPointOffsetBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeOffsetBatch/EditorActionChangeTimingPointOffsetBatch.cs
@@ -15,9 +15,9 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffsetBatch
 
         private Qua WorkingMap { get; }
 
-        private List<TimingPointInfo> TimingPoints { get; }
+        public List<TimingPointInfo> TimingPoints { get; }
 
-        private float Offset { get; }
+        public float Offset { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointOffsetBatch(EditorActionManager manager, Qua workingMap, List<TimingPointInfo> tps,

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeSignature/EditorActionChangeTimingPointSignature.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeSignature/EditorActionChangeTimingPointSignature.cs
@@ -15,11 +15,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeSignature
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
-        private int OriginalSignature { get; }
+        public int OriginalSignature { get; }
 
-        private int NewSignature { get; }
+        public int NewSignature { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointSignature(EditorActionManager manager, Qua workingMap, TimingPointInfo tp, int newSignature)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeSignatureBatch/EditorActionChangeTimingPointSignatureBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/ChangeSignatureBatch/EditorActionChangeTimingPointSignatureBatch.cs
@@ -16,11 +16,11 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.ChangeSignatureBatch
 
         private Qua WorkingMap { get; }
 
-        private List<TimingPointInfo> TimingPoints { get; }
+        public List<TimingPointInfo> TimingPoints { get; }
 
-        private List<int> OriginalSignatures { get; } = new List<int>();
+        public List<int> OriginalSignatures { get; } = new List<int>();
 
-        private int NewSignature { get; }
+        public int NewSignature { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionChangeTimingPointSignatureBatch(EditorActionManager manager, Qua workingMap, List<TimingPointInfo> tps,

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/Remove/EditorActionRemoveTimingPoint.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/Remove/EditorActionRemoveTimingPoint.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.Remove
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionRemoveTimingPoint(EditorActionManager manager, Qua workingMap, TimingPointInfo tp)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/RemoveBatch/EditorActionRemoveTimingPointBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/RemoveBatch/EditorActionRemoveTimingPointBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch
 
         private Qua WorkingMap { get; }
 
-        private List<TimingPointInfo> TimingPoints { get; }
+        public List<TimingPointInfo> TimingPoints { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionRemoveTimingPointBatch(EditorActionManager manager, Qua workingMap, List<TimingPointInfo> tps)

--- a/Quaver.Shared/Screens/Edit/Actions/Timing/Reset/EditorActionResetTimingPoint.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/Timing/Reset/EditorActionResetTimingPoint.cs
@@ -16,15 +16,12 @@ namespace Quaver.Shared.Screens.Edit.Actions.Timing.Reset
 
         private Qua WorkingMap { get; }
 
-        private TimingPointInfo TimingPoint { get; }
+        public TimingPointInfo TimingPoint { get; }
 
-        [MoonSharpVisible(false)]
         public float OriginalBpm { get; }
 
-        [MoonSharpVisible(false)]
         public float OriginalOffset { get; }
 
-        [MoonSharpVisible(false)]
         public EditorActionResetTimingPoint(EditorActionManager manager, Qua workingMap, TimingPointInfo tp)
         {
             ActionManager = manager;

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvent.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvent.cs
@@ -12,13 +12,34 @@ public class EditorEvent
 
     private readonly HashSet<Closure> _closures = new();
 
+    /// <summary>
+    ///     Make the closure be called when this event is triggered
+    /// </summary>
+    /// <param name="closure">A Lua function(instance: <see cref="EditorEventInstance"/>)</param>
     public void Add(Closure closure) => _closures.Add(closure);
+
+    /// <summary>
+    /// </summary>
+    /// <param name="action"></param>
     public void Add(Action<EditorEventInstance> action) => OnInvoke += action;
+
+    /// <summary>
+    ///     Make the closure no longer be called when this event is triggered
+    /// </summary>
+    /// <param name="closure">A Lua function(instance: <see cref="EditorEventInstance"/>)</param>
     public void Remove(Closure closure) => _closures.Remove(closure);
+
+    /// <summary>
+    /// </summary>
+    /// <param name="action"></param>
     public void Remove(Action<EditorEventInstance> action) => OnInvoke -= action;
 
+    /// <summary>
+    ///     Invokes the event with an instance
+    /// </summary>
+    /// <param name="instance">The arguments of the event</param>
     [MoonSharpHidden]
-    public virtual void Invoke(EditorEventInstance instance)
+    public void Invoke(EditorEventInstance instance)
     {
         OnInvoke?.Invoke(instance);
         foreach (var closure in _closures)

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvent.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvent.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using MoonSharp.Interpreter;
+using Quaver.Shared.Scripting;
+
+namespace Quaver.Shared.Screens.Edit.LuaEvents;
+
+[MoonSharpUserData]
+public class EditorEvent
+{
+    [MoonSharpHidden] public event Action<EditorEventInstance> OnInvoke;
+
+    private readonly HashSet<Closure> _closures = new();
+
+    public void Add(Closure closure) => _closures.Add(closure);
+    public void Add(Action<EditorEventInstance> action) => OnInvoke += action;
+    public void Remove(Closure closure) => _closures.Remove(closure);
+    public void Remove(Action<EditorEventInstance> action) => OnInvoke -= action;
+
+    [MoonSharpHidden]
+    public virtual void Invoke(EditorEventInstance instance)
+    {
+        OnInvoke?.Invoke(instance);
+        foreach (var closure in _closures)
+        {
+            closure.SafeCall(instance);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEventInstance.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEventInstance.cs
@@ -1,0 +1,10 @@
+using MoonSharp.Interpreter;
+using Quaver.Shared.Screens.Edit.Actions;
+
+namespace Quaver.Shared.Screens.Edit.LuaEvents;
+
+[MoonSharpUserData]
+public record EditorEventInstance(IEditorAction Action, bool IsUndo)
+{
+    public EditorActionType ActionType => Action.Type;
+}

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEventInstance.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEventInstance.cs
@@ -6,5 +6,8 @@ namespace Quaver.Shared.Screens.Edit.LuaEvents;
 [MoonSharpUserData]
 public record EditorEventInstance(IEditorAction Action, bool IsUndo)
 {
+    /// <summary>
+    ///     Type of the action that yields the event
+    /// </summary>
     public EditorActionType ActionType => Action.Type;
 }

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvents.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvents.cs
@@ -13,9 +13,9 @@ public class EditorEvents
     private readonly Dictionary<EditorActionType, EditorEvent> _events = new();
 
     /// <summary>
-    /// 
+    ///     Gets the corresponding event handler for the action type
     /// </summary>
-    /// <param name="type"></param>
+    /// <param name="type">The type of the event handler</param>
     public EditorEvent this[EditorActionType type]
     {
         get
@@ -43,6 +43,10 @@ public class EditorEvents
         this[eventType].Add(closure);
     }
 
+    /// <summary>
+    /// </summary>
+    /// <param name="eventType"></param>
+    /// <param name="action"></param>
     public void Subscribe(EditorActionType eventType, Action<EditorEventInstance> action)
     {
         this[eventType].Add(action);
@@ -61,6 +65,10 @@ public class EditorEvents
         this[eventType].Remove(closure);
     }
 
+    /// <summary>
+    /// </summary>
+    /// <param name="eventType"></param>
+    /// <param name="action"></param>
     public void Unsubscribe(EditorActionType eventType, Action<EditorEventInstance> action)
     {
         this[eventType].Remove(action);
@@ -68,6 +76,7 @@ public class EditorEvents
 
     public EditorEvents()
     {
+        // The None event action marks the global event: any actions triggered will call this event
         _events.Add(EditorActionType.None, new EditorEvent());
     }
 }

--- a/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvents.cs
+++ b/Quaver.Shared/Screens/Edit/LuaEvents/EditorEvents.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using MoonSharp.Interpreter;
+using Quaver.Shared.Screens.Edit.Actions;
+
+// ReSharper disable ExpressionIsAlwaysNull
+
+namespace Quaver.Shared.Screens.Edit.LuaEvents;
+
+[MoonSharpUserData]
+public class EditorEvents
+{
+    private readonly Dictionary<EditorActionType, EditorEvent> _events = new();
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="type"></param>
+    public EditorEvent this[EditorActionType type]
+    {
+        get
+        {
+            if (_events.TryGetValue(type, out var editorEvent)) return editorEvent;
+
+            editorEvent = new EditorEvent();
+            // None is treated as global action: every action will trigger this
+            editorEvent.Add(a => _events[EditorActionType.None].Invoke(a));
+            _events.Add(type, editorEvent);
+            return editorEvent;
+        }
+    }
+
+    /// <summary>
+    ///     Subscribes to a particular event, or the whole category of events.<br/>
+    ///     The function has the signature <c>function (type: event_types, args: object[])</c>
+    /// </summary>
+    /// <param name="eventType"></param>
+    /// <param name="closure"></param>
+    /// <seealso cref="EditorActionType"/>
+    /// <seealso cref="EditorEvent"/>
+    public void Subscribe(EditorActionType eventType, Closure closure)
+    {
+        this[eventType].Add(closure);
+    }
+
+    public void Subscribe(EditorActionType eventType, Action<EditorEventInstance> action)
+    {
+        this[eventType].Add(action);
+    }
+
+    /// <summary>
+    ///     Unsubscribes to a particular event, or the whole category of events
+    /// </summary>
+    /// <param name="eventType"></param>
+    /// <param name="closure"></param>
+    /// <seealso cref="Subscribe(Quaver.Shared.Screens.Edit.Actions.EditorActionType,MoonSharp.Interpreter.Closure)"/>
+    /// <seealso cref="EditorActionType"/>
+    /// <seealso cref="EditorEvent"/>
+    public void Unsubscribe(EditorActionType eventType, Closure closure)
+    {
+        this[eventType].Remove(closure);
+    }
+
+    public void Unsubscribe(EditorActionType eventType, Action<EditorEventInstance> action)
+    {
+        this[eventType].Remove(action);
+    }
+
+    public EditorEvents()
+    {
+        _events.Add(EditorActionType.None, new EditorEvent());
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -96,6 +96,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             WorkingScript.Globals["time_signature"] = typeof(TimeSignature);
             WorkingScript.Globals["action_type"] = typeof(EditorActionType);
             WorkingScript.Globals["actions"] = Editor.ActionManager.PluginActionManager;
+            WorkingScript.Globals["events"] = Editor.ActionManager.LuaEditorEvents;
 
             var state = (EditorPluginState)State;
 

--- a/Quaver.Shared/Scripting/LuaScriptHelper.cs
+++ b/Quaver.Shared/Scripting/LuaScriptHelper.cs
@@ -1,0 +1,48 @@
+using System;
+using MoonSharp.Interpreter;
+using Quaver.Shared.Graphics.Notifications;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Scripting;
+
+public static class LuaScriptHelper
+{
+    public static void TryPerform(Action action)
+    {
+        TryPerform(() =>
+        {
+            action();
+            return true;
+        });
+    }
+
+    public static T TryPerform<T>(Func<T> func)
+    {
+        try
+        {
+            return func();
+        }
+        catch (ScriptRuntimeException e)
+        {
+            NotificationManager.Show(NotificationLevel.Error, $"Lua script: {e.DecoratedMessage}");
+            Logger.Error($"Lua chart script runtime error: {e.DecoratedMessage}", LogType.Runtime);
+        }
+        catch (SyntaxErrorException e)
+        {
+            NotificationManager.Show(NotificationLevel.Error, $"Lua script: {e.DecoratedMessage}");
+            Logger.Error($"Lua chart script syntax error: {e.DecoratedMessage}", LogType.Runtime);
+        }
+        catch (Exception e)
+        {
+            NotificationManager.Show(NotificationLevel.Error, $"Lua script caused an internal error: {e}");
+            Logger.Error($"Lua chart script internal error: {e}", LogType.Runtime);
+        }
+
+        return default;
+    }
+
+    public static DynValue SafeCall(this Closure closure, params object[] args)
+    {
+        return TryPerform(() => closure.Call(args));
+    }
+}


### PR DESCRIPTION
Resolves #4051 with a few differences

This is a modified copy of the event system implemented in the animation pr (#4045):

Subscribe to events with `events.Subscribe(action_type.xxx, handler_function)`

Unsubscribe with `events.Unsubscribe`

`handler_function` has the form `function(instance: EventInstance)` where the `EventInstance` has fields:
* `EventInstance.Action` the action object. e.g. `instance.action.hitObject.startTime`
* `EventInstance.ActionType` type of the action (`action_type.xxx`)
* `EventInstance.IsUndo` indicates whether the action is performed(redid) or undid

The action type `action_type.None` is treated as a wildcard. If you subscribe a function to this type, it will be called if **any** action is performed or undid.

Example plugin code:
```lua
logs = ""
firstUpdate = true

function draw()
    if firstUpdate then
        firstUpdate = false
        -- Subscribes to any event
        events.subscribe(action_type.None, listener)
        -- Subscribes particularly to the placement of hitObjects
        events.subscribe(action_type.PlaceHitObject, notePlacementListener)
    end
    imgui.Begin("Event logger")
    imgui.Text(logs)
    imgui.End()
end

function addLog(s)
    logs = logs .. '\n' .. s
end

function listener(instance)
    addLog("Action captured by global: " .. tostring(instance.actionType) .. ", undo = " .. tostring(instance.isUndo))
end

function notePlacementListener(instance)
    addLog("Note place at " .. tostring(instance.action.hitObject.StartTime) .. ", undo = " .. tostring(instance.isUndo))
end
```