### PR TITLE
[1.5.0] Cap FPS to 500 if FPS mode is set to Custom and the custom fps is set above 500

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -534,11 +534,15 @@ namespace Quaver.Shared
         private static void ShowFpsCounter(FpsCounter counter) => counter.Visible = ConfigManager.FpsCounter.Value;
 
         /// <summary>
-        ///    Handles limiting/unlimiting FPS based on user config
+        ///     Uses a custom fps config
         /// </summary>
-        public void InitializeFpsLimiting()
+        /// <param name="fpsLimitType"></param>
+        /// <param name="customFpsLimit"></param>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        public void SetFps(FpsLimitType fpsLimitType, int customFpsLimit)
         {
-            switch (ConfigManager.FpsLimiterType.Value)
+            
+            switch (fpsLimitType)
             {
                 case FpsLimitType.Unlimited:
                     Graphics.SynchronizeWithVerticalRetrace = false;
@@ -563,15 +567,22 @@ namespace Quaver.Shared
                     break;
                 case FpsLimitType.Custom:
                     Graphics.SynchronizeWithVerticalRetrace = false;
-                    TargetElapsedTime = TimeSpan.FromSeconds(1d / ConfigManager.CustomFpsLimit.Value);
+                    TargetElapsedTime = TimeSpan.FromSeconds(1d / customFpsLimit);
                     IsFixedTimeStep = true;
                     WaylandVsync = false;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
             Graphics.ApplyChanges();
+        }
+
+        /// <summary>
+        ///    Handles limiting/unlimiting FPS based on user config
+        /// </summary>
+        public void InitializeFpsLimiting()
+        {
+            SetFps(ConfigManager.FpsLimiterType.Value, ConfigManager.CustomFpsLimit.Value);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -115,7 +115,7 @@ namespace Quaver.Shared.Screens.Edit
             {
                 previousCustomFps = ConfigManager.CustomFpsLimit.Value;
                 Container.ScheduleUpdate(() =>
-                    ConfigManager.CustomFpsLimit.Value = MaximumCustomFps
+                    ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, MaximumCustomFps)
                 );
             }
 
@@ -182,7 +182,7 @@ namespace Quaver.Shared.Screens.Edit
         public override void Destroy()
         {
             if (previousCustomFps != 0)
-                ConfigManager.CustomFpsLimit.Value = previousCustomFps;
+                ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, previousCustomFps);
 
             Container?.Destroy();
 

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -97,13 +97,6 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         private const int MaximumCustomFps = 500;
 
-        /// <summary>
-        ///     If the fps is capped, the previous custom fps value.
-        ///     Otherwise, it will be 0
-        ///     When the screen is destroyed, the FPS cap should return to <see cref="previousCustomFps"/>
-        /// </summary>
-        private int previousCustomFps;
-
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -113,7 +106,6 @@ namespace Quaver.Shared.Screens.Edit
             if (ConfigManager.FpsLimiterType.Value == FpsLimitType.Custom &&
                 ConfigManager.CustomFpsLimit.Value > MaximumCustomFps)
             {
-                previousCustomFps = ConfigManager.CustomFpsLimit.Value;
                 Container.ScheduleUpdate(() =>
                     ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, MaximumCustomFps)
                 );
@@ -181,8 +173,8 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         public override void Destroy()
         {
-            if (previousCustomFps != 0)
-                ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, previousCustomFps);
+            if (ConfigManager.FpsLimiterType.Value == FpsLimitType.Custom)
+                ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, ConfigManager.CustomFpsLimit.Value);
 
             Container?.Destroy();
 

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -107,7 +107,7 @@ namespace Quaver.Shared.Screens.Edit
                 ConfigManager.CustomFpsLimit.Value > MaximumCustomFps)
             {
                 Container.ScheduleUpdate(() =>
-                    ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Custom, MaximumCustomFps)
+                    ((QuaverGame)GameBase.Game).SetFps(FpsLimitType.Unlimited, MaximumCustomFps)
                 );
             }
 


### PR DESCRIPTION
~~Side effect: If the editor crashes, the Custom FPS limit might not be recovered. I don't know if I can do anything with that.~~ **EDIT** No it will work properly now.