### PR TITLE
[1.5.0] Add judgement burst and combo bump Y and bump time

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -108,7 +108,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <summary>
         ///     Sprite that displays the current combo.
         /// </summary>
-        public GameplayNumberDisplay ComboDisplay { get; private set; }
+        public ComboDisplay ComboDisplay { get; private set; }
 
         /// <summary>
         ///     The combo in the previous frame. Used to determine if we should update it.
@@ -119,7 +119,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         ///     The original value for the combo display's Y position,
         ///     so we can use this to set it back after it's done with its animation.
         /// </summary>
-        public float OriginalComboDisplayY { get; set; }
+        public float OriginalComboDisplayY
+        {
+            get => ComboDisplay.OriginalPosY;
+            set => ComboDisplay.OriginalPosY = value;
+        }
 
         /// <summary>
         ///     The HitError bar.
@@ -489,16 +493,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             var skin = SkinManager.Skin.Keys[Screen.Map.Mode];
 
             // Create the combo display.
-            ComboDisplay = new GameplayNumberDisplay(NumberDisplayType.Combo, "0",
-                new Vector2(skin.ComboDisplayScale / 100f, skin.ComboDisplayScale / 100f))
+            ComboDisplay = new ComboDisplay(NumberDisplayType.Combo, "0",
+                new Vector2(skin.ComboDisplayScale / 100f, skin.ComboDisplayScale / 100f),
+                Screen,
+                Skin.ComboPosY)
             {
                 Parent = Playfield.ForegroundContainer,
                 Alignment = Alignment.MidCenter,
-                X = Skin.ComboPosX,
-                Y = Skin.ComboPosY
+                X = Skin.ComboPosX
             };
-
-            OriginalComboDisplayY = ComboDisplay.Y;
 
             // Start off the map by making the display invisible.
             ComboDisplay.MakeInvisible();
@@ -510,20 +513,13 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// <param name="gameTime"></param>
         private void UpdateComboDisplay(GameTime gameTime)
         {
-            // Gradually tween the position back to what it was originally.
-            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / Skin.ComboDisplayBumpTime, 1) / 2);
-
             if (OldCombo == Screen.Ruleset.ScoreProcessor.Combo)
                 return;
 
             // Set the new one
             ComboDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Combo);
+            ComboDisplay.StartBump();
 
-            // Set the position and scale  of the combo display, so that we can perform some animations.
-            ComboDisplay.Y = OriginalComboDisplayY + Skin.ComboDisplayBumpY;
-
-            // Gradually tween the position back to what it was originally.
-            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / Skin.ComboDisplayBumpTime, 1) / 2);
             OldCombo = Screen.Ruleset.ScoreProcessor.Combo;
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -511,7 +511,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         private void UpdateComboDisplay(GameTime gameTime)
         {
             // Gradually tween the position back to what it was originally.
-            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / 30, 1) / 2);
+            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / Skin.ComboDisplayBumpTime, 1) / 2);
 
             if (OldCombo == Screen.Ruleset.ScoreProcessor.Combo)
                 return;
@@ -520,10 +520,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             ComboDisplay.UpdateValue(Screen.Ruleset.ScoreProcessor.Combo);
 
             // Set the position and scale  of the combo display, so that we can perform some animations.
-            ComboDisplay.Y = OriginalComboDisplayY - 5;
+            ComboDisplay.Y = OriginalComboDisplayY + Skin.ComboDisplayBumpY;
 
             // Gradually tween the position back to what it was originally.
-            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / 30, 1) / 2);
+            ComboDisplay.Y = MathHelper.Lerp(ComboDisplay.Y, OriginalComboDisplayY, (float)Math.Min(GameBase.Game.TimeSinceLastFrame / Skin.ComboDisplayBumpTime, 1) / 2);
             OldCombo = Screen.Ruleset.ScoreProcessor.Combo;
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -116,16 +116,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         private int OldCombo { get; set; }
 
         /// <summary>
