### PR TITLE
[1.5.0] Allow placing long notes during livemapping

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -387,6 +387,11 @@ namespace Quaver.Shared.Config
         ///     Whether long notes can be placed when live mapping
         /// </summary>
         internal static Bindable<bool> EditorLiveMapLongNote { get; private set; }
+        
+        /// <summary>
+        ///     Minimum time needed to press the key to place a long note when live mapping
+        /// </summary>
+        internal static BindableInt EditorLiveMapLongNoteThreshold { get; private set; }
 
         /// <summary>
         ///     Whether or not to play hitsounds in the editor.
@@ -1112,6 +1117,7 @@ namespace Quaver.Shared.Config
             EditorLiveMapSnap = ReadValue(@"EditorLiveMapSnap", false, data);
             EditorLiveMapOffset = ReadInt(@"EditorLiveMapOffset", 0, -200, 200, data);
             EditorLiveMapLongNote = ReadValue(@"EditorLiveMapLongNote", true, data);
+            EditorLiveMapLongNoteThreshold = ReadInt(@"EditorLiveMapLongNoteThreshold", 100, 0, 1000, data);
             EditorEnableHitsounds = ReadValue(@"EditorEnableHitsounds", true, data);
             EditorEnableKeysounds = ReadValue(@"EditorEnableKeysounds", true, data);
             EditorBeatSnapColorType = ReadValue(@"EditorBeatSnapColorType", EditorBeatSnapColor.Default, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -373,9 +373,20 @@ namespace Quaver.Shared.Config
         /// </summary>
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
 
+        /// <summary>
+        ///     Whether to snap notes when livemapping
+        /// </summary>
         internal static Bindable<bool> EditorLiveMapSnap { get; private set; }
 
+        /// <summary>
+        ///     The offset applied to every hit objects placed by livemapping
+        /// </summary>
         internal static BindableInt EditorLiveMapOffset { get; private set; }
+
+        /// <summary>
+        ///     Whether long notes can be placed when live mapping
+        /// </summary>
+        internal static Bindable<bool> EditorLiveMapLongNote { get; private set; }
 
         /// <summary>
         ///     Whether or not to play hitsounds in the editor.
@@ -1100,6 +1111,7 @@ namespace Quaver.Shared.Config
             InvertEditorScrolling = ReadValue(@"InvertEditorScrolling", true, data);
             EditorLiveMapSnap = ReadValue(@"EditorLiveMapSnap", false, data);
             EditorLiveMapOffset = ReadInt(@"EditorLiveMapOffset", 0, -200, 200, data);
+            EditorLiveMapLongNote = ReadValue(@"EditorLiveMapLongNote", true, data);
             EditorEnableHitsounds = ReadValue(@"EditorEnableHitsounds", true, data);
             EditorEnableKeysounds = ReadValue(@"EditorEnableKeysounds", true, data);
             EditorBeatSnapColorType = ReadValue(@"EditorBeatSnapColorType", EditorBeatSnapColor.Default, data);

--- a/Quaver.Shared/Graphics/Graphs/DifficultySeekBar.cs
+++ b/Quaver.Shared/Graphics/Graphs/DifficultySeekBar.cs
@@ -75,6 +75,17 @@ namespace Quaver.Shared.Graphics.Graphs
         /// </summary>
         protected List<Sprite> Bars { get; set; }
 
+        /// <summary>
+        ///     When the timer reaches <see cref="RecreateBarsTimeout"/>, <see cref="CreateBars"/> will be called.
+        ///     (Debouncing)
+        /// </summary>
+        private TimeSpan recreateBarsTimer = TimeSpan.MaxValue;
+
+        /// <summary>
+        ///     The duration that needs to be passed before <see cref="CreateBars"/> is called.
+        /// </summary>
+        private static readonly TimeSpan RecreateBarsTimeout = TimeSpan.FromMilliseconds(200);
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -135,6 +146,16 @@ namespace Quaver.Shared.Graphics.Graphs
             if (SeekBarLine != null)
                 SeekBarLine.Y = Height - (float) (Track.Time  / Track.Length) * Height;
 
+            if (recreateBarsTimer != TimeSpan.MaxValue)
+            {
+                recreateBarsTimer += gameTime.ElapsedGameTime;
+                if (recreateBarsTimer > RecreateBarsTimeout)
+                {
+                    AddScheduledUpdate(CreateBars);
+                    recreateBarsTimer = TimeSpan.MaxValue;
+                }
+            }
+
             base.Update(gameTime);
         }
 
