### PR TITLE
Optimize editor line and builtin plugin table rendering 

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLine.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLine.cs
@@ -45,6 +45,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <returns></returns>
         public bool IsOnScreen() => StartTime * Playfield.TrackSpeed >= Playfield.TrackPositionY - Playfield.Height &&
                                     StartTime * Playfield.TrackSpeed <= Playfield.TrackPositionY + Playfield.Height;
+
+        public bool IsInPool { get; set; }
         
         /// <summary>
         ///     Returns the color of the tick

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLine.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLine.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Assets;
 using Wobble.Graphics;
+using Wobble.Graphics.Primitives;
 using Wobble.Graphics.Sprites;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Graphics.UI.Buttons;
@@ -10,13 +11,13 @@ using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
 {
-    public abstract class DrawableEditorLine : ImageButton, IStartTime
+    public abstract class DrawableEditorLine : FilledRectangleSprite, IStartTime
     {
         protected EditorPlayfield Playfield { get; }
 
         protected static ScalableVector2 DefaultSize { get; } = new ScalableVector2(40, 2);
         
-        public DrawableEditorLine(EditorPlayfield playfield) : base(UserInterface.BlankBox)
+        public DrawableEditorLine(EditorPlayfield playfield)
         {
             Playfield = playfield;
             Size = DefaultSize;
@@ -30,7 +31,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// </summary>
         public virtual void SetPosition()
         {
-            var x = Playfield.AbsolutePosition.X + Playfield.Width + 2;
+            var x = Playfield.AbsolutePosition.X + Playfield.Width + 2 - Width / 2;
             var y = Playfield.HitPositionY - StartTime * Playfield.TrackSpeed - Height;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
@@ -34,8 +34,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             };
 
             Image = UserInterface.BlankBox;
-            Clicked += OnClicked;
-            RightClicked += OnRightClicked;
         }
         
         public override void Draw(GameTime gameTime)
@@ -67,7 +65,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
                 Height = height;
         }
 
-        protected override bool IsMouseInClickArea() => ScreenRectangle.Contains(Playfield.GetRelativeMousePosition());
+        protected bool IsMouseInClickArea() => ScreenRectangle.Contains(Playfield.GetRelativeMousePosition());
         
         private void OnClicked(object sender, EventArgs e) => DialogManager.Show(new EditorBookmarkDialog(Playfield.ActionManager, Playfield.Track, Bookmark));
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
@@ -7,6 +7,7 @@ using Quaver.Shared.Screens.Edit.Dialogs;
 using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites.Text;
+using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
 using Wobble.Managers;
@@ -21,33 +22,38 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
 
         private Tooltip Tooltip { get; }
 
+        private ImageButton ImageButton { get; }
+
         public DrawableEditorLineBookmark(EditorPlayfield playfield, BookmarkInfo bookmark) : base(playfield)
         {
             Playfield = playfield;
             Bookmark = bookmark;
+            DrawIfOffScreen = true;
 
             Tooltip = new Tooltip(Bookmark.Note, Color.Yellow, false)
             {
                 Parent = this,
                 Alignment = Alignment.MidLeft,
-                X = Width + 4
+                X = Width + 4,
+                DrawIfOffScreen = true
             };
 
+            Tooltip.Text.DrawIfOffScreen = true;
+            Tooltip.Border.DrawIfOffScreen = true;
+            ImageButton = new DrawableEditorLineBookmarkButton(Playfield, Bookmark)
+            {
+                Parent = this,
+                Size = new ScalableVector2(0, 0, 1, 1),
+                X = Width / 2
+            };
             Image = UserInterface.BlankBox;
         }
-        
+
         public override void Draw(GameTime gameTime)
         {
-            Update(gameTime);
-            DrawToSpriteBatch();
-
-            if (string.IsNullOrEmpty(Bookmark.Note)) 
-                return;
-            
-            Tooltip.Draw(gameTime);
-            Tooltip.Border.Draw(gameTime);
-            Tooltip.ChangeText(Bookmark.Note);
-            Tooltip.Text.Draw(gameTime);
+            if (Tooltip.Text.Text != Bookmark.Note)
+                Tooltip.ChangeText(Bookmark.Note);
+            base.Draw(gameTime);
         }
 
         public override Color GetColor() => Color.Yellow;
@@ -65,10 +71,5 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
                 Height = height;
         }
 
