### PR TITLE
Read quaver.cfg with UTF-8 encoding

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -974,7 +974,7 @@ namespace Quaver.Shared.Config
                 Logger.Important("Creating a new config file...", LogType.Runtime);
             }
 
-            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(configFilePath)["Config"];
+            var data = new IniFileParser.IniFileParser(new ConcatenateDuplicatedKeysIniDataParser()).ReadFile(configFilePath, Encoding.UTF8)["Config"];
 
             // Read / Set Config Values
             // NOTE: MAKE SURE TO SET THE VALUE TO AUTO-SAVE WHEN CHANGING! THIS ISN'T DONE AUTOMATICALLY.


### PR DESCRIPTION
By default, ini is read with ASCII and written with UTF-8. This makes CJK characters not readable. This commit will fix it such that for example, the choice of an audio device with CJK characters in its name will be saved and loaded correctly, instead of falling back to Default. (My headphone is named '耳机 (Realtek Audio)' and it was read as '?????? (Realtek Audio)' which does not exist as a device, so it just falls back to Default)