-        ///     The original value for the combo display's Y position,
-        ///     so we can use this to set it back after it's done with its animation.
-        /// </summary>
-        public float OriginalComboDisplayY
-        {
-            get => ComboDisplay.OriginalPosY;
-            set => ComboDisplay.OriginalPosY = value;
-        }
-
-        /// <summary>
         ///     The HitError bar.
         /// </summary>
         public HitErrorBar HitError { get; private set; }

--- a/Quaver.Shared/Screens/Gameplay/UI/ComboDisplay.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/ComboDisplay.cs
@@ -1,0 +1,68 @@
+using System;
+using Microsoft.Xna.Framework;
+using MonoGame.Extended.Timers;
+using Quaver.Shared.Graphics;
+using Quaver.Shared.Skinning;
+using Wobble.Graphics.Animations;
+
+namespace Quaver.Shared.Screens.Gameplay.UI;
+
+public class ComboDisplay : GameplayNumberDisplay
+{
+    /// <summary>
+    /// </summary>
+    private GameplayScreen Screen { get; }
+
+    /// <summary>
+    ///     Timer for bumping the combo
+    /// </summary>
+    private readonly CountdownTimer _bumpTimer;
+
+    /// <summary>
+    ///     Time to bump
+    /// </summary>
+    private readonly TimeSpan _bumpTime;
+
+    /// <summary>
+    ///     Start Y of bumping
+    /// </summary>
+    private float _bumpY;
+
+    /// <summary>
+    ///     The original Y position of the combo display.
+    /// </summary>
+    public float OriginalPosY { get; set; }
+
+    private SkinKeys Skin => SkinManager.Skin.Keys[Screen.Map.Mode];
+
+    internal ComboDisplay(NumberDisplayType type, string startingValue, Vector2 imageScale, GameplayScreen screen,
+        float originalPosY) : base(type, startingValue, imageScale)
+    {
+        Screen = screen;
+        OriginalPosY = originalPosY;
+        Y = OriginalPosY;
+
+        _bumpTime = TimeSpan.FromMilliseconds(Skin.ComboDisplayBumpTime);
+        _bumpTimer = new CountdownTimer(_bumpTime);
+        _bumpTimer.TimeRemainingChanged += LerpY;
+        _bumpTimer.Stopped += LerpY;
+    }
+
+    private void LerpY(object sender, EventArgs e)
+    {
+        var t = 1 - _bumpTimer.TimeRemaining / _bumpTime;
+        Y = EasingFunctions.EaseOutExpo(_bumpY, OriginalPosY, (float)t);
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        base.Update(gameTime);
+        _bumpTimer.Update(gameTime);
+    }
+
+    public void StartBump()
+    {
+        _bumpY = OriginalPosY + Skin.ComboDisplayBumpY;
+        _bumpTimer.Restart();
+    }
+}

--- a/Quaver.Shared/Screens/Gameplay/UI/ComboDisplay.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/ComboDisplay.cs
@@ -16,17 +16,17 @@ public class ComboDisplay : GameplayNumberDisplay
     /// <summary>
     ///     Timer for bumping the combo
     /// </summary>
-    private readonly CountdownTimer _bumpTimer;
+    private readonly CountdownTimer bumpTimer;
 
     /// <summary>
     ///     Time to bump
     /// </summary>
-    private readonly TimeSpan _bumpTime;
+    private readonly TimeSpan bumpTime;
 
     /// <summary>
     ///     Start Y of bumping
     /// </summary>
-    private float _bumpY;
+    private float bumpY;
 
     /// <summary>
     ///     The original Y position of the combo display.
@@ -42,27 +42,27 @@ public class ComboDisplay : GameplayNumberDisplay
         OriginalPosY = originalPosY;
         Y = OriginalPosY;
 