@@ -145,6 +166,14 @@ namespace Quaver.Shared.Graphics.Graphs
         {
             AudioSeeked = null;
             base.Destroy();
+        }
+
+        /// <summary>
+        ///     Resets the timer to 0 so <see cref="CreateBars"/> will start debouncing
+        /// </summary>
+        protected void ScheduleCreateBars()
+        {
+            recreateBarsTimer = TimeSpan.Zero;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorSetLiveMapLongNoteThresholdDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorSetLiveMapLongNoteThresholdDialog.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.RegularExpressions;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Config;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Helpers;
+using Wobble.Graphics;
+using Wobble.Graphics.UI.Form;
+using Wobble.Managers;
+
+namespace Quaver.Shared.Screens.Edit.Dialogs
+{
+    public class EditorSetLiveMapLongNoteThresholdDialog : YesNoDialog
+    {
+        private EditScreen Screen { get; }
+
+        /// <summary>
+        /// </summary>
+        protected Textbox Textbox { get; set; }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public EditorSetLiveMapLongNoteThresholdDialog(EditScreen screen) : base("SET LIVEMAP LN THRESHOLD",
+            "Enter the minimum length of a long note during live-mapping...")
+        {
+            Screen = screen;
+            CreateTextbox();
+
+            Panel.Height += 50;
+            YesButton.Y = -30;
+            NoButton.Y = YesButton.Y;
+
+            YesButton.Clicked += (sender, args) => OnSubmit(Textbox.RawText);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void CreateTextbox()
+        {
+            Textbox = new Textbox(new ScalableVector2(Panel.Width * 0.90f, 50),
+                FontManager.GetWobbleFont(Fonts.LatoBlack),
+                20, ConfigManager.EditorLiveMapLongNoteThreshold.Value.ToString(),
+                "Enter an threshold of LNs during livemapping...", OnSubmit)
+            {
+                Parent = Panel,
+                Alignment = Alignment.BotCenter,
+                Y = -100,
+                Tint = ColorHelper.HexToColor("#2F2F2F"),
+                AlwaysFocused = true,
+                AllowedCharacters = new Regex(@"^[0-9-]*$")
+            };
+
+            Textbox.AddBorder(ColorHelper.HexToColor("#363636"), 2);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        public override void Close()
+        {
+            Textbox.Visible = false;
+            base.Close();
+        }
+
+        private void OnSubmit(string s)
+        {
+            try
+            {
+                var val = int.Parse(s);
+                ConfigManager.EditorLiveMapLongNoteThreshold.Value = val;
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorSetLiveMapLongNoteThresholdDialog.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorSetLiveMapLongNoteThresholdDialog.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
+using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Form;
@@ -41,14 +42,14 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
             Textbox = new Textbox(new ScalableVector2(Panel.Width * 0.90f, 50),
                 FontManager.GetWobbleFont(Fonts.LatoBlack),
                 20, ConfigManager.EditorLiveMapLongNoteThreshold.Value.ToString(),
-                "Enter an threshold of LNs during livemapping...", OnSubmit)
+                "Enter a threshold of LNs during livemapping...", OnSubmit)
             {
                 Parent = Panel,
                 Alignment = Alignment.BotCenter,
                 Y = -100,
                 Tint = ColorHelper.HexToColor("#2F2F2F"),
                 AlwaysFocused = true,
-                AllowedCharacters = new Regex(@"^[0-9-]*$")
+                AllowedCharacters = new Regex(@"^[0-9]*$")
             };
 
             Textbox.AddBorder(ColorHelper.HexToColor("#363636"), 2);
@@ -65,15 +66,13 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
 
         private void OnSubmit(string s)
         {
-            try
+            if (!int.TryParse(s, out var val))
             {
-                var val = int.Parse(s);
-                ConfigManager.EditorLiveMapLongNoteThreshold.Value = val;
+                NotificationManager.Show(NotificationLevel.Error, $"Invalid value: '{s}'");
+                return;
             }
-            catch (Exception)
-            {
-                // ignored
-            }
+
+            ConfigManager.EditorLiveMapLongNoteThreshold.Value = val;
         }
     }
 }

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -888,7 +888,6 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         private void HandleTemporaryHitObjectPlacement()
         {
-            const float minimumLongNoteLength = 100;
             if (!LiveMapping.Value)
                 return;
             if (KeyboardManager.IsAltDown()) return; // Swapping lanes, not placing objects
@@ -932,7 +931,7 @@ namespace Quaver.Shared.Screens.Edit
                 }
                 else if (heldLivemapHitObjectInfos[i] != null && ConfigManager.EditorLiveMapLongNote.Value)
                 {
-                    if (time - heldLivemapHitObjectInfos[i].StartTime > minimumLongNoteLength)
+                    if (time - heldLivemapHitObjectInfos[i].StartTime > ConfigManager.EditorLiveMapLongNoteThreshold.Value)
                         ActionManager.ResizeLongNote(heldLivemapHitObjectInfos[i], heldLivemapHitObjectInfos[i].EndTime, time);
                 }
             }

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -880,6 +880,7 @@ namespace Quaver.Shared.Screens.Edit
 
             DeleteSelectedObjects();
         }
+
         /// <summary>
         ///     Places a note if a note at the current editor time and the given number key
         ///     lane doesn't exist, otherwise removes all instances of notes at that time and lane
@@ -887,6 +888,7 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         private void HandleTemporaryHitObjectPlacement()
         {
+            const float minimumLongNoteLength = 100;
             if (!LiveMapping.Value)
                 return;
             if (KeyboardManager.IsAltDown()) return; // Swapping lanes, not placing objects
@@ -928,9 +930,10 @@ namespace Quaver.Shared.Screens.Edit
                     else
                         heldLivemapHitObjectInfos[i] = ActionManager.PlaceHitObject(lane, time, 0, layer);
                 }
-                else if (heldLivemapHitObjectInfos[i] != null)
+                else if (heldLivemapHitObjectInfos[i] != null && ConfigManager.EditorLiveMapLongNote.Value)
                 {
-                    ActionManager.ResizeLongNote(heldLivemapHitObjectInfos[i], heldLivemapHitObjectInfos[i].EndTime, time);
+                    if (time - heldLivemapHitObjectInfos[i].StartTime > minimumLongNoteLength)
+                        ActionManager.ResizeLongNote(heldLivemapHitObjectInfos[i], heldLivemapHitObjectInfos[i].EndTime, time);
                 }
             }
         }

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -527,6 +527,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.MenuItem("Set Offset For Notes Placed During Live Mapping"))
                 DialogManager.Show(new EditorSetLiveMapOffsetDialog(Screen));
 
