### PR TITLE
Add toggle to display ranked accuracy on local leaderboards

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -274,6 +274,11 @@ namespace Quaver.Shared.Config
         internal static Bindable<bool> DisplayRankedAccuracy { get; private set; }
 
         /// <summary>
+        ///     Display the ranked accuracy for local leaderboards instead of the custom judgement windows accuracy
+        /// </summary>
+        internal static Bindable<bool> LeaderboardRankedAccuracy { get; private set; }
+
+        /// <summary>
         ///     If true, the hitlighting will be tinted to the judgement color in the skin
         /// </summary>
         internal static Bindable<bool> TintHitLightingBasedOnJudgementColor { get; private set; }
@@ -1077,6 +1082,7 @@ namespace Quaver.Shared.Config
             Pitched = ReadValue(@"Pitched", true, data);
             ScoreboardVisible = ReadValue(@"ScoreboardVisible", true, data);
             DisplayRankedAccuracy = ReadValue(@"DisplayRankedAccuracy", false, data);
+            LeaderboardRankedAccuracy = ReadValue(@"LeaderboardRankedAccuracy", false, data);
             SelectOrderMapsetsBy = ReadValue(@"SelectOrderMapsetsBy", OrderMapsetsBy.Artist, data);
             LeaderboardSection = ReadValue(@"LeaderboardSection", LeaderboardType.Local, data);
             OsuDbPath = ReadSpecialConfigType(SpecialConfigType.Path, @"OsuDbPath", "", data);

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -452,7 +452,8 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Display Menu Audio Visualizer", ConfigManager.DisplayMenuAudioVisualizer),
                         new OptionsItemCheckbox(containerRect, "Display Failed Local Scores", ConfigManager.DisplayFailedLocalScores),
                         new OptionsItemCheckbox(containerRect, "Delete Original File After Import", ConfigManager.DeleteOriginalFileAfterImport),
-                        new OptionsItemCheckbox(containerRect, "Discord Rich Presence", ConfigManager.DiscordRichPresence)
+                        new OptionsItemCheckbox(containerRect, "Discord Rich Presence", ConfigManager.DiscordRichPresence),
+                        new OptionsItemCheckbox(containerRect, "Display Ranked Accuracy For Local Leaderboards", ConfigManager.LeaderboardRankedAccuracy)
                     }),
                 }),
             };

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
@@ -222,12 +222,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
                 PerformanceRating.Text = StringHelper.RatingToString(score.Item.PerformanceRating);
 
-                UpdateAccuracyMaxCombo(score);
-
-                var grade = score.Item.Grade == API.Enums.Grade.F
-                    ? API.Enums.Grade.F
-                    : GradeHelper.GetGradeFromAccuracy((float)score.Item.Accuracy);
-                Grade.Image = SkinManager.Skin?.Grades[grade] ?? UserInterface.Logo;
+                UpdateAccuracyMode(score);
 
                 UpdateTime();
                 UpdateModifiers();
@@ -765,20 +760,28 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnAccuracyDisplayChanged(object sender, BindableValueChangedEventArgs<bool> e) =>
-            AddScheduledUpdate(() => UpdateAccuracyMaxCombo(Score));
+            AddScheduledUpdate(() => UpdateAccuracyMode(Score));
 
         /// <summary>
-        /// Called when <see cref="AccuracyMaxCombo"/> might need to be updated
+        /// Called when <see cref="AccuracyMaxCombo"/> and <see cref="Grade"> might need to be updated
         /// </summary>
         /// <param name="score"></param>
-        private void UpdateAccuracyMaxCombo(DrawableLeaderboardScore score)
+        private void UpdateAccuracyMode(DrawableLeaderboardScore score)
         {
+            var acc = (float)(ConfigManager.LeaderboardSection.Value == LeaderboardType.Local &&
+                ConfigManager.LeaderboardRankedAccuracy.Value
+                    ? score.Item.RankedAccuracy
+                    : score.Item.Accuracy);
+
             if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
-                AccuracyMaxCombo.Text = $"{StringHelper.AccuracyToString((float)score.Item.Accuracy)}";
-            else if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Local && ConfigManager.LeaderboardRankedAccuracy.Value)
-                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float)score.Item.RankedAccuracy)}";
+                AccuracyMaxCombo.Text = $"{StringHelper.AccuracyToString(acc)}";
             else
