### PR TITLE
Fix LN Body and End not being rendered when SSF changes from 0 to a number

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -410,11 +410,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             // Stop drawing LN body + end if the ln reaches half the height of the hitobject
             // (prevents body + end extending below this point)
-            if (CurrentLongNoteBodySize + LongNoteSizeDifference <= HitObjectSprite.Height / 2f || CurrentLongNoteBodySize <= 0 || curTime >= Info.EndTime && Info.State == HitObjectState.Held)
-            {
-                LongNoteEndSprite.Visible = false;
-                LongNoteBodySprite.Visible = false;
-            }
+            var longNoteOverlap = CurrentLongNoteBodySize + LongNoteSizeDifference <= HitObjectSprite.Height / 2f ||
+                                  CurrentLongNoteBodySize <= 0 ||
+                                  curTime >= Info.EndTime && Info.State is HitObjectState.Held or HitObjectState.Dead;
+            LongNoteEndSprite.Visible = !longNoteOverlap;
+            LongNoteBodySprite.Visible = !longNoteOverlap;
         }
 
         /// <summary>


### PR DESCRIPTION
Before, when LNs become within half the note head, the LNs stop rendering. This is not ideal if we have changing SSFs, since if we have an SSF 0 -> 1, all LNs will become invisible. (Demo later today). Now it will update the visibility if it doesn't conform to the condition.