### PR TITLE
Fix asynchronous map saving causing issues with map loading and plugins

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -1440,7 +1440,8 @@ namespace Quaver.Shared.Screens.Edit
             if (Map.Game == MapGame.Quaver)
                 FileWatcher.EnableRaisingEvents = false;
 
-            WorkingMap.Save($"{ConfigManager.SongDirectory}/{Map.Directory}/{Map.Path}");
+            var map = WorkingMap.DeepClone();
+            map.Save($"{ConfigManager.SongDirectory}/{Map.Directory}/{Map.Path}");
 
             if (Map.Game == MapGame.Quaver)
                 FileWatcher.EnableRaisingEvents = true;


### PR DESCRIPTION
Resolves #4320 

When saving map, first clone the map instead.

This is due to the fact that when saving is done asynchronously, the plugin panels may access its contents during serialization, which may be the point where timing groups are being temporarily removed, etc.