### PR TITLE
Decompress score judgement breakdown in chunks

### DIFF
--- a/Quaver.Shared/Helpers/GzipHelper.cs
+++ b/Quaver.Shared/Helpers/GzipHelper.cs
@@ -64,7 +64,14 @@ namespace Quaver.Shared.Helpers
                 ms.Position = 0;
                 using (var zip = new GZipStream(ms, CompressionMode.Decompress))
                 {
-                    zip.Read(buffer, 0, buffer.Length);
+                    var offset = 0;
+                    while (true)
+                    {
+                        var bytesRead = zip.Read(buffer, offset, buffer.Length - offset);
+                        if (bytesRead <= 0)
+                            break;
+                        offset += bytesRead;
+                    }
                 }
 
                 return Encoding.UTF8.GetString(buffer);


### PR DESCRIPTION
Fixes https://a.quavergame.com/logs/crash/48837

When length of buffer to read is too high, the GZip decompressor won't read the whole of it, and `Read()`'s return value is thus lower than the length (in limhyi's case, `42728` < `48347`. This makes the trailing bytes `0` and thus erroring the `int.TryParse()`.

This PR makes it read the whole of the string.