+            if (ImGui.MenuItem("Place Long Notes When Live Mapping", "", ConfigManager.EditorLiveMapLongNote.Value))
+                ConfigManager.EditorLiveMapLongNote.Value = !ConfigManager.EditorLiveMapLongNote.Value;
+
             if (ImGui.MenuItem("Invert Beat Snap Scroll", "", Screen.InvertBeatSnapScroll.Value))
                 Screen.InvertBeatSnapScroll.Value = !Screen.InvertBeatSnapScroll.Value;
 

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -530,6 +530,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
             if (ImGui.MenuItem("Place Long Notes When Live Mapping", "", ConfigManager.EditorLiveMapLongNote.Value))
                 ConfigManager.EditorLiveMapLongNote.Value = !ConfigManager.EditorLiveMapLongNote.Value;
 
+            if (ImGui.MenuItem("Set Minimum Length Of Long Notes Placed During Live Mapping"))
+                DialogManager.Show(new EditorSetLiveMapLongNoteThresholdDialog(Screen));
+
             if (ImGui.MenuItem("Invert Beat Snap Scroll", "", Screen.InvertBeatSnapScroll.Value))
                 Screen.InvertBeatSnapScroll.Value = !Screen.InvertBeatSnapScroll.Value;
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Seek/EditorDifficultySeekBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Seek/EditorDifficultySeekBar.cs
@@ -55,7 +55,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Seek
             base.Destroy();
         }
 
-        public void Refresh() => CreateBars();
+        public void Refresh() => ScheduleCreateBars();
 
         private void OnHitObjectPlaced(object sender, EditorHitObjectPlacedEventArgs e) => Refresh();
 


### PR DESCRIPTION
Resolves #4220

Adds two menu options: a toggle for placing long notes during livemapping (defaults to true), and a setting for the minimum threshold to hold the key to recognize it as a long note (defaults to 100ms).

Difficulty bar recreation creation is now debounced (200ms), because it keeps getting called when resizing long notes, which just eats the entire memory and fps.

Keybind is not added yet; I'm thinking maybe we can do that when we move everything to the new unused input manager.