### PR TITLE
Add letterboxing to playfield

### DIFF
--- a/Quaver.Shared/Assets/UserInterface.cs
+++ b/Quaver.Shared/Assets/UserInterface.cs
@@ -13,6 +13,7 @@ namespace Quaver.Shared.Assets
     public static class UserInterface
     {
         public static Texture2D BlankBox => TextureManager.Load($"Quaver.Resources/Textures/UI/blank-box.png");
+        public static Texture2D PlayfieldMask => TextureManager.Load($"Quaver.Resources/Textures/UI/playfield-mask.png");
         public static Texture2D UnknownAvatar => TextureManager.Load($"Quaver.Resources/Textures/UI/unknown-avatar.png");
         public static Texture2D YouAvatar => TextureManager.Load($"Quaver.Resources/Textures/UI/you-avatar.png");
         public static Texture2D MenuBackground => TextureManager.Load($"Quaver.Resources/Textures/UI/Menu/menu-background.jpg");

--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -167,6 +167,10 @@ namespace Quaver.Shared.Config
 
         /// <summary>
         /// </summary>
+        internal static BindableInt PlayfieldScale { get; private set; }
+
+        /// <summary>
+        /// </summary>
         internal static Bindable<bool> PreferWayland { get; private set; }
 
         /// <summary>
@@ -1058,6 +1062,7 @@ namespace Quaver.Shared.Config
             WindowHeight = ReadInt(@"WindowHeight", 768, 360, short.MaxValue, data);
             WindowWidth = ReadInt(@"WindowWidth", 1366, 640, short.MaxValue, data);
             WindowBorderless = ReadValue(@"WindowBorderless", false, data);
+            PlayfieldScale = ReadInt(@"PlayfieldScale", 100, 25, 100, data);
             PreferWayland = ReadValue(@"PreferWayland", false, data);
             DisplaySongTimeProgress = ReadValue(@"DisplaySongTimeProgress", true, data);
             WindowFullScreen = ReadValue(@"WindowFullScreen", false, data);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -200,8 +200,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             };
             SetLaneScrollDirections();
             SetReferencePositions();
-            CreateElementContainers(); 
-            Container.Scale = Vector2.One * (ConfigManager.PlayfieldScale.Value / 100f);
+            CreateElementContainers();
+            if (!Screen.IsSongSelectPreview)
+                Container.Scale = Vector2.One * (ConfigManager.PlayfieldScale.Value / 100f);
         }
 
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -13,10 +13,13 @@ using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 using Quaver.Shared.Skinning;
 using System;
 using System.Linq;
+using Microsoft.Xna.Framework.Graphics;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Screens.Gameplay.UI;
 using Quaver.Shared.Window;
 using Wobble;
 using Wobble.Graphics;
+using Wobble.Graphics.Sprites;
 using Wobble.Window;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
@@ -47,6 +50,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         ///     The foreground of the playfield.
         /// </summary>
         public Container ForegroundContainer { get; private set; }
+
+        /// <summary>
+        ///     The mask of the playfield. Used to hide notes outside of the playfield.
+        /// </summary>
+        public Sprite PlayfieldMask { get; private set; }
 
         /// <summary>
         ///     The stage of the playfield.
@@ -186,10 +194,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         {
             Screen = screen;
             Ruleset = ruleset;
-            Container = new Container();
+            Container = new Container
+            {
+                Pivot = new Vector2(0.5f, 0.5f)
+            };
             SetLaneScrollDirections();
             SetReferencePositions();
-            CreateElementContainers();
+            CreateElementContainers(); 
+            Container.Scale = Vector2.One * (ConfigManager.PlayfieldScale.Value / 100f);
         }
 
 
@@ -214,6 +226,22 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 Size = new ScalableVector2(Width, WindowManager.Height),
                 Alignment = Alignment.TopCenter,
                 X = SkinManager.Skin.Keys[Screen.Map.Mode].ColumnAlignment
+            };
+
+            PlayfieldMask = new Sprite
+            {
+                Parent = Container,
+                Image = UserInterface.PlayfieldMask,
+                Alignment = Alignment.MidCenter,
+                Size = new ScalableVector2(WindowManager.Width * 4, WindowManager.Height * 4),
+                Visible = ConfigManager.PlayfieldScale.Value < 100 && !Screen.IsSongSelectPreview,
+                SpriteBatchOptions = new SpriteBatchOptions
+                {
+                    SamplerState = new SamplerState
+                    {
+                        Filter = TextureFilter.Point
+                    }
+                }
             };
 
             Stage = new GameplayPlayfieldKeysStage(Screen, this);

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -252,6 +252,8 @@ namespace Quaver.Shared.Screens.Options
                     {
                         new OptionsSlider(containerRect, "Note & Receptor Size Scale", ConfigManager.GameplayNoteScale, i => $"{i / 100f:0.00}x")
                             {Tags = new List<string>() {"mini"}},
+                        new OptionsSlider(containerRect, "Playfield Scale", ConfigManager.PlayfieldScale, i => $"{i / 100f:0.00}x")
+                            {Tags = new List<string>() {"mini"}},
                         new OptionsItemCheckbox(containerRect, "Tint Hitlighting Based On Judgement Color", ConfigManager.TintHitLightingBasedOnJudgementColor)
                     })
                 }),

--- a/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
@@ -58,6 +58,13 @@ namespace Quaver.Shared.Screens.Tournament
                 OnlineManager.LeaveGame();
                 TournamentScreen.Exit(() => new MultiplayerLobbyScreen());
             }
+
+            foreach (var gameplayScreen in TournamentScreen.GameplayScreens)
+            {
+                var playfield = (GameplayPlayfieldKeys)gameplayScreen.Ruleset.Playfield;
+                playfield.PlayfieldMask.Visible = false;
+            }
+
             CreateBackground();
             SetPlayfieldPositions();
             PositionPlayfieldItems();
@@ -129,7 +136,6 @@ namespace Quaver.Shared.Screens.Tournament
             {
                 var screen = TournamentScreen.GameplayScreens[i];
                 var playfield = (GameplayPlayfieldKeys)screen.Ruleset.Playfield;
-                playfield.PlayfieldMask.Visible = false;
 
                 playfield.Container.Width = playfield.Width + playfield.Stage.HealthBar.Width;
 

--- a/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
+++ b/Quaver.Shared/Screens/Tournament/TournamentScreenView.cs
@@ -129,6 +129,7 @@ namespace Quaver.Shared.Screens.Tournament
             {
                 var screen = TournamentScreen.GameplayScreens[i];
                 var playfield = (GameplayPlayfieldKeys)screen.Ruleset.Playfield;
+                playfield.PlayfieldMask.Visible = false;
 
                 playfield.Container.Width = playfield.Width + playfield.Stage.HealthBar.Width;
 


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.Resources/pull/21 , #4436 and https://github.com/Quaver/Wobble/pull/163

Adds a scaling percentage slider for scaling the playfield down from 0.25x up to 1.0x

A mask will be applied to the playfield to hide the upper and lower overflow part. The mask will not show in tournament settings as it hides other playfields.