### PR TITLE
Fix difficulty bar of the last difficulty being rendered with black background instead of transparent

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/CachedDifficultyBarDisplay.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/Components/Difficulty/CachedDifficultyBarDisplay.cs
@@ -114,6 +114,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps.Components.Difficulty
                     if (RenderTarget.IsDisposed)
                         return;
 
+                    GameBase.Game.TryEndBatch();
                     GameBase.Game.GraphicsDevice.SetRenderTarget(RenderTarget);
                     GameBase.Game.GraphicsDevice.Clear(Color.Transparent);
 


### PR DESCRIPTION
bug: 
![image](https://github.com/user-attachments/assets/a851fcd7-40da-4ee4-bfa5-f1e764620760)

Fixed:
![image](https://github.com/user-attachments/assets/98a16dc9-3d92-4402-b829-00a3a7f83335)
