### PR TITLE
Fix Visual Audio Offset and Audio Offset not being set correctly the …

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -283,6 +283,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 timingGroupController.Initialize();
                 TimingGroupControllers.Add(id, timingGroupController);
             }
+            UpdateCurrentTrackPosition();
 
             InitializeHitStats();
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollGroupControllerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/ScrollGroupControllerKeys.cs
@@ -24,7 +24,6 @@ public class ScrollGroupControllerKeys : TimingGroupControllerKeys
         // Initialize SV
         Populate();
         InitializePositionMarkers();
-        UpdateCurrentTrackPosition();
     }
 
     public override float ScrollSpeed => base.ScrollSpeed * CurrentScrollSpeedFactor;


### PR DESCRIPTION
…first frame

Fix issue described in https://discord.com/channels/354206121386573824/531647732612464640/1308363781256122390 and potentially fix the issue mentioned by ESV TURTLESS24 and KGB Official https://discord.com/channels/354206121386573824/531647732612464640/1308218467031449692

Basically the cause is that the current audio and visual time isn't being set the first frame, so there is a single frame where the time is 0.