### PR TITLE
[QoL] Add option to scale scroll speed with rate

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -214,6 +214,11 @@ namespace Quaver.Shared.Config
         internal static BindableInt ScrollSpeed7K { get; private set; }
 
         /// <summary>
+        ///     Percentage of scaling applied when changing rates
+        /// </summary>
+        internal static BindableInt ScaleScrollSpeedStrengthPercentage { get; private set; }
+
+        /// <summary>
         ///     Direction in which hit objects will be moving for 4K gamemode
         /// </summary>
         internal static Bindable<ScrollDirection> ScrollDirection4K { get; private set; }
@@ -1059,6 +1064,7 @@ namespace Quaver.Shared.Config
             SmoothAudioStart = ReadValue(@"SmoothAudioStart", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
+            ScaleScrollSpeedStrengthPercentage = ReadInt(@"ScaleScrollSpeedStrengthPercentage", 0, 0, 100, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);
             ScrollDirection7K = ReadValue(@"ScrollDirection7K", ScrollDirection.Down, data);
             GlobalAudioOffset = ReadInt(@"GlobalAudioOffset", 0, -500, 500, data);

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -216,7 +216,7 @@ namespace Quaver.Shared.Config
         /// <summary>
         ///     Percentage of scaling applied when changing rates
         /// </summary>
-        internal static BindableInt ScaleScrollSpeedStrengthPercentage { get; private set; }
+        internal static BindableInt NormaliseScrollVelocityByRatePercentage { get; private set; }
 
         /// <summary>
         ///     Direction in which hit objects will be moving for 4K gamemode
@@ -1064,7 +1064,7 @@ namespace Quaver.Shared.Config
             SmoothAudioStart = ReadValue(@"SmoothAudioStart", false, data);
             ScrollSpeed4K = ReadInt(@"ScrollSpeed4K", 150, 50, 1000, data);
             ScrollSpeed7K = ReadInt(@"ScrollSpeed7K", 150, 50, 1000, data);
-            ScaleScrollSpeedStrengthPercentage = ReadInt(@"ScaleScrollSpeedStrengthPercentage", 0, 0, 100, data);
+            NormaliseScrollVelocityByRatePercentage = ReadInt(@"NormaliseScrollVelocityByRatePercentage", 0, 0, 100, data);
             ScrollDirection4K = ReadValue(@"ScrollDirection4K", ScrollDirection.Down, data);
             ScrollDirection7K = ReadValue(@"ScrollDirection7K", ScrollDirection.Down, data);
             GlobalAudioOffset = ReadInt(@"GlobalAudioOffset", 0, -500, 500, data);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -50,6 +50,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         private Qua Map;
 
         /// <summary>
+        ///     Whether the normalized map contains any SVs outside the range 0.99x - 1.01x.
+        /// </summary>
+        public bool HasSignificantSVs { get; private set; }
+
+        /// <summary>
         ///     Cached length of the map
         /// </summary>
         private int Length { get; set; }
@@ -275,10 +280,15 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             {
                 if (TimingGroupControllers.TryGetValue(id, out TimingGroupControllerKeys timingGroupController))
                     continue;
-                if (timingGroup is ScrollGroup)
+
+                if (timingGroup is ScrollGroup scrollGroup)
+                {
+                    if (scrollGroup.ScrollVelocities.Any(x => x.Multiplier > 1.01 || x.Multiplier < 0.99))
+                        HasSignificantSVs = true;
+
                     timingGroupController = new ScrollGroupControllerKeys(timingGroup, Map, this);
-                else
-                    throw new InvalidOperationException();
+                }
+                else throw new InvalidOperationException();
 
                 timingGroupController.Initialize();
                 TimingGroupControllers.Add(id, timingGroupController);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
@@ -26,7 +26,7 @@ public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjec
 
     /// <summary>
     ///     This is the perceived scroll speed to the player.
-    ///     This is adjusted by <see cref="ConfigManager.ScaleScrollSpeedStrengthPercentage"/>
+    ///     This is adjusted by <see cref="ConfigManager.NormaliseScrollVelocityByRatePercentage"/>
     /// </summary>
     public virtual float AdjustedScrollSpeed
     {
@@ -37,8 +37,12 @@ public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjec
                 speed = MapManager.Selected.Value.Qua.Mode == GameMode.Keys4
                     ? ConfigManager.ScrollSpeed4K
                     : ConfigManager.ScrollSpeed7K;
+
+            if (!Manager.HasSignificantSVs)
+                return speed.Value;
+
             var rateScaling = 1 + (ModHelper.GetRateFromMods(ModManager.Mods) - 1) *
-                ConfigManager.ScaleScrollSpeedStrengthPercentage.Value / 100f;
+                ConfigManager.NormaliseScrollVelocityByRatePercentage.Value / 100f;
 
             // Cap the speed
             var adjustedScrollSpeed = Math.Clamp(speed.Value * rateScaling, 50, 1000);

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -183,6 +183,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemScrollDirection(containerRect, "7K Scroll Direction", ConfigManager.ScrollDirection7K),
                         new OptionsSlider(containerRect, "4K Scroll Speed", ConfigManager.ScrollSpeed4K, i => $"{i / 10f:0.0}"),
                         new OptionsSlider(containerRect, "7K Scroll Speed", ConfigManager.ScrollSpeed7K, i => $"{i / 10f:0.0}"),
+                        new OptionsSlider(containerRect, "Scroll Speed Rate Scaling Percentage", ConfigManager.ScaleScrollSpeedStrengthPercentage, i => $"{i}%"),
                     }),
                     new OptionsSubcategory("Scratch Lane", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -183,7 +183,7 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemScrollDirection(containerRect, "7K Scroll Direction", ConfigManager.ScrollDirection7K),
                         new OptionsSlider(containerRect, "4K Scroll Speed", ConfigManager.ScrollSpeed4K, i => $"{i / 10f:0.0}"),
                         new OptionsSlider(containerRect, "7K Scroll Speed", ConfigManager.ScrollSpeed7K, i => $"{i / 10f:0.0}"),
-                        new OptionsSlider(containerRect, "Scroll Speed Rate Scaling Percentage", ConfigManager.ScaleScrollSpeedStrengthPercentage, i => $"{i}%"),
+                        new OptionsSlider(containerRect, "Normalise Scroll Velocity By Rate Percentage", ConfigManager.NormaliseScrollVelocityByRatePercentage, i => $"{i}%"),
                     }),
                     new OptionsSubcategory("Scratch Lane", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -31,6 +31,7 @@ using Quaver.Shared.Online;
 using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Gameplay;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Input;
+using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Screens.Loading;
 using Quaver.Shared.Screens.Multi;
 using Quaver.Shared.Screens.Results.UI.Header.Contents.Tabs;
@@ -871,10 +872,10 @@ namespace Quaver.Shared.Screens.Results
                 }
             }
 