-        _bumpTime = TimeSpan.FromMilliseconds(Skin.ComboDisplayBumpTime);
-        _bumpTimer = new CountdownTimer(_bumpTime);
-        _bumpTimer.TimeRemainingChanged += LerpY;
-        _bumpTimer.Stopped += LerpY;
+        bumpTime = TimeSpan.FromMilliseconds(Skin.ComboDisplayBumpTime);
+        bumpTimer = new CountdownTimer(bumpTime);
+        bumpTimer.TimeRemainingChanged += LerpY;
+        bumpTimer.Stopped += LerpY;
     }
 
     private void LerpY(object sender, EventArgs e)
     {
-        var t = 1 - _bumpTimer.TimeRemaining / _bumpTime;
-        Y = EasingFunctions.EaseOutExpo(_bumpY, OriginalPosY, (float)t);
+        var t = 1 - bumpTimer.TimeRemaining / bumpTime;
+        Y = EasingFunctions.EaseOutExpo(bumpY, OriginalPosY, (float)t);
     }
 
     public override void Update(GameTime gameTime)
     {
         base.Update(gameTime);
-        _bumpTimer.Update(gameTime);
+        bumpTimer.Update(gameTime);
     }
 
     public void StartBump()
     {
-        _bumpY = OriginalPosY + Skin.ComboDisplayBumpY;
-        _bumpTimer.Restart();
+        bumpY = OriginalPosY + Skin.ComboDisplayBumpY;
+        bumpTimer.Restart();
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
@@ -38,17 +38,17 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// <summary>
         ///     Timer for bumping the burst if <see cref="IsAnimatingWithOneFrame"/>
         /// </summary>
-        private readonly CountdownTimer _bumpTimer;
+        private readonly CountdownTimer bumpTimer;
 
         /// <summary>
         ///     Time to bump
         /// </summary>
-        private readonly TimeSpan _bumpTime;
+        private readonly TimeSpan bumpTime;
 
         /// <summary>
         ///     Start Y of bumping
         /// </summary>
-        private readonly float _bumpY;
+        private readonly float bumpY;
 
         /// <summary>
         ///     The original size of the hit burst.
@@ -81,17 +81,17 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             // Whenever the judgement is finished looping, then we'll make it invisible.
             FinishedLooping += (o, e) => Visible = false;
 
-            _bumpTime = TimeSpan.FromMilliseconds(Skin.JudgementHitBurstBumpTime);
-            _bumpTimer = new CountdownTimer(_bumpTime);
-            _bumpTimer.TimeRemainingChanged += LerpY;
-            _bumpTimer.Stopped += LerpY;
-            _bumpY = OriginalPosY + Skin.JudgementHitBurstBumpY;
+            bumpTime = TimeSpan.FromMilliseconds(Skin.JudgementHitBurstBumpTime);
+            bumpTimer = new CountdownTimer(bumpTime);
+            bumpTimer.TimeRemainingChanged += LerpY;
+            bumpTimer.Stopped += LerpY;
+            bumpY = OriginalPosY + Skin.JudgementHitBurstBumpY;
         }
 
         private void LerpY(object sender, EventArgs e)
         {
-            var t = 1 - _bumpTimer.TimeRemaining / _bumpTime;
-            Y = EasingFunctions.EaseOutExpo(_bumpY, OriginalPosY, (float)t);
+            var t = 1 - bumpTimer.TimeRemaining / bumpTime;
+            Y = EasingFunctions.EaseOutExpo(bumpY, OriginalPosY, (float)t);
         }
 
         /// <inheritdoc />
@@ -103,7 +103,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             PerformOneFrameAnimation(gameTime);
 
             base.Update(gameTime);
-            _bumpTimer.Update(gameTime);
+            bumpTimer.Update(gameTime);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             }
             else
             {
-                _bumpTimer.Restart();
+                bumpTimer.Restart();
                 IsAnimatingWithOneFrame = true;
             }
 
@@ -160,7 +160,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             var dt = gameTime.ElapsedGameTime.TotalMilliseconds;
 
             // Tween the position if need be
