### PR TITLE
Default InitialScrollVelocity to 1

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -840,6 +840,7 @@ namespace Quaver.Shared.Screens.Edit
 
             var timingGroup = new ScrollGroup
             {
+                InitialScrollVelocity = 1,
                 ScrollVelocities =
                     new List<SliderVelocityInfo> { new() { Multiplier = 1, StartTime = 0 } },
                 ColorRgb = $"{rgb[0]},{rgb[1]},{rgb[2]}"

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollSpeedFactorPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollSpeedFactorPanel.cs
@@ -214,6 +214,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                     Screen.ActionManager.CreateTimingGroup(newGroupId,
                         new ScrollGroup
                         {
+                            InitialScrollVelocity = 1,
                             ScrollSpeedFactors =
                                 new List<ScrollSpeedFactorInfo> { new() { Multiplier = 1, StartTime = 0 } },
                             ColorRgb = $"{rgb[0]},{rgb[1]},{rgb[2]}"

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -224,6 +224,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
                     Screen.ActionManager.CreateTimingGroup(newGroupId,
                         new ScrollGroup
                         {
+                            InitialScrollVelocity = 1,
                             ScrollVelocities =
                                 new List<SliderVelocityInfo> { new() { Multiplier = 1, StartTime = 0 } },
                             ColorRgb = $"{rgb[0]},{rgb[1]},{rgb[2]}"


### PR DESCRIPTION
A unit test described showed that `InitialScrollVelocity` shouldn't default to 1. Instead it should be 0. However as described in https://github.com/Quaver/Quaver.API/pull/195 the unit test got skipped due to the problem with reference. This PR is to fix that and lift the default value on creation.