### PR TITLE
Fix scoreboard avatar loading concurrent issue

### DIFF
--- a/Quaver.Shared/Online/SteamManager.cs
+++ b/Quaver.Shared/Online/SteamManager.cs
@@ -6,6 +6,7 @@
 */
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -38,12 +39,12 @@ namespace Quaver.Shared.Online
         /// <summary>
         ///     The avatars for steam users.
         /// </summary>
-        public static Dictionary<ulong, Texture2D> UserAvatars { get; private set; }
+        public static ConcurrentDictionary<ulong, Texture2D> UserAvatars { get; private set; }
 
         /// <summary>
         ///     Large Steam user avatars
         /// </summary>
-        public static Dictionary<ulong, Texture2D> UserAvatarsLarge { get; private set; }
+        public static ConcurrentDictionary<ulong, Texture2D> UserAvatarsLarge { get; private set; }
 
         /// <summary>
         ///     A user's steam avatar has loaded.
@@ -105,8 +106,8 @@ namespace Quaver.Shared.Online
 
             IsInitialized = SteamAPI.Init();
 
-            UserAvatars = new Dictionary<ulong, Texture2D>();
-            UserAvatarsLarge = new Dictionary<ulong, Texture2D>();
+            UserAvatars = new ConcurrentDictionary<ulong, Texture2D>();
+            UserAvatarsLarge = new ConcurrentDictionary<ulong, Texture2D>();
 
             if (!IsInitialized)
             {


### PR DESCRIPTION
Use ConcurrentDictionary instead of Dictionary for Avatars (and the large ones).

Resolves error
```
RUNTIME - ERROR: System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary2.ContainsKey(TKey key)
   at Quaver.Shared.Screens.Gameplay.UI.Scoreboard.ScoreboardUser..ctor(GameplayScreen screen, ScoreboardUserType type, String username, List`1 judgements, Texture2D avatar, ModIdentifier mods, Score score, RatingProcessorKeys processor) in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Gameplay\UI\Scoreboard\ScoreboardUser.cs:line 217
   at Quaver.Shared.Screens.Gameplay.GameplayScreenView.CheckIfNewScoreboardUsers() in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Gameplay\GameplayScreenView.cs:line 556
   at Quaver.Shared.Screens.Gameplay.GameplayScreenView.Update(GameTime gameTime) in D:\QuaverDeploy\Quaver\Quaver.Shared\Screens\Gameplay\GameplayScreenView.cs:line 327
```