### PR TITLE
Do not override log level if QUAVER_LOGLEVEL is specified

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -257,7 +257,9 @@ namespace Quaver.Shared
 #endif
         {
             Content.RootDirectory = "Content";
-            Logger.MinimumLogLevel = IsDeployedBuild ? LogLevel.Important : LogLevel.Debug;
+
+            if (Environment.GetEnvironmentVariable("QUAVER_LOGLEVEL") is null)
+                Logger.MinimumLogLevel = IsDeployedBuild ? LogLevel.Important : LogLevel.Debug;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Fixes a bug where passing in the environment variable `QUAVER_LOGLEVEL` only applies to the first log message, and not any subsequent messages.