### PR TITLE
Update ImGui.NET to 1.91.0.1

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -376,7 +376,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             const int ElementBaseHeight = 12;
             const int NumberOfColumns = 2;
             var elementHeight = Screen.ImGuiScale * ElementBaseHeight;
-            var y = ImGui.GetWindowContentRegionMax().Y - ImGui.GetWindowContentRegionMin().Y;
+            var y = ImGui.GetContentRegionAvail().Y;
 
             var start = Math.Min(
                 (int)(_progress * Screen.WorkingMap.SliderVelocities.Count - 1),

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -413,7 +413,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
             const int ElementBaseHeight = 12;
             const int NumberOfColumns = 4;
             var elementHeight = Screen.ImGuiScale * ElementBaseHeight;
-            var y = ImGui.GetWindowContentRegionMax().Y - ImGui.GetWindowContentRegionMin().Y;
+            var y = ImGui.GetContentRegionAvail().Y;
 
             var start = Math.Min(
                 (int)(_progress * Screen.WorkingMap.TimingPoints.Count - 1),

--- a/Quaver.Shared/Scripting/ImGuiRedirect.cs
+++ b/Quaver.Shared/Scripting/ImGuiRedirect.cs
@@ -246,6 +246,12 @@ namespace Quaver.Shared.Scripting
                 stride
             );
 
+        public static void PushAllowKeyboardFocus() => PushTabStop();
+
+        public static void PushButtonRepeat() => ImGui.PushItemFlag(ImGuiItemFlags.ButtonRepeat, true);
+
+        public static void PushTabStop() => ImGui.PushItemFlag(ImGuiItemFlags.NoTabStop, true);
+
         public static void SaveIniSettingsToDisk(string ini_filename) =>
             throw new NotSupportedException("Please use the 'write' global instead.");
 
@@ -753,7 +759,14 @@ namespace Quaver.Shared.Scripting
         public static float GetContentRegionAvailWidth() => ImGui.GetContentRegionAvail().X;
 
         public static float GetWindowRegionAvailWidth() =>
-            ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
+            GetWindowContentRegionMax().X - GetWindowContentRegionMin().X;
+
+        public static Vector2 GetContentRegionMax() =>
+            ImGui.GetContentRegionAvail() + ImGui.GetCursorScreenPos() - ImGui.GetWindowPos();
+
+        public static Vector2 GetWindowContentRegionMax() => ImGui.GetContentRegionAvail() + ImGui.GetCursorPos();
+
+        public static Vector2 GetWindowContentRegionMin() => ImGui.GetCursorPos();
 
         /// <summary>
         ///     Replaces the matched patterns with the result of the evaluator.

--- a/Quaver.Shared/Scripting/ImGuiRedirect.cs
+++ b/Quaver.Shared/Scripting/ImGuiRedirect.cs
@@ -16,17 +16,6 @@ namespace Quaver.Shared.Scripting
     [MoonSharpUserData]
     public static class ImGuiRedirect
     {
-        // These vector functions aren't part of ImGui but are needed to maintain compatibility
-        // with plugins, even if its functionality is practically useless.
-
-        private static readonly DynValue s_pack = DynValue.NewCallback(TableModule.pack);
-
-        public static DynValue CreateVector2 => s_pack;
-
-        public static DynValue CreateVector3 => s_pack;
-
-        public static DynValue CreateVector4 => s_pack;
-
         public static void BeginPopupContextWindow() => ImGui.BeginPopupContextWindow();
 
         public static void BeginPopupContextWindow(string str_id) => ImGui.BeginPopupContextWindow(str_id);
@@ -760,6 +749,17 @@ namespace Quaver.Shared.Scripting
 
         public static float GetWindowRegionAvailWidth() =>
             GetWindowContentRegionMax().X - GetWindowContentRegionMin().X;
+
+        // These vector functions aren't part of ImGui but are needed to maintain compatibility
+        // with plugins, even if its functionality is practically useless.
+        public static DynValue CreateVector2(ScriptExecutionContext executionContext, CallbackArguments args) =>
+            TableModule.pack(executionContext, args);
+
+        public static DynValue CreateVector3(ScriptExecutionContext executionContext, CallbackArguments args) =>
+            TableModule.pack(executionContext, args);
+
+        public static DynValue CreateVector4(ScriptExecutionContext executionContext, CallbackArguments args) =>
+            TableModule.pack(executionContext, args);
 
         public static Vector2 GetContentRegionMax() =>
             ImGui.GetContentRegionAvail() + ImGui.GetCursorScreenPos() - ImGui.GetWindowPos();

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -74,6 +74,7 @@ namespace Quaver.Shared.Scripting
                 ("Multiline", ImGuiInputTextFlags.None)
             ),
             [typeof(ImGuiTreeNodeFlags)] = DefineEnum(("AllowItemOverlap", ImGuiTreeNodeFlags.AllowOverlap)),
+            [typeof(ImGuiSelectableFlags)] = DefineEnum(("DontClosePopups", ImGuiSelectableFlags.NoAutoClosePopups)),
         };
 
         private static readonly Regex s_capitals = new(@"\p{Lu}", RegexOptions.Compiled);
@@ -169,8 +170,10 @@ namespace Quaver.Shared.Scripting
                     EndChildFrame = nameof(ImGui.EndChild),
                     ListBoxHeader = nameof(ImGui.BeginListBox),
                     ListBoxFooter = nameof(ImGui.EndListBox),
-                    PopAllowKeyboardFocus = nameof(ImGui.PopTabStop),
-                    PushAllowKeyboardFocus = nameof(ImGui.PushTabStop),
+                    PopButtonRepeat = nameof(ImGui.PopItemFlag),
+                    PopTabStop = nameof(ImGui.PopItemFlag),
+                    PopAllowKeyboardFocus = nameof(ImGui.PopItemFlag),
+                    GetWindowContentRegionMin = nameof(ImGui.GetCursorPos),
                     SetNextTreeNodeOpen = nameof(ImGui.SetNextItemOpen),
                 }
             );


### PR DESCRIPTION
There are newer ImGui versions but they have yet to be updated in ImGui.NET as of the time of writing.

Here's a trimmed down version of breaking changes from [1.91.0](https://github.com/ocornut/imgui/releases/tag/v1.91.0) that this PR aims to keep backwards compatibility for:

> Obsoleted GetContentRegionMax(), GetWindowContentRegionMin() and GetWindowContentRegionMax().
> Obsoleted PushButtonRepeat()/PopButtonRepeat() in favor of using new PushItemFlag()/PopItemFlag() with ImGuiItemFlags_ButtonRepeat. Kept inline redirecting functions (will obsolete).
> Obsoleted PushTabStop()/PopTabStop() in favor of using new PushItemFlag()/PopItemFlag() with ImGuiItemFlags_NoTabStop. Kept inline redirecting functions (will obsolete).
> Renamed ImGuiSelectableFlags_DontClosePopups to ImGuiSelectableFlags_NoAutoClosePopups for consistency. Kept inline redirecting functions (will obsolete).
