### PR TITLE
Fix notes not sorted after moving them and change the order

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/HitObjects/Move/EditorActionMoveHitObjects.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/HitObjects/Move/EditorActionMoveHitObjects.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using MoonSharp.Interpreter;
+using Quaver.API.Helpers;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
 
@@ -81,6 +82,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.HitObjects.Move
                 }
             }
 
+            WorkingMap.HitObjects.HybridSort();
             ActionManager.TriggerEvent(EditorActionType.MoveHitObjects, new EditorHitObjectsMovedEventArgs(HitObjects));
         }
 


### PR DESCRIPTION
This fixes the issue seen in this video:

https://github.com/user-attachments/assets/0da0bf7e-7826-43b6-8992-3c68b1176746

This apparently has been happening on stable too. God knows for how long this has been undiscovered.

Thanks ESV TURTLESS24 for discovering this