### PR TITLE
Improve audio start stutter reduction

### DIFF
--- a/Quaver.Shared/Audio/AudioEngine.cs
+++ b/Quaver.Shared/Audio/AudioEngine.cs
@@ -43,7 +43,7 @@ namespace Quaver.Shared.Audio
         /// <summary>
         ///     The length of time when the audio time is 0 after we first play the audio
         /// </summary>
-        public static double MeasuredAudioStartDelay { get; private set; }
+        public static double MeasuredAudioStartDelay { get; internal set; }
 
         /// <summary>
         ///     Loads the track for the currently selected map.


### PR DESCRIPTION
This PR aims to improve the experimental feature of improving the audio start stutter.

A slightly different strategy is used, so that it is more consistent and less fps based:
* The timing will now approach the audio time evenly within the first second of the audio, as opposed to approaching by a factor every update.
* The maximum pre-starting time of audio has been clamped within [-40..0]. This is to prevent the audio starting too early.
* The stutter delay will be measured and improved over time (although it's not consistent, since audio seem to get buffered over time).