-        protected bool IsMouseInClickArea() => ScreenRectangle.Contains(Playfield.GetRelativeMousePosition());
-        
-        private void OnClicked(object sender, EventArgs e) => DialogManager.Show(new EditorBookmarkDialog(Playfield.ActionManager, Playfield.Track, Bookmark));
-
-        private void OnRightClicked(object sender, EventArgs e) => Playfield.ActionManager.RemoveBookmark(Bookmark);
     }
 }

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmarkButton.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmarkButton.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.API.Maps.Structures;
+using Quaver.Shared.Assets;
+using Quaver.Shared.Screens.Edit.Dialogs;
+using Wobble.Graphics;
+using Wobble.Graphics.UI.Buttons;
+using Wobble.Graphics.UI.Dialogs;
+
+namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines;
+
+public class DrawableEditorLineBookmarkButton : ImageButton
+{
+    private EditorPlayfield Playfield { get; }
+
+    public BookmarkInfo Bookmark { get; }
+
+    public DrawableEditorLineBookmarkButton(EditorPlayfield playfield, BookmarkInfo bookmark) : base(UserInterface
+        .BlankBox)
+    {
+        Playfield = playfield;
+        Bookmark = bookmark;
+        Alpha = 0;
+        Clicked += OnClicked;
+        RightClicked += OnRightClicked;
+    }
+
+    protected override bool IsMouseInClickArea() => ScreenRectangle.Contains(Playfield.GetRelativeMousePosition());
+
+    private void OnClicked(object sender, EventArgs e) =>
+        DialogManager.Show(new EditorBookmarkDialog(Playfield.ActionManager, Playfield.Track, Bookmark));
+
+    private void OnRightClicked(object sender, EventArgs e) => Playfield.ActionManager.RemoveBookmark(Bookmark);
+}

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLinePreview.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLinePreview.cs
@@ -10,7 +10,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         public DrawableEditorLinePreview(EditorPlayfield playfield, int time) : base(playfield)
         {
             Time = time;
-            IsClickable = false;
         }
 
         public override Color GetColor() => Colors.SecondaryAccent;

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineScrollSpeedFactor.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineScrollSpeedFactor.cs
@@ -17,7 +17,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         {
             ScrollSpeedFactor = sv;
             TimingGroup = timingGroup;
-            IsClickable = false;
             Rotation = 180;
         }
 