-                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float)score.Item.Accuracy)}";
+                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString(acc)}";
+
+            var grade = score.Item.Grade == API.Enums.Grade.F
+                ? API.Enums.Grade.F
+                : GradeHelper.GetGradeFromAccuracy(acc);
+            Grade.Image = SkinManager.Skin?.Grades[grade] ?? UserInterface.Logo;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Enums;
@@ -9,7 +8,6 @@ using Quaver.API.Maps.Processors.Rating;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
-using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
@@ -207,7 +205,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                     return;
 
                 Tint = Button.IsHovered || CantBeatAlert.IsHovered || RequiredAccuracyAlert.IsHovered
-                    ? ColorHelper.HexToColor("#575757") : BackgroundColor;
+                    ? ColorHelper.HexToColor("#575757"): BackgroundColor;
 
                 // Ranks don't show on PB scores.
                 if (!Score.IsPersonalBest)
@@ -221,7 +219,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                     Username.Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreUsernameOtherColor ?? ColorHelper.HexToColor("#FBFFB6");
 
                 PerformanceRating.Text = StringHelper.RatingToString(score.Item.PerformanceRating);
-
+                
                 UpdateAccuracyMode(score);
 
                 UpdateTime();
@@ -267,8 +265,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                     return;
-
-                var game = (QuaverGame)GameBase.Game;
+                
+                var game = (QuaverGame) GameBase.Game;
 
                 if (OnlineManager.CurrentGame != null)
                     return;
@@ -280,8 +278,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                     return;
-
-                var game = (QuaverGame)GameBase.Game;
+                
+                var game = (QuaverGame) GameBase.Game;
                 game?.CurrentScreen?.ActivateRightClickOptions(new LeaderboardScoreRightClickOptions(Score.Item));
             };
         }
@@ -319,7 +317,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Image = BlankImage,
                 Alpha = 0
             };
-
+            
             if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                 Avatar.Size = new ScalableVector2(0, 0);
         }
@@ -367,10 +365,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 Parent = this,
                 Alignment = Alignment.TopLeft,
-                Position = new ScalableVector2(Flag.X + Flag.Width + PaddingLeft / 4f, UsernameY + 4),
+                Position = new ScalableVector2(Flag.X + Flag.Width +PaddingLeft / 4f, UsernameY + 4),
                 UsePreviousSpriteBatchOptions = true
             };
-
+            
         }
 
         /// <summary>
@@ -444,13 +442,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             CantBeatAlert.Hovered += (sender, args) =>
             {
-                var game = (QuaverGame)GameBase.Game;
+                var game = (QuaverGame) GameBase.Game;
                 game.CurrentScreen.ActivateTooltip(UnbeatableTooltip);
             };
 
             CantBeatAlert.LeftHover += (sender, args) =>
             {
-                var game = (QuaverGame)GameBase.Game;
+                var game = (QuaverGame) GameBase.Game;
                 game.CurrentScreen.DeactivateTooltip();
             };
 
@@ -478,10 +476,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             RequiredAccuracyAlert.LeftHover += (sender, args) =>
             {
-                var game = (QuaverGame)GameBase.Game;
+                var game = (QuaverGame) GameBase.Game;
                 game.CurrentScreen.DeactivateTooltip();
             };
-
+            
             if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                 RequiredAccuracyAlert.Size = new ScalableVector2(0, 0);
         }
@@ -528,27 +526,27 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             Time.X = Clock.Width + 2;
 
             // Years
-            if ((int)timeDifference.TotalDays > 365)
-                Time.Text = $"{(int)(timeDifference.TotalDays / 365)}y";
+            if ((int) timeDifference.TotalDays > 365)
+                Time.Text = $"{(int) (timeDifference.TotalDays / 365)}y";
             // Months
-            else if ((int)timeDifference.TotalDays > 30)
-                Time.Text = $"{(int)(timeDifference.TotalDays / 30)}mo";
+            else if ((int) timeDifference.TotalDays > 30)
+                Time.Text = $"{(int) (timeDifference.TotalDays / 30)}mo";
             // Weeks