-            if (_bumpTimer.State == TimerState.Completed)
+            if (bumpTimer.State == TimerState.Completed)
             {
                 Alpha = MathHelper.Lerp(Alpha, 0, (float) Math.Min(dt / 240, 1));
 

--- a/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
@@ -107,7 +107,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             }
             else
             {
-                Y = OriginalPosY - 5;
+                Y = OriginalPosY + Skin.JudgementHitBurstBumpY;
                 IsAnimatingWithOneFrame = true;
             }
 
@@ -131,7 +131,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             // Tween the position if need be
             if (Math.Abs(Y - OriginalPosY) > 0.01)
-                Y = MathHelper.Lerp(Y, OriginalPosY, (float) Math.Min(dt / 30, 1));
+                Y = MathHelper.Lerp(Y, OriginalPosY, (float) Math.Min(dt / Skin.JudgementHitBurstBumpTime, 1));
             // If we've already tweened it, then we can begin to fade it out.
             else
             {

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -285,17 +285,17 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                             for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                                 playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
 
-                        if (playfield.Stage.OriginalComboDisplayY < 0)
-                            playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
+                        if (playfield.Stage.ComboDisplay.OriginalPosY < 0)
+                            playfield.Stage.ComboDisplay.OriginalPosY *= previewMultiplier;
 
-                        playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
+                        playfield.Stage.ComboDisplay.Y = playfield.Stage.ComboDisplay.OriginalPosY;
                         break;
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
                         playfield.Stage.HitError.Y -= filterPanelHeight + MenuBorder.HEIGHT;
                         for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                             playfield.Stage.JudgementHitBursts[i].OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
-                        playfield.Stage.OriginalComboDisplayY -= filterPanelHeight + MenuBorder.HEIGHT;
+                        playfield.Stage.ComboDisplay.OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
 
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
@@ -304,10 +304,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                             for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                                 playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
 
-                        if (playfield.Stage.OriginalComboDisplayY < 0)
-                            playfield.Stage.OriginalComboDisplayY *= previewMultiplier;
+                        if (playfield.Stage.ComboDisplay.OriginalPosY < 0)
+                            playfield.Stage.ComboDisplay.OriginalPosY *= previewMultiplier;
 
-                        playfield.Stage.ComboDisplay.Y = playfield.Stage.OriginalComboDisplayY;
+                        playfield.Stage.ComboDisplay.Y = playfield.Stage.ComboDisplay.OriginalPosY;
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -167,7 +167,7 @@ namespace Quaver.Shared.Skinning
 
         internal int ComboDisplayBumpY { get; private set; } = -5;
 
-        internal int ComboDisplayBumpTime { get; private set; } = 30;
+        internal int ComboDisplayBumpTime { get; private set; } = 370;
 
         [FixedScale]
         internal float JudgementBurstPosY { get; private set; }
@@ -265,7 +265,7 @@ namespace Quaver.Shared.Skinning
 
         internal int JudgementHitBurstBumpY { get; private set; } = -5;
 
-        internal int JudgementHitBurstBumpTime { get; private set; } = 30;
+        internal int JudgementHitBurstBumpTime { get; private set; } = 183;
 
         [FixedScale]
         internal int WidthForNoteHeightScale { get; private set; }

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -165,6 +165,10 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float ComboDisplayScale { get; private set; }
 
+        internal int ComboDisplayBumpY { get; private set; } = -5;
+
+        internal int ComboDisplayBumpTime { get; private set; } = 30;
+
         [FixedScale]
         internal float JudgementBurstPosY { get; private set; }
 
@@ -258,6 +262,10 @@ namespace Quaver.Shared.Skinning
         internal bool RotateHitObjectsByColumn { get; private set; }
 
         internal int JudgementHitBurstFps { get; private set; }
+
+        internal int JudgementHitBurstBumpY { get; private set; } = -5;
+
+        internal int JudgementHitBurstBumpTime { get; private set; } = 30;
 
         [FixedScale]
         internal int WidthForNoteHeightScale { get; private set; }
@@ -516,6 +524,8 @@ namespace Quaver.Shared.Skinning
             RatingDisplayScale = ConfigHelper.ReadInt32((int) RatingDisplayScale, ini["RatingDisplayScale"]);
             AccuracyDisplayScale = ConfigHelper.ReadInt32((int) AccuracyDisplayScale, ini["AccuracyDisplayScale"]);
             ComboDisplayScale = ConfigHelper.ReadInt32((int) ComboDisplayScale, ini["ComboDisplayScale"]);
+            ComboDisplayBumpY = ConfigHelper.ReadInt32(ComboDisplayBumpY, ini["ComboDisplayBumpY"]);
+            ComboDisplayBumpTime = ConfigHelper.ReadInt32(ComboDisplayBumpTime, ini["ComboDisplayBumpTime"]);
             KpsDisplayScale = ConfigHelper.ReadInt32((int) KpsDisplayScale, ini["KpsDisplayScale"]);
             SongTimeProgressScale = ConfigHelper.ReadInt32((int) SongTimeProgressScale, ini["SongTimeProgressScale"]);
             SongTimeProgressPositionAtTop = ConfigHelper.ReadBool(SongTimeProgressPositionAtTop, ini["SongTimeProgressPositionAtTop"]);
@@ -531,6 +541,8 @@ namespace Quaver.Shared.Skinning
             ScratchLaneSize = ConfigHelper.ReadFloat(ScratchLaneSize, ini["ScratchLaneSize"]);
             RotateHitObjectsByColumn = ConfigHelper.ReadBool(RotateHitObjectsByColumn, ini["RotateHitObjectsByColumn"]);
             JudgementHitBurstFps = ConfigHelper.ReadInt32(JudgementHitBurstFps, ini["JudgementHitBurstFps"]);
+            JudgementHitBurstBumpY = ConfigHelper.ReadInt32(JudgementHitBurstBumpY, ini["JudgementHitBurstBumpY"]);
+            JudgementHitBurstBumpTime = ConfigHelper.ReadInt32(JudgementHitBurstBumpTime, ini["JudgementHitBurstBumpTime"]);
             WidthForNoteHeightScale = ConfigHelper.ReadInt32(WidthForNoteHeightScale, ini["WidthForNoteHeightScale"]);
 
             var defaultSkin = ini["DefaultSkin"];


### PR DESCRIPTION
Resolves #4097 

The bump time is not precise because currently lerp is used between *current* value and target value. There are two ways to solve this problem:
1. Use animation with a different easing type and length
2. Change lerp progress calculation (make $progress=1-ToleranceFactor^{\frac{\Delta t}{BumpTime}}$ ),

The lerp causes the y to vary in the following way:

It can be shown that $y=y_0 + (y_1 - y_0)(1-(1-m)^n)$, where $y_0$ and $y_1$ are current and target $y$, $m=k=\frac{\Delta t}{T}$, $T$ is the bump time and $\Delta t$ is elapsed game time per update, $n$ is the number of updates.

When $n=n_0=\frac{T}{\Delta t}$, $y$ is not necessarily close to 0 ($lim_{T\to\infty} (1-m)^n = \frac{1}{e},n=n_0$). So we might need to change the factor $m=1-b^k$, where $b$ is the tolerance factor like $0.1$, which makes $y=y_1 - b (y_1 - y_0)$ when $n=n_0$. (See https://www.geogebra.org/calculator/yeynnm2f)

2 is easier to change than 1 but is apparently a weirder solution. 

**UPDATE**
* 1 is being used
* EaseOutExpo is used to interpolate between bump Y and target Y. 
* `CountdownTimer` from `MonoGame.Extended` is used for countdown. `Animation` is not usable because it only accepts integer Y for whatever reason.
* `ComboDisplay` is now a separate class just so it can have a bump timer.
* `JudgementHitBurstBumpTime` and `ComboDisplayBumpTime` are changed to match the original estimated length of time where the distance to original Y is less than 0.01 (see the geogebra link above)