### PR TITLE
Fix HitBubbles™ being out of view in preview in upscroll

### DIFF
--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -281,6 +281,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
+                        if (playfield.Stage.HitBubbles.Y < 0)
+                            playfield.Stage.HitBubbles.Y *= previewMultiplier;
+
                         if (playfield.Stage.JudgementHitBursts[0].OriginalPosY < 0)
                             for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                                 playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
@@ -306,6 +309,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
 
                         if (playfield.Stage.ComboDisplay.OriginalPosY < 0)
                             playfield.Stage.ComboDisplay.OriginalPosY *= previewMultiplier;
+
+                        playfield.Stage.HitBubbles.Y -= filterPanelHeight + MenuBorder.HEIGHT;
+                        if (playfield.Stage.HitBubbles.Y < 0)
+                            playfield.Stage.HitBubbles.Y *= previewMultiplier;
 
                         playfield.Stage.ComboDisplay.Y = playfield.Stage.ComboDisplay.OriginalPosY;
                         break;


### PR DESCRIPTION
Resolves #4335 

![image](https://github.com/user-attachments/assets/8593c489-3259-4b0e-a6cd-b29fc62802db)
![image](https://github.com/user-attachments/assets/429ab5fc-db67-4ce1-8c4c-1e97d6716d44)

You will see that for upscroll the hit bubble is slightly higher than it's supposed to be. This is because of another bug which I think is in stable too.