### PR TITLE
SVDirectionChange: Use reverse prefix max/min to query max/min position better

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollGroupControllerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollGroupControllerKeys.cs
@@ -203,6 +203,16 @@ public class ScrollGroupControllerKeys : TimingGroupControllerKeys
             });
         }
 
+        if (changes.Count > 0)
+        {
+            changes[^1].BackPrefixMaxPosition = changes[^1].BackPrefixMinPosition = changes[^1].Position;
+            for (var j = changes.Count - 2; j >= 0; j--)
+            {
+                changes[j].BackPrefixMaxPosition = Math.Max(changes[j + 1].BackPrefixMaxPosition, changes[j].Position);
+                changes[j].BackPrefixMinPosition = Math.Min(changes[j + 1].BackPrefixMinPosition, changes[j].Position);
+            }
+        }
+
         return changes;
     }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollNoteController.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollNoteController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Quaver.API.Helpers;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Config;
 
@@ -62,10 +63,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 var earliestPosition = Math.Min(InitialTrackPosition, EndTrackPosition);
                 var latestPosition = Math.Max(InitialTrackPosition, EndTrackPosition);
 
-                foreach (var change in SVDirectionChanges)
+                if (SVDirectionChanges.Count > 0)
                 {
-                    earliestPosition = Math.Min(earliestPosition, change.Position);
-                    latestPosition = Math.Max(latestPosition, change.Position);
+                    var change = SVDirectionChanges[0];
+                    earliestPosition = Math.Min(earliestPosition, change.BackPrefixMinPosition);
+                    latestPosition = Math.Max(latestPosition, change.BackPrefixMaxPosition);
                 }
 
                 EarliestTrackPosition = earliestPosition;
@@ -127,14 +129,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         {
             if (SVDirectionChanges == null)
                 return;
-            foreach (var change in SVDirectionChanges)
-            {
-                if (curTime >= change.StartTime)
-                    continue; // We're past this change already.
 
-                earliestPosition = Math.Min(earliestPosition, change.Position);
-                latestPosition = Math.Max(latestPosition, change.Position);
-            }
+            var lastChange = SVDirectionChanges.AtTime((float)curTime);
+            if (lastChange == default)
+                return;
+            earliestPosition = Math.Min(earliestPosition, lastChange.BackPrefixMinPosition);
+            latestPosition = Math.Max(latestPosition, lastChange.BackPrefixMaxPosition);
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
@@ -1,18 +1,23 @@
+using Quaver.API.Maps.Structures;
+
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys
 {
     /// <summary>
     ///     Represents a change in the SV direction (positive to negative or negative to positive).
     /// </summary>
-    public struct SVDirectionChange
+    public class SVDirectionChange : IStartTime
     {
         /// <summary>
         ///     Start time of the SV that changed the direction.
         /// </summary>
-        public float StartTime;
+        public float StartTime { get; set; }
 
         /// <summary>
         ///     Position at the time of the direction change.
         /// </summary>
-        public long Position;
+        public long Position { get; set; }
+
+        public long BackPrefixMaxPosition { get; set; }
+        public long BackPrefixMinPosition { get; set; }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/SVDirectionChange.cs
@@ -17,7 +17,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys
         /// </summary>
         public long Position { get; set; }
 
+        /// <summary>
+        ///     The maximum position from this direction change onwards
+        /// </summary>
         public long BackPrefixMaxPosition { get; set; }
+
+        /// <summary>
+        ///     The minimum position from this direction change onwards
+        /// </summary>
         public long BackPrefixMinPosition { get; set; }
     }
 }


### PR DESCRIPTION
This needs testing before being merged. It is not known yet if this brings remarkable improvements. Since this PR is created when I was trying to fix a bug with LN length with changing SSF, so I didn't really test this.

This PR calculates reverse prefix min/max `SVDirectionChange.Position` for `SVDirectionChanges` so that maximum/minimum position could be queried in O(1) after knowing the latest direction change.

Furthermore, since `SVDirectionChange` uses `StartTime`, we could use binary search, so looking it up now only takes logarithmic time. So this basically makes `SetEarliestAndLatestLongNotes()` `O(log n)`, where n is number of SV direction changes.
