### PR TITLE
Add option to smoothen the start of audio to reduce lag

### DIFF
--- a/Quaver.Shared/Audio/AudioEngine.cs
+++ b/Quaver.Shared/Audio/AudioEngine.cs
@@ -40,6 +40,9 @@ namespace Quaver.Shared.Audio
         /// </summary>
         private static CancellationTokenSource Source { get; set; } = new CancellationTokenSource();
 
+        /// <summary>
+        ///     The length of time when the audio time is 0 after we first play the audio
+        /// </summary>
         public static double MeasuredAudioStartDelay { get; private set; }
 
         /// <summary>

--- a/Quaver.Shared/Audio/AudioEngine.cs
+++ b/Quaver.Shared/Audio/AudioEngine.cs
@@ -6,6 +6,7 @@
 */
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Scheduling;
+using Wobble;
 using Wobble.Audio;
 using Wobble.Audio.Tracks;
 using Wobble.Graphics;
@@ -37,6 +39,8 @@ namespace Quaver.Shared.Audio
         ///     Cancellation token to prevent multiple audio tracks playing at once
         /// </summary>
         private static CancellationTokenSource Source { get; set; } = new CancellationTokenSource();
+
+        public static double MeasuredAudioStartDelay { get; private set; }
 
         /// <summary>
         ///     Loads the track for the currently selected map.
@@ -196,6 +200,31 @@ namespace Quaver.Shared.Audio
             }
 
             return track;
+        }
+
+        /// <summary>
+        ///     Loads up a dummy audio. Plays it and see how long it takes for its Time
+        ///     to get from 0 to other values.
+        /// </summary>
+        /// <remarks>
+        ///     We need to make this single threaded here. It seems like bass doesn't like Tasks.
+        /// </remarks>
+        public static void MeasureAudioStartDelay()
+        {
+            var prevTrack = Track;
+            Track =
+                new AudioTrack(GameBase.Game.Resources.Get($"Quaver.Resources/Maps/Offset/offset.mp3"));
+            Track.Volume = 0;
+            var stopwatch = Stopwatch.StartNew();
+            Track.Play();
+            while (Track.Time == 0)
+            {
+            }
+            stopwatch.Stop();
+            Track.Stop();
+            Track.Dispose();
+            MeasuredAudioStartDelay = stopwatch.ElapsedMilliseconds;
+            Track = prevTrack;
         }
     }
 }

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -189,6 +189,14 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> SmoothAudioTimingGameplay { get; private set; }
 
         /// <summary>
+        ///     When an audio starts to play, its <see cref="Quaver.Shared.Audio.AudioEngine.Track.Time"/>
+        ///     will stay 0 for some time. This causes the gameplay to freeze for a while.
+        ///     By turning this on, audio starts a bit early (amount determined at start). We then slowly
+        ///     Let the gameplay timing reach the actual audio time.
+        /// </summary>
+        internal static Bindable<bool> SmoothAudioStart { get; private set; }
+
+        /// <summary>
         ///     Determines if we should show the song time progress display in the
         ///     gameplay screen.
         /// </summary>
@@ -1037,6 +1045,7 @@ namespace Quaver.Shared.Config
             FpsLimiterType = ReadValue(@"FpsLimiterType", FpsLimitType.Unlimited, data);
             CustomFpsLimit = ReadInt(@"CustomFpsLimit", 240, 60, 5000, data);
             SmoothAudioTimingGameplay = ReadValue(@"SmoothAudioTimingGameplay", false, data);
+            SmoothAudioStart = ReadValue(@"SmoothAudioStart", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -66,7 +66,9 @@ namespace Quaver.Shared.Screens.Main
             OriginalAutoLoadOsuBeatmapsValue = ConfigManager.AutoLoadOsuBeatmaps.Value;
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
             TheaterCheat = new CheatCodeTheater();
-            AudioEngine.MeasureAudioStartDelay();
+
+            if (AudioEngine.MeasuredAudioStartDelay == 0)
+                AudioEngine.MeasureAudioStartDelay();
 
             View = new MainMenuScreenView(this);
         }

--- a/Quaver.Shared/Screens/Main/MainMenuScreen.cs
+++ b/Quaver.Shared/Screens/Main/MainMenuScreen.cs
@@ -66,6 +66,7 @@ namespace Quaver.Shared.Screens.Main
             OriginalAutoLoadOsuBeatmapsValue = ConfigManager.AutoLoadOsuBeatmaps.Value;
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
             TheaterCheat = new CheatCodeTheater();
+            AudioEngine.MeasureAudioStartDelay();
 
             View = new MainMenuScreenView(this);
         }

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -414,7 +414,8 @@ namespace Quaver.Shared.Screens.Options
                     }),
                     new OptionsSubcategory("Audio", new List<OptionsItem>()
                     {
-                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay)
+                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio/Frame Timing During Gameplay", ConfigManager.SmoothAudioTimingGameplay),
+                        new OptionsItemCheckbox(containerRect, "Use Smooth Audio Start Timing During Gameplay", ConfigManager.SmoothAudioStart)
                     }),
                     new OptionsSubcategory("Gameplay", new List<OptionsItem>()
                     {


### PR DESCRIPTION
Reference map: https://quavergame.com/mapset/map/148940

By comparing `GameplayAudioTiming.Time` to `AudioEngine.Track.Time`, I noticed that when the audio starts playing, the gameplay will freeze for some amount of time (in my case ~30ms), which causes major inconvenience especially in tournaments. The image below demonstrates this behaviour (this is printed every update loop, when `|Time| < 5ms`:
![image](https://github.com/user-attachments/assets/50e6888a-d98f-41f5-a1d5-e036457e224a)

Thus, this PR proposes a method to resolve this issue by:
* First, measure audio start delay (Quaver.Shared/Audio/AudioEngine.cs) when quaver is loading the main menu.
* Add an option for smoothing the start.
* If the option is enabled, we:
  * Upon start, we will start to play the audio earlier, determined by the measured audio start delay mentioned above.
  * When the audio starts to become nonzero, we let our accumulated timer approach the audio time by 10% every update.
  * When the difference between audio time and game time is less than 3ms, we switch to using audio time from now on
* Any change described above (except delay measurement) will not affect the gameplay if the option is not turned on.