### PR TITLE
[1.5.0] Reduce memory allocation in menu audio visualiser

### DIFF
--- a/Quaver.Shared/Screens/Menu/UI/Visualizer/MenuAudioVisualizer.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Visualizer/MenuAudioVisualizer.cs
@@ -29,6 +29,8 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
         /// </summary>
         public int MaxBarHeight { get; }
 
+        private readonly float[]  _spectrumData = new float[2048];
+
         /// <inheritdoc />
         ///   <summary>
         ///   </summary>
@@ -88,19 +90,17 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
         /// </summary>
         private void InterpolateBars()
         {
-            var spectrumData = new float[2048];
-
             if (AudioEngine.Track == null || AudioEngine.Track.IsDisposed)
                 return;
 
             if (AudioEngine.Track.IsPlaying)
-                Bass.ChannelGetData(AudioEngine.Track.Stream, spectrumData, (int)DataFlags.FFT2048);
+                Bass.ChannelGetData(AudioEngine.Track.Stream, _spectrumData, (int)DataFlags.FFT2048);
 
             for (var i = 0; i < Bars.Count; i++)
             {
                 var bar = Bars[i];
 
-                var targetHeight = spectrumData[i] * MaxBarHeight;
+                var targetHeight = _spectrumData[i] * MaxBarHeight;
 
                 bar.Visible = targetHeight > 1f;
 

--- a/Quaver.Shared/Screens/Menu/UI/Visualizer/MenuAudioVisualizer.cs
+++ b/Quaver.Shared/Screens/Menu/UI/Visualizer/MenuAudioVisualizer.cs
@@ -33,14 +33,14 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
         /// <summary>
         ///     Timer used to record time passed since last interpolation
         /// </summary>
-        private TimeSpan _interpolationTimer = TimeSpan.Zero;
+        private TimeSpan interpolationTimer = TimeSpan.Zero;
 
         /// <summary>
         ///     Minimum time that needs to pass before the bars are interpolated again
         /// </summary>
-        private readonly TimeSpan _barInterpolateInterval = TimeSpan.FromMilliseconds(50);
+        private readonly TimeSpan barInterpolateInterval = TimeSpan.FromMilliseconds(50);
 
-        private readonly float[]  _spectrumData = new float[2048];
+        private readonly float[]  spectrumData = new float[2048];
 
         /// <inheritdoc />
         ///   <summary>
@@ -82,11 +82,11 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
         {
             if (ConfigManager.DisplayMenuAudioVisualizer != null && ConfigManager.DisplayMenuAudioVisualizer.Value)
             {
-                _interpolationTimer += gameTime.ElapsedGameTime;
+                interpolationTimer += gameTime.ElapsedGameTime;
                 // ReSharper disable once InconsistentlySynchronizedField
-                if (_interpolationTimer >= _barInterpolateInterval)
+                if (interpolationTimer >= barInterpolateInterval)
                 {
-                    _interpolationTimer = TimeSpan.Zero;
+                    interpolationTimer = TimeSpan.Zero;
                     InterpolateBars();
                 }
             }
@@ -113,15 +113,15 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
                 return;
 
             if (AudioEngine.Track.IsPlaying)
-                _ = Bass.ChannelGetData(AudioEngine.Track.Stream, _spectrumData, (int)DataFlags.FFT2048);
+                _ = Bass.ChannelGetData(AudioEngine.Track.Stream, spectrumData, (int)DataFlags.FFT2048);
             else
-                Array.Clear(_spectrumData);
+                Array.Clear(spectrumData);
 
             for (var i = 0; i < Bars.Count; i++)
             {
                 var bar = Bars[i];
 
-                var targetHeight = _spectrumData[i] * MaxBarHeight;
+                var targetHeight = spectrumData[i] * MaxBarHeight;
 
                 bar.Visible = targetHeight > 1f;
 
@@ -133,7 +133,7 @@ namespace Quaver.Shared.Screens.Menu.UI.Visualizer
                 {
                     bar.Animations.Clear();
                     bar.Animations.Add(new Animation(AnimationProperty.Height, Easing.Linear,
-                        bar.Height, targetHeight, (float)_barInterpolateInterval.TotalMilliseconds));
+                        bar.Height, targetHeight, (float)barInterpolateInterval.TotalMilliseconds));
                 }
             }
         }


### PR DESCRIPTION
Don't allocate float[2048] per update (this causes hundreds of megabytes to be used as reported by Rider DPA). Instead, allocate one and write to it only.

The amount of FFT requests and animations are also reduced. They now only interpolate once per 50ms, as opposed to as many as the amount of updates.

Similar issue occurs in waveform generation which also slows down the entire process too, as compared to spectrogram. I'll look into that later.