-            var scrollSpeed = Map.Mode == GameMode.Keys4 ? ConfigManager.ScrollSpeed4K.Value : ConfigManager.ScrollSpeed7K.Value;
+            var scrollSpeed = ((HitObjectManagerKeys)screen.Ruleset.HitObjectManager).DefaultGroupController.AdjustedScrollSpeed;
 
             // Submit score to the server...
-            OnlineManager.Client?.Submit(new OnlineScore(submissionMd5, replay, processor, scrollSpeed,
+            OnlineManager.Client?.Submit(new OnlineScore(submissionMd5, replay, processor, (int)scrollSpeed,
                 ModHelper.GetRateFromMods(ModManager.Mods), Gameplay.TimePlayEnd, OnlineManager.CurrentGame));
 
             return true;


### PR DESCRIPTION
This PR adds an option to scale scroll speed with the rate applied, so that SV maps does not need manual scroll speed change to be comfortably read when applied rates.

The new option is a slider of percentage strength. The perceived scroll speed will be the set scroll speed multiplied by $1 + (rate - 1) * \frac{strength}{100}$, so that 0 strength is the default behaviour, 100 strength means the spacing between notes will be the same no matter the rate, and 50 means something in-between: the spacing will change, but not as drastic as 0 and not as static as 100.

Care is taken to constraint the perceived scroll speed between 5 and 100 (which is the original bound), so that SV maps with 100x SV as teleport won't accidentally show its notes early.

Also, the submitted replay will record the perceived scroll speed instead of the set scroll speed.

Here is an example: 


https://github.com/user-attachments/assets/f3d275bd-d1a1-4614-b582-b906e7e9c6f1


Notice that when the strength is set to 100, the spacing won't change when the rates change. This is very convenient for practising SV maps:
+ By making the spacing (near) constant, you can start practicing from a lower rate and slowly go back to 1.0x and the experience would be more familiar, as the notes you see don't change places.
+ When practising SV maps with rates, normally you really need this adjustment to at least make it readable (for example, when practising 1.2x you normally need to add a few scroll speed so it looks better) . This automates the need to manually adjust scroll speed. 