-            else if ((int)timeDifference.TotalDays > 7)
-                Time.Text = $"{(int)(timeDifference.TotalDays / 7)}w";
+            else if ((int) timeDifference.TotalDays > 7)
+                Time.Text = $"{(int) (timeDifference.TotalDays / 7)}w";
             // Days
-            else if ((int)timeDifference.TotalDays > 0)
-                Time.Text = $"{(int)timeDifference.TotalDays}d";
+            else if ((int) timeDifference.TotalDays > 0)
+                Time.Text = $"{(int) timeDifference.TotalDays}d";
             // Hours
-            else if ((int)timeDifference.TotalHours > 0)
-                Time.Text = $"{(int)timeDifference.TotalHours}h";
+            else if ((int) timeDifference.TotalHours > 0)
+                Time.Text = $"{(int) timeDifference.TotalHours}h";
             // Minutes
-            else if ((int)timeDifference.TotalMinutes > 0)
-                Time.Text = $"{(int)timeDifference.TotalMinutes}m";
+            else if ((int) timeDifference.TotalMinutes > 0)
+                Time.Text = $"{(int) timeDifference.TotalMinutes}m";
             // Seconds
             else
             {
-                var seconds = (int)timeDifference.TotalSeconds;
+                var seconds = (int) timeDifference.TotalSeconds;
 
                 if (seconds <= 0)
                     Time.Text = "now";
@@ -570,7 +568,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             if (Button == null)
                 return;
 
-            var color = Button.IsHovered || CantBeatAlert.IsHovered ? ColorHelper.HexToColor("#575757") : BackgroundColor;
+            var color = Button.IsHovered || CantBeatAlert.IsHovered ? ColorHelper.HexToColor("#575757"): BackgroundColor;
             FadeToColor(color, gameTime.ElapsedGameTime.TotalMilliseconds, 30);
         }
 
@@ -584,7 +582,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             Modifiers = new List<DrawableModifier>();
 
-            var modsList = ModManager.GetModsList((ModIdentifier)Score.Item.Mods);
+            var modsList = ModManager.GetModsList((ModIdentifier) Score.Item.Mods);
 
             if (modsList.Count == 0)
                 modsList.Add(ModIdentifier.None);
@@ -625,38 +623,38 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// </summary>
         private void UpdateAvatar()
         {
-            var steamId = (ulong)Score.Item.SteamId;
+            var steamId = (ulong) Score.Item.SteamId;
 
             if (ConfigManager.LeaderboardSection?.Value == LeaderboardType.Local)
                 steamId = SteamUser.GetSteamID().m_SteamID;
 
             lock (Avatar)
-                lock (Avatar.Image)
+            lock (Avatar.Image)
+            {
+                if (Score.IsPersonalBest && !Score.Item.IsOnline)
                 {
-                    if (Score.IsPersonalBest && !Score.Item.IsOnline)
-                    {
-                        Avatar.Image = SteamManager.GetAvatarOrUnknown(steamId);
-                        Avatar.Alpha = 1;
-                        return;
-                    }
-
-                    if (SteamManager.UserAvatars.ContainsKey(steamId))
-                    {
-                        if (Avatar.Image == SteamManager.UserAvatars[steamId])
-                            return;
-
-                        Avatar.Alpha = 0;
-                        Avatar.ClearAnimations();
-                        Avatar.FadeTo(1, Easing.Linear, 400);
-
-                        Avatar.Image = SteamManager.UserAvatars[steamId];
-                        return;
-                    }
-
-                    Avatar.Image = UserInterface.UnknownAvatar;
-                    Avatar.ClearAnimations();
-                    Avatar.Alpha = 0;
+                    Avatar.Image = SteamManager.GetAvatarOrUnknown(steamId);
+                    Avatar.Alpha = 1;
+                    return;
                 }
+
+                if (SteamManager.UserAvatars.ContainsKey(steamId))
+                {
+                    if (Avatar.Image == SteamManager.UserAvatars[steamId])
+                        return;
+
+                    Avatar.Alpha = 0;
+                    Avatar.ClearAnimations();
+                    Avatar.FadeTo(1, Easing.Linear, 400);
+
+                    Avatar.Image = SteamManager.UserAvatars[steamId];
+                    return;
+                }
+
+                Avatar.Image = UserInterface.UnknownAvatar;
+                Avatar.ClearAnimations();
+                Avatar.Alpha = 0;
+            }
 
             SteamManager.SendAvatarRetrievalRequest(steamId);
         }
