### PR TITLE
Use Deferred SortMode in Default SpriteBatch

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -159,7 +159,7 @@ namespace Quaver.Shared.Screens.Edit
                     DrawPlugins(gameTime);
 
                 MenuBar?.Draw(gameTime);
-                GameBase.Game.SpriteBatch.End();
+                GameBase.Game.TryEndBatch();
 
                 if (ImGui.IsAnyItemHovered())
                     IsImGuiHovered = true;


### PR DESCRIPTION
Requires https://github.com/Quaver/Wobble/pull/158

Using Deferred SortMode by default, there is an 100+ fps boost on my end.

This PR is just a fix for a side effect brought by the Wobble PR, i.e. ImGui rendering calls. The major changes are in the PR shown above.

A testing patch: 
[deferred-sortmode-testing.patch](https://github.com/user-attachments/files/16792939/deferred-sortmode-testing.patch)
Press `D` anywhere to switch between `Immediate` and `Deferred` mode.

Comparison recorded with GeForce InGame Overlay:


https://github.com/user-attachments/assets/94ea8d3d-00a5-485d-a232-0d394b4df164


Comparison recorded with OBS (with input overlay):


https://github.com/user-attachments/assets/36f31245-7b7d-4e87-84dc-b218c42c1c95

