### PR TITLE
Fix LN detaching from head when missing

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -344,6 +344,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         /// </summary>
         public void UpdateLongNoteSize(double curTime)
         {
+            if (Info.State != HitObjectState.Held || !SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd)
+                return;
+
             Info.UpdateLongNoteSize(curTime);
             CurrentLongNoteBodySize = Info.CurrentLongNoteBodySize - LongNoteSizeDifference;
         }


### PR DESCRIPTION
Resolves #4321 

Basic cause is https://github.com/Quaver/Quaver/commit/3f0d288b6d9a1507740fc699c2a87f9b6d44343e#diff-bf5bd1ef67286ac65eb752a1fabd2699bea48dd242352c815cc0a51d4b0296afR377 where I forgot to put the guards inside the function.