@@ -685,7 +683,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         {
             if (CantBeatAlert.Visible ||
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
-                ModHelper.GetRateFromMods(ModManager.Mods) == ModHelper.GetRateFromMods((ModIdentifier)Score.Item.Mods))
+                ModHelper.GetRateFromMods(ModManager.Mods) == ModHelper.GetRateFromMods((ModIdentifier) Score.Item.Mods))
             {
                 RequiredAccuracyAlert.Visible = false;
                 return;
@@ -724,17 +722,17 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// <param name="e"></param>
         private void OnSteamAvatarLoaded(object sender, SteamAvatarLoadedEventArgs e)
         {
-            if (e.SteamId != (ulong)Score.Item.SteamId)
+            if (e.SteamId != (ulong) Score.Item.SteamId)
                 return;
 
             lock (Avatar)
-                lock (Avatar.Image)
-                {
-                    Avatar.Alpha = 0;
-                    Avatar.ClearAnimations();
-                    Avatar.FadeTo(1, Easing.Linear, 400);
-                    Avatar.Image = e.Texture;
-                }
+            lock (Avatar.Image)
+            {
+                Avatar.Alpha = 0;
+                Avatar.ClearAnimations();
+                Avatar.FadeTo(1, Easing.Linear, 400);
+                Avatar.Image = e.Texture;
+            }
         }
 
         /// <summary>
@@ -788,14 +786,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// </summary>
         private void ActivateRequiredAccuracyTooltip()
         {
-            var game = (QuaverGame)GameBase.Game;
+            var game = (QuaverGame) GameBase.Game;
 
             var processor = new RatingProcessorKeys(MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods));
 
             var requiredAcc = processor.GetAccuracyFromRating(Score.Item.PerformanceRating);
 
             var tooltip = new Tooltip("In order to beat this score with your current modifiers,\n" +
-                                      $"you must achieve higher than {StringHelper.AccuracyToString((float)requiredAcc)} accuracy.",
+                                      $"you must achieve higher than {StringHelper.AccuracyToString((float) requiredAcc)} accuracy.",
                 ColorHelper.HexToColor("#5dc7f9"));
 
             game.CurrentScreen.ActivateTooltip(tooltip);

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Components/DrawableLeaderboardScoreContainer.cs
@@ -9,6 +9,7 @@ using Quaver.API.Maps.Processors.Rating;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Database.Scores;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
@@ -19,6 +20,7 @@ using Quaver.Shared.Skinning;
 using Steamworks;
 using Wobble;
 using Wobble.Assets;
+using Wobble.Bindables;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
@@ -174,6 +176,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             SteamManager.SteamUserAvatarLoaded += OnSteamAvatarLoaded;
             ModManager.ModsChanged += OnModsChanged;
+            ConfigManager.LeaderboardRankedAccuracy.ValueChanged += OnAccuracyDisplayChanged;
         }
 
         /// <inheritdoc />
@@ -204,7 +207,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                     return;
 
                 Tint = Button.IsHovered || CantBeatAlert.IsHovered || RequiredAccuracyAlert.IsHovered
-                    ? ColorHelper.HexToColor("#575757"): BackgroundColor;
+                    ? ColorHelper.HexToColor("#575757") : BackgroundColor;
 
                 // Ranks don't show on PB scores.
                 if (!Score.IsPersonalBest)
@@ -218,14 +221,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                     Username.Tint = SkinManager.Skin?.SongSelect?.LeaderboardScoreUsernameOtherColor ?? ColorHelper.HexToColor("#FBFFB6");
 
                 PerformanceRating.Text = StringHelper.RatingToString(score.Item.PerformanceRating);
-                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float) score.Item.Accuracy)}";
 