@@ -35,7 +34,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// </summary>
         public override void SetPosition()
         {
-            var x = Playfield.AbsolutePosition.X - DesiredWidth;
+            var x = Playfield.AbsolutePosition.X - DesiredWidth + Width / 2;
             var y = Playfield.HitPositionY - StartTime * Playfield.TrackSpeed - Height;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineScrollVelocity.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineScrollVelocity.cs
@@ -15,7 +15,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         {
             ScrollVelocity = sv;
             TimingGroup = timingGroup;
-            IsClickable = false;
         }
 
         public override Color GetColor() =>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineTimingPoint.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineTimingPoint.cs
@@ -12,7 +12,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         public DrawableEditorLineTimingPoint(EditorPlayfield playfield, TimingPointInfo timingPoint) : base(playfield)
         {
             TimingPoint = timingPoint;
-            IsClickable = false;
         }
 
         public override Color GetColor() => ColorHelper.HexToColor("#FE5656");

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
@@ -32,6 +32,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Edit.Actions.TimingGroups.Create;
 using Quaver.Shared.Screens.Edit.Actions.TimingGroups.Remove;
 using Quaver.Shared.Screens.Edit.UI.Playfield.Timeline;
+using Wobble;
 using Wobble.Audio.Tracks;
 using Wobble.Graphics;
 
@@ -123,6 +124,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
+            // if (gameTime.IsRunningSlowly)
+                // return;
             for (var i = 0; i < LinePool.Count; i++)
             {
                 var line = LinePool[i];

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended.Collections;
+using MonoGame.Extended.Timers;
 using MoreLinq.Extensions;
 using Quaver.API.Helpers;
 using Quaver.API.Maps;
@@ -56,7 +58,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <summary>
         ///     The lines that are visible and ready to be drawn to the screen
         /// </summary>
-        private List<DrawableEditorLine> LinePool { get; set; }
+        private Deque<DrawableEditorLine> LinePool { get; set; }
 
         /// <summary>
         /// </summary>
@@ -66,6 +68,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         ///     The index of the last object that was added to the pool
         /// </summary>
         private int LastPooledLineIndex { get; set; } = -1;
+
+        private readonly ContinuousClock _removeLinesClock = new(0.3);
+
+        public int MaximumLineCount => 1500;
 
         /// <summary>
         /// </summary>
@@ -106,6 +112,35 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             ActionManager.BookmarkBatchOffsetChanged += OnBookmarkBatchOffsetChanged;
             ActionManager.TimingGroupCreated += OnTimingGroupCreated;
             ActionManager.TimingGroupDeleted += OnTimingGroupDeleted;
+            _removeLinesClock.Tick += RemoveLines;
+            _removeLinesClock.Start();
+        }
+
+        private void RemoveLines(object sender, EventArgs e)
+        {
+            // Check the objects that are in the pool currently to see if they're still in view.
+            // if they're not, remove them.
+            while(LinePool.GetFront(out var item) && !item.IsOnScreen())
+            {
+                LinePool.RemoveFromFront();
+                item.IsInPool = false;
+            }
+            var minTime = (Playfield.TrackPositionY - Playfield.Height) / Playfield.TrackSpeed;
+            var maxTime = (Playfield.TrackPositionY + Playfield.Height) / Playfield.TrackSpeed;
+            var minIndex = Lines.IndexAtTimeBefore(minTime);
+            var maxIndex = Lines.IndexAtTime(maxTime);
+            for (var i = minIndex; i <= maxIndex; i++)
+            {
+                var line = Lines[i];
+
+                if (line.IsInPool)
+                    continue;
+
+                LinePool.AddToBack(line);
+                line.IsInPool = true;
+                LastPooledLineIndex = i;
+            }
+
         }
         
         /// <inheritdoc />
@@ -114,7 +149,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <param name="gameTime"></param>
         public override void Update(GameTime gameTime)
         {
-            UpdateLinePool();
+            _removeLinesClock.Update(gameTime);
+            UpdateLinePool(gameTime);
             base.Update(gameTime);
         }
 
@@ -124,8 +160,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <param name="gameTime"></param>
         public override void Draw(GameTime gameTime)
         {
-            // if (gameTime.IsRunningSlowly)
-                // return;
             for (var i = 0; i < LinePool.Count; i++)
             {
                 var line = LinePool[i];
@@ -178,6 +212,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             ActionManager.BookmarkBatchOffsetChanged -= OnBookmarkBatchOffsetChanged;
             ActionManager.TimingGroupCreated -= OnTimingGroupCreated;
             ActionManager.TimingGroupDeleted -= OnTimingGroupDeleted;
+            _removeLinesClock.Tick -= RemoveLines;
             
             base.Destroy();
         }
@@ -223,17 +258,22 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// </summary>
         private void InitializeLinePool()
         {
-            LinePool = new List<DrawableEditorLine>();
+            LinePool = new Deque<DrawableEditorLine>();
             LastPooledLineIndex = -1;
 
-            for (var i = 0; i < Lines.Count; i++)
+            var minTime = (Playfield.TrackPositionY - Playfield.Height) / Playfield.TrackSpeed;
+            var maxTime = (Playfield.TrackPositionY + Playfield.Height) / Playfield.TrackSpeed;
+            var minIndex = Lines.IndexAtTimeBefore(minTime);
+            var maxIndex = Lines.IndexAtTime(maxTime);
+            for (var i = minIndex; i <= maxIndex; i++)
             {
                 var line = Lines[i];
 
                 if (!line.IsOnScreen())
                     continue;
 
-                LinePool.Add(line);
+                LinePool.AddToBack(line);
+                line.IsInPool = true;
                 LastPooledLineIndex = i;
             }
 
@@ -244,28 +284,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// <summary>
         ///     Updates the object pool to get rid of old/out of view objects
         /// </summary>
-        private void UpdateLinePool()
+        private void UpdateLinePool(GameTime gameTime)
         {
-            // Check the objects that are in the pool currently to see if they're still in view.
-            // if they're not, remove them.
-            for (var i = LinePool.Count - 1; i >= 0; i--)
+            foreach (var line in LinePool)
             {
-                var line = LinePool[i];
-
-                if (!line.IsOnScreen())
-                    LinePool.Remove(line);
-            }
-
-            // Add any objects that are now on-screen
-            for (var i = LastPooledLineIndex + 1; i < Lines.Count; i++)
-            {
-                var line = Lines[i];
-
-                if (!line.IsOnScreen())
-                    break;
-
-                LinePool.Add(line);
-                LastPooledLineIndex = i;
+                line.Update(gameTime);
             }
         }
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
@@ -9,7 +9,7 @@ using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
 {
-    public class EditorPlayfieldTimelineTick : Sprite
+    public class EditorPlayfieldTimelineTick : Sprite, IStartTime
     {
         /// <summary>
         /// </summary>
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// <summary>
         ///     The time in the song the line is located.
         /// </summary>
-        public float Time { get; }
+        public float StartTime { get; set; }
 
         /// <summary>
         ///     The index of the timing point this snap line is.
@@ -43,15 +43,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// <param name="playfield"></param>
         /// <param name="tp"></param>
         /// <param name="beatSnap"></param>
-        /// <param name="time"></param>
+        /// <param name="startTimearam>
         /// <param name="index"></param>
         /// <param name="measureCount"></param>
-        public EditorPlayfieldTimelineTick(EditorPlayfield playfield, TimingPointInfo tp, float time, int index, int measureCount, bool isMeasureLine)
+        public EditorPlayfieldTimelineTick(EditorPlayfield playfield, TimingPointInfo tp, float startTime, int index, int measureCount, bool isMeasureLine)
         {
             Playfield = playfield;
             TimingPoint = tp;
             Index = index;
-            Time = time;
+            StartTime = startTime;
             IsMeasureLine = isMeasureLine;
 
             if (!IsMeasureLine)
@@ -91,15 +91,15 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         ///     Checks if the timing line is on-screen.
         /// </summary>
         /// <returns></returns>
-        public bool IsOnScreen() => Time * Playfield.TrackSpeed >= Playfield.TrackPositionY - Playfield.Height &&
-                                         Time * Playfield.TrackSpeed <= Playfield.TrackPositionY + Playfield.Height;
+        public bool IsOnScreen() => StartTime * Playfield.TrackSpeed >= Playfield.TrackPositionY - Playfield.Height &&
+                                         StartTime * Playfield.TrackSpeed <= Playfield.TrackPositionY + Playfield.Height;
 
         /// <summary>
         /// </summary>
         public void SetPosition()
         {
             var x = Playfield.AbsolutePosition.X + 2;
-            var y = Playfield.HitPositionY - Time * Playfield.TrackSpeed - Height;
+            var y = Playfield.HitPositionY - StartTime * Playfield.TrackSpeed - Height;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (X != x || Y != y)


### PR DESCRIPTION
+ Under limited fps, when the amount of lines are over 1024, the lines will start to be rendered and updated once per a few frames (logarithmically increasing). This will cause the lines to be flashy but it saves the fps.
+ Make table drawing consistent. Timing points and timing groups editor now use the new ImGui table API to boost performance.
+ Make editor lines FilledRectangles instead of Buttons. This saves a **huge** amount of fps.
  + Only bookmark lines will need to be buttons, so now it always has a hidden button child for this functionality.

From those optimizations I can now get 100+fps on 500fps limiter in [*the* emme](https://quavergame.com/mapset/map/157633), including the part where there's a wall of timing points.