### PR TITLE
Fix editor memory leak

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -411,6 +411,7 @@ namespace Quaver.Shared.Screens.Edit
 
         public void ResetInputManager()
         {
+            InputManager?.Destroy();
             InputManager = new EditorInputManager(this);
         }
 
@@ -551,6 +552,8 @@ namespace Quaver.Shared.Screens.Edit
             SkinManager.SkinLoaded -= OnSkinLoaded;
 
             Plugins.ForEach(x => x.Destroy());
+            
+            InputManager?.Destroy();
 
             base.Destroy();
         }

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -19,8 +19,8 @@ namespace Quaver.Shared.Screens.Edit.Input
     public class EditorInputManager
     {
         public EditorInputConfig InputConfig { get; }
-        public EditScreen Screen { get; }
-        private EditScreenView View { get; }
+        private EditScreen Screen { get; set; }
+        private EditScreenView View { get; set; }
 
         private Dictionary<Keybind, HashSet<KeybindActions>> keybindDictionary;
         private GenericKeyState previousKeyState;
@@ -716,8 +716,10 @@ namespace Quaver.Shared.Screens.Edit.Input
             lastActionTime[action] = GameBase.Game.TimeRunning;
         }
 
-        ~EditorInputManager()
+        public void Destroy()
         {
+            Screen = null;
+            View = null;
             ConfigManager.InvertEditorScrolling.ValueChanged -= InvertScrollingValueChanged;
             if (Screen?.InvertBeatSnapScroll != null)
                 Screen.InvertBeatSnapScroll.ValueChanged -= InvertScrollingValueChanged;


### PR DESCRIPTION
Seems to be a cyclic reference issue. I am not 100% sure this solves the issue entirely, but it is better at least.