-                if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
-                    AccuracyMaxCombo.Text = $"{StringHelper.AccuracyToString((float)score.Item.Accuracy)}";
-                
+                UpdateAccuracyMaxCombo(score);
+
                 var grade = score.Item.Grade == API.Enums.Grade.F
                     ? API.Enums.Grade.F
-                    : GradeHelper.GetGradeFromAccuracy((float) score.Item.Accuracy);
+                    : GradeHelper.GetGradeFromAccuracy((float)score.Item.Accuracy);
                 Grade.Image = SkinManager.Skin?.Grades[grade] ?? UserInterface.Logo;
 
                 UpdateTime();
@@ -248,6 +249,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             // ReSharper disable once DelegateSubtraction
             SteamManager.SteamUserAvatarLoaded -= OnSteamAvatarLoaded;
             ModManager.ModsChanged -= OnModsChanged;
+            ConfigManager.LeaderboardRankedAccuracy.ValueChanged -= OnAccuracyDisplayChanged;
 
             base.Destroy();
         }
@@ -270,8 +272,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                     return;
-                
-                var game = (QuaverGame) GameBase.Game;
+
+                var game = (QuaverGame)GameBase.Game;
 
                 if (OnlineManager.CurrentGame != null)
                     return;
@@ -283,8 +285,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                     return;
-                
-                var game = (QuaverGame) GameBase.Game;
+
+                var game = (QuaverGame)GameBase.Game;
                 game?.CurrentScreen?.ActivateRightClickOptions(new LeaderboardScoreRightClickOptions(Score.Item));
             };
         }
@@ -322,7 +324,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
                 Image = BlankImage,
                 Alpha = 0
             };
-            
+
             if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                 Avatar.Size = new ScalableVector2(0, 0);
         }
@@ -370,10 +372,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             {
                 Parent = this,
                 Alignment = Alignment.TopLeft,
-                Position = new ScalableVector2(Flag.X + Flag.Width +PaddingLeft / 4f, UsernameY + 4),
+                Position = new ScalableVector2(Flag.X + Flag.Width + PaddingLeft / 4f, UsernameY + 4),
                 UsePreviousSpriteBatchOptions = true
             };
-            
+
         }
 
         /// <summary>
@@ -447,13 +449,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             CantBeatAlert.Hovered += (sender, args) =>
             {
-                var game = (QuaverGame) GameBase.Game;
+                var game = (QuaverGame)GameBase.Game;
                 game.CurrentScreen.ActivateTooltip(UnbeatableTooltip);
             };
 
             CantBeatAlert.LeftHover += (sender, args) =>
             {
-                var game = (QuaverGame) GameBase.Game;
+                var game = (QuaverGame)GameBase.Game;
                 game.CurrentScreen.DeactivateTooltip();
             };
 
@@ -481,10 +483,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             RequiredAccuracyAlert.LeftHover += (sender, args) =>
             {
-                var game = (QuaverGame) GameBase.Game;
+                var game = (QuaverGame)GameBase.Game;
                 game.CurrentScreen.DeactivateTooltip();
             };
-            
+
             if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
                 RequiredAccuracyAlert.Size = new ScalableVector2(0, 0);
         }
@@ -531,27 +533,27 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             Time.X = Clock.Width + 2;
 
             // Years
-            if ((int) timeDifference.TotalDays > 365)
-                Time.Text = $"{(int) (timeDifference.TotalDays / 365)}y";
+            if ((int)timeDifference.TotalDays > 365)
+                Time.Text = $"{(int)(timeDifference.TotalDays / 365)}y";
             // Months
-            else if ((int) timeDifference.TotalDays > 30)
-                Time.Text = $"{(int) (timeDifference.TotalDays / 30)}mo";
+            else if ((int)timeDifference.TotalDays > 30)
+                Time.Text = $"{(int)(timeDifference.TotalDays / 30)}mo";
             // Weeks
-            else if ((int) timeDifference.TotalDays > 7)
-                Time.Text = $"{(int) (timeDifference.TotalDays / 7)}w";
+            else if ((int)timeDifference.TotalDays > 7)
+                Time.Text = $"{(int)(timeDifference.TotalDays / 7)}w";
             // Days
-            else if ((int) timeDifference.TotalDays > 0)
-                Time.Text = $"{(int) timeDifference.TotalDays}d";
+            else if ((int)timeDifference.TotalDays > 0)
+                Time.Text = $"{(int)timeDifference.TotalDays}d";
             // Hours
-            else if ((int) timeDifference.TotalHours > 0)
-                Time.Text = $"{(int) timeDifference.TotalHours}h";
+            else if ((int)timeDifference.TotalHours > 0)
+                Time.Text = $"{(int)timeDifference.TotalHours}h";
             // Minutes
-            else if ((int) timeDifference.TotalMinutes > 0)
-                Time.Text = $"{(int) timeDifference.TotalMinutes}m";
+            else if ((int)timeDifference.TotalMinutes > 0)
+                Time.Text = $"{(int)timeDifference.TotalMinutes}m";
             // Seconds
             else
             {
-                var seconds = (int) timeDifference.TotalSeconds;
+                var seconds = (int)timeDifference.TotalSeconds;
 
                 if (seconds <= 0)
                     Time.Text = "now";
@@ -573,7 +575,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
             if (Button == null)
                 return;
 
-            var color = Button.IsHovered || CantBeatAlert.IsHovered ? ColorHelper.HexToColor("#575757"): BackgroundColor;
+            var color = Button.IsHovered || CantBeatAlert.IsHovered ? ColorHelper.HexToColor("#575757") : BackgroundColor;
             FadeToColor(color, gameTime.ElapsedGameTime.TotalMilliseconds, 30);
         }
 
@@ -587,7 +589,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
             Modifiers = new List<DrawableModifier>();
 
-            var modsList = ModManager.GetModsList((ModIdentifier) Score.Item.Mods);
+            var modsList = ModManager.GetModsList((ModIdentifier)Score.Item.Mods);
 
             if (modsList.Count == 0)
                 modsList.Add(ModIdentifier.None);
@@ -628,38 +630,38 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// </summary>
         private void UpdateAvatar()
         {
-            var steamId = (ulong) Score.Item.SteamId;
+            var steamId = (ulong)Score.Item.SteamId;
 
             if (ConfigManager.LeaderboardSection?.Value == LeaderboardType.Local)
                 steamId = SteamUser.GetSteamID().m_SteamID;
 
             lock (Avatar)
-            lock (Avatar.Image)
-            {
-                if (Score.IsPersonalBest && !Score.Item.IsOnline)
+                lock (Avatar.Image)
                 {
-                    Avatar.Image = SteamManager.GetAvatarOrUnknown(steamId);
-                    Avatar.Alpha = 1;
-                    return;
-                }
-
-                if (SteamManager.UserAvatars.ContainsKey(steamId))
-                {
-                    if (Avatar.Image == SteamManager.UserAvatars[steamId])
+                    if (Score.IsPersonalBest && !Score.Item.IsOnline)
+                    {
+                        Avatar.Image = SteamManager.GetAvatarOrUnknown(steamId);
+                        Avatar.Alpha = 1;
                         return;
+                    }
 
-                    Avatar.Alpha = 0;
+                    if (SteamManager.UserAvatars.ContainsKey(steamId))
+                    {
+                        if (Avatar.Image == SteamManager.UserAvatars[steamId])
+                            return;
+
+                        Avatar.Alpha = 0;
+                        Avatar.ClearAnimations();
+                        Avatar.FadeTo(1, Easing.Linear, 400);
+
+                        Avatar.Image = SteamManager.UserAvatars[steamId];
+                        return;
+                    }
+
+                    Avatar.Image = UserInterface.UnknownAvatar;
                     Avatar.ClearAnimations();
-                    Avatar.FadeTo(1, Easing.Linear, 400);
-
-                    Avatar.Image = SteamManager.UserAvatars[steamId];
-                    return;
+                    Avatar.Alpha = 0;
                 }
-
-                Avatar.Image = UserInterface.UnknownAvatar;
-                Avatar.ClearAnimations();
-                Avatar.Alpha = 0;
-            }
 
             SteamManager.SendAvatarRetrievalRequest(steamId);
         }
@@ -688,7 +690,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         {
             if (CantBeatAlert.Visible ||
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
-                ModHelper.GetRateFromMods(ModManager.Mods) == ModHelper.GetRateFromMods((ModIdentifier) Score.Item.Mods))
+                ModHelper.GetRateFromMods(ModManager.Mods) == ModHelper.GetRateFromMods((ModIdentifier)Score.Item.Mods))
             {
                 RequiredAccuracyAlert.Visible = false;
                 return;
@@ -727,17 +729,17 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
         /// <param name="e"></param>
         private void OnSteamAvatarLoaded(object sender, SteamAvatarLoadedEventArgs e)
         {
-            if (e.SteamId != (ulong) Score.Item.SteamId)
+            if (e.SteamId != (ulong)Score.Item.SteamId)
                 return;
 
             lock (Avatar)
-            lock (Avatar.Image)
-            {
-                Avatar.Alpha = 0;
-                Avatar.ClearAnimations();
-                Avatar.FadeTo(1, Easing.Linear, 400);
-                Avatar.Image = e.Texture;
-            }
+                lock (Avatar.Image)
+                {
+                    Avatar.Alpha = 0;
+                    Avatar.ClearAnimations();
+                    Avatar.FadeTo(1, Easing.Linear, 400);
+                    Avatar.Image = e.Texture;
+                }
         }
 
         /// <summary>
@@ -760,16 +762,37 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Components
 
         /// <summary>
         /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnAccuracyDisplayChanged(object sender, BindableValueChangedEventArgs<bool> e) =>
+            AddScheduledUpdate(() => UpdateAccuracyMaxCombo(Score));
+
+        /// <summary>
+        /// Called when <see cref="AccuracyMaxCombo"/> might need to be updated
+        /// </summary>
+        /// <param name="score"></param>
+        private void UpdateAccuracyMaxCombo(DrawableLeaderboardScore score)
+        {
+            if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Clan)
+                AccuracyMaxCombo.Text = $"{StringHelper.AccuracyToString((float)score.Item.Accuracy)}";
+            else if (ConfigManager.LeaderboardSection.Value == LeaderboardType.Local && ConfigManager.LeaderboardRankedAccuracy.Value)
+                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float)score.Item.RankedAccuracy)}";
+            else
+                AccuracyMaxCombo.Text = $"{score.Item.MaxCombo:N0}x | {StringHelper.AccuracyToString((float)score.Item.Accuracy)}";
+        }
+
+        /// <summary>
+        /// </summary>
         private void ActivateRequiredAccuracyTooltip()
         {
-            var game = (QuaverGame) GameBase.Game;
+            var game = (QuaverGame)GameBase.Game;
 
             var processor = new RatingProcessorKeys(MapManager.Selected.Value.DifficultyFromMods(ModManager.Mods));
 
             var requiredAcc = processor.GetAccuracyFromRating(Score.Item.PerformanceRating);
 
             var tooltip = new Tooltip("In order to beat this score with your current modifiers,\n" +
-                                      $"you must achieve higher than {StringHelper.AccuracyToString((float) requiredAcc)} accuracy.",
+                                      $"you must achieve higher than {StringHelper.AccuracyToString((float)requiredAcc)} accuracy.",
                 ColorHelper.HexToColor("#5dc7f9"));
 
             game.CurrentScreen.ActivateTooltip(tooltip);


### PR DESCRIPTION
Adds a configuration setting to replace accuracy for the `Local` leaderboard during song select with ranked accuracy (which all other leaderboards do by default). This makes switching judgement windows less awkward, since you can more easily see your own growth and determine a target (ranked) accuracy to aim for.

I considered merging this with `ConfigManager.DisplayRankedAccuracy`, but I did not since comparing scores and setting score are separate activities with separate requirements (e.g. I personally do not set `DisplayRankedAccuracy`, but would set this).

## Example
The higher PR play here uses `Extreme`, while the lower PR play uses `Standard*`.
<details>
    <summary>Disabled</summary>
    <img src="https://github.com/user-attachments/assets/ba3ebf66-f5d6-4d84-90f1-dd797cda2fb1"/>
</details>
<details>
    <summary>Enabled</summary>
    <img src="https://github.com/user-attachments/assets/7bbd09f5-dcdd-4772-88e8-900d445aa455"/>
</details>