### PR TITLE
Add toggle for disabling preview in multiplayer

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -258,6 +258,7 @@ namespace Quaver.Shared.Online
             Client.OnGameHealthTypeChanged += OnGameHealthTypeChanged;
             Client.OnGameLivesChanged += OnGameLivesChanged;
             Client.OnGameHostRotationChanged += OnGameHostRotationChanged;
+            Client.OnGameEnablePreviewChanged += OnGameEnablePreviewChanged;
             Client.OnGamePlayerTeamChanged += OnGamePlayerTeamChanged;
             Client.OnGameRulesetChanged += OnGameRulesetChanged;
             Client.OnGameLongNotePercentageChanged += OnGameLongNotePercentageChanged;
@@ -1029,6 +1030,18 @@ namespace Quaver.Shared.Online
                 return;
 
             CurrentGame.HostRotation = e.HostRotation;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private static void OnGameEnablePreviewChanged(object sender, EnablePreviewChangedEventArgs e)
+        {
+            if (CurrentGame == null)
+                return;
+
+            CurrentGame.EnablePreview = e.EnablePreview;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -344,7 +344,7 @@ namespace Quaver.Shared.Screens.Multi
         /// </summary>
         private void HandleKeyPressF3()
         {
-            if (!Game.Value.EnablePreview)
+            if (!Game.Value.EnablePreview && Game.Value.HostId != OnlineManager.Self.OnlineUser.Id)
             {
                 NotificationManager.Show(NotificationLevel.Warning, "Preview is disabled in this game!");
                 return;
@@ -465,7 +465,8 @@ namespace Quaver.Shared.Screens.Multi
 
         private void OnGameEnablePreviewChanged(object sender, EnablePreviewChangedEventArgs e)
         {
-            if (!e.EnablePreview && ActiveLeftPanel.Value is SelectContainerPanel.MapPreview)
+            if (!e.EnablePreview && ActiveLeftPanel.Value is SelectContainerPanel.MapPreview
+                                 && Game.Value.HostId != OnlineManager.Self.OnlineUser.Id)
             {
                 ActiveLeftPanel.Value = SelectContainerPanel.MatchSettings;
                 NotificationManager.Show(NotificationLevel.Info, "Map preview is disabled by host.");

--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -88,6 +88,7 @@ namespace Quaver.Shared.Screens.Multi
                 OnlineManager.Client.OnUserJoinedGame += OnUserJoinedGame;
                 OnlineManager.Client.OnUserLeftGame += OnUserLeftGame;
                 OnlineManager.Client.OnGameMaxPlayersChanged += OnMaxPlayersChanged;
+                OnlineManager.Client.OnGameEnablePreviewChanged += OnGameEnablePreviewChanged;
             }
 
             SetRichPresence();
@@ -145,6 +146,7 @@ namespace Quaver.Shared.Screens.Multi
                 OnlineManager.Client.OnUserJoinedGame -= OnUserJoinedGame;
                 OnlineManager.Client.OnUserLeftGame -= OnUserLeftGame;
                 OnlineManager.Client.OnGameMaxPlayersChanged -= OnMaxPlayersChanged;
+                OnlineManager.Client.OnGameEnablePreviewChanged -= OnGameEnablePreviewChanged;
             }
 
             base.Destroy();
@@ -342,6 +344,11 @@ namespace Quaver.Shared.Screens.Multi
         /// </summary>
         private void HandleKeyPressF3()
         {
+            if (!Game.Value.EnablePreview)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "Preview is disabled in this game!");
+                return;
+            }
             if (ActiveLeftPanel.Value != SelectContainerPanel.MapPreview)
                 ActiveLeftPanel.Value = SelectContainerPanel.MapPreview;
             else
@@ -443,6 +450,7 @@ namespace Quaver.Shared.Screens.Multi
                 },
                 RefereeUserId = 11,
                 HostRotation = true,
+                EnablePreview = true,
                 FreeModType = MultiplayerFreeModType.Regular,
             };
         }
@@ -454,5 +462,14 @@ namespace Quaver.Shared.Screens.Multi
         private void OnUserLeftGame(object sender, UserLeftGameEventArgs e) => SetRichPresence();
 
         private void OnMaxPlayersChanged(object sender, MaxPlayersChangedEventArgs e) => SetRichPresence();
+
+        private void OnGameEnablePreviewChanged(object sender, EnablePreviewChangedEventArgs e)
+        {
+            if (!e.EnablePreview && ActiveLeftPanel.Value is SelectContainerPanel.MapPreview)
+            {
+                ActiveLeftPanel.Value = SelectContainerPanel.MatchSettings;
+                NotificationManager.Show(NotificationLevel.Info, "Map preview is disabled by host.");
+            }
+        }
     }
 }

--- a/Quaver.Shared/Screens/Multiplayer/MultiplayerScreenView.cs
+++ b/Quaver.Shared/Screens/Multiplayer/MultiplayerScreenView.cs
@@ -236,6 +236,7 @@ namespace Quaver.Shared.Screens.Multiplayer
             new MultiplayerSettingsAutoHostRotation("Auto Host Rotation", MultiplayerSettingsText.BooleanToYesOrNo(OnlineManager.CurrentGame.HostRotation)),
             new MultiplayerSettingsFreeModType("Free Mod", MultiplayerSettingsFreeModType.FreeModTypeToString(MultiplayerFreeModType.Regular), MultiplayerFreeModType.Regular),
             new MultiplayerSettingsFreeModType("Free Rate", MultiplayerSettingsFreeModType.FreeModTypeToString(MultiplayerFreeModType.Rate), MultiplayerFreeModType.Rate),
+            new MultiplayerSettingsEnablePreview("Enable Preview", MultiplayerSettingsText.BooleanToYesOrNo(OnlineManager.CurrentGame.EnablePreview)),
             new MultiplayerSettingsHealthType("Health Type", ((MultiplayerHealthType) OnlineManager.CurrentGame.HealthType).ToString().Replace("_", " ")),
             new MultiplayerSettingsLives("Lives", OnlineManager.CurrentGame.Lives.ToString()),
             new MultiplayerSettingsAllowedGameModes("Allowed Game Modes", MultiplayerSettingsAllowedGameModes.AllowedModesToString(OnlineManager.CurrentGame.AllowedGameModes)),

--- a/Quaver.Shared/Screens/Multiplayer/UI/Settings/Items/MultiplayerSettingsEnablePreview.cs
+++ b/Quaver.Shared/Screens/Multiplayer/UI/Settings/Items/MultiplayerSettingsEnablePreview.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Quaver.Server.Client.Handlers;
+using Quaver.Shared.Graphics.Dialogs.Menu;
+using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Multiplayer.UI.Dialogs;
+
+namespace Quaver.Shared.Screens.Multiplayer.UI.Settings.Items
+{
+    public class MultiplayerSettingsEnablePreview : MultiplayerSettingsText
+    {
+        public MultiplayerSettingsEnablePreview(string name, string value) : base(name, value)
+        {
+            CreateDialog = () =>
+            {
+                OnlineManager.Client?.ChangeGameEnablePreview(!OnlineManager.CurrentGame.EnablePreview);
+                return null;
+            };
+
+            OnlineManager.Client.OnGameEnablePreviewChanged += OnGameEnablePreviewChanged;
+        }
+
+        public override void Destroy()
+        {
+            OnlineManager.Client.OnGameEnablePreviewChanged -= OnGameEnablePreviewChanged;
+            base.Destroy();
+        }
+
+        private void OnGameEnablePreviewChanged(object sender, EnablePreviewChangedEventArgs e)
+        {
+            Value.Text = BooleanToYesOrNo(e.EnablePreview);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Dialogs/Create/CreateGameDialog.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Dialogs/Create/CreateGameDialog.cs
@@ -249,7 +249,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Dialogs.Create
                 var alternativeMd5 = MapManager.Selected.Value.GetAlternativeMd5();
 
                 var game = MultiplayerGame.CreateCustom(MultiplayerGameType.Friendly, name, password, maxPlayers, map,
-                    mapId, mapsetId, ruleset, false, mode, difficultyRating, md5, difficultyRatings,
+                    mapId, mapsetId, ruleset, false, true, mode, difficultyRating, md5, difficultyRatings,
                     judgementCount, alternativeMd5);
 
                 OnlineManager.Client?.CreateMultiplayerGame(game);

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTable.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/DrawableMultiplayerTable.cs
@@ -113,6 +113,7 @@ namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
                 new MultiplayerTableItemFreeRate(game, isMultiplayer),
                 new MultiplayerTableItemAutoHost(game, isMultiplayer),
                 new MultiplayerTableItemAutoHostRotation(game, isMultiplayer),
+                new MultiplayerTableItemEnablePreview(game, isMultiplayer),
             });
 
             if (isMultiplayer)

--- a/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemEnablePreview.cs
+++ b/Quaver.Shared/Screens/MultiplayerLobby/UI/Selected/Table/MultiplayerTableItemEnablePreview.cs
@@ -1,0 +1,56 @@
+using Microsoft.Xna.Framework;
+using Quaver.Server.Client.Objects.Multiplayer;
+using Quaver.Shared.Graphics.Form;
+using Quaver.Shared.Online;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.MultiplayerLobby.UI.Selected.Table
+{
+    public sealed class MultiplayerTableItemEnablePreview : MultiplayerTableItem
+    {
+        public MultiplayerTableItemEnablePreview(Bindable<MultiplayerGame> game, bool isMultiplayer)
+            : base(game, isMultiplayer)
+        {
+            var checkbox = new MultiplayerEnablePreviewCheckbox(game);
+            Selector = checkbox;
+
+            if (OnlineManager.CurrentGame != null)
+                ClickAction = () => checkbox?.FireButtonClickEvent();
+        }
+
+        public override string GetName() => "Enable Preview";
+
+        public override string GetValue() => SelectedGame.Value.EnablePreview ? "Yes" : "No";
+    }
+
+    public class MultiplayerEnablePreviewCheckbox : QuaverCheckbox
+    {
+        /// <summary>
+        /// </summary>
+        private Bindable<MultiplayerGame> Game { get; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="game"></param>
+        public MultiplayerEnablePreviewCheckbox(Bindable<MultiplayerGame> game)
+            : base(new Bindable<bool>(game?.Value?.EnablePreview ?? false))
+        {
+            Game = game;
+
+            Clicked += (sender, args) =>
+            {
+                OnlineManager.Client.ChangeGameEnablePreview(BindedValue.Value);
+            };
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            base.Update(gameTime);
+            BindedValue.Value = Game?.Value?.EnablePreview ?? false;
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
@@ -28,7 +28,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Borders.Footer
                     }
                     else
                     {
-                        if (OnlineManager.CurrentGame is { EnablePreview: false })
+                        if (OnlineManager.CurrentGame is { EnablePreview: false, HostId: var host } &&
+                            host != OnlineManager.Self.OnlineUser.Id)
                             NotificationManager.Show(NotificationLevel.Warning, "Preview is disabled in this game!");
                         else
                             activeLeftPanel.Value = SelectContainerPanel.MapPreview;

--- a/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Borders/Footer/IconTextButtonMapPreview.cs
@@ -1,5 +1,7 @@
 using Quaver.Shared.Assets;
 using Quaver.Shared.Graphics.Menu.Border.Components;
+using Quaver.Shared.Graphics.Notifications;
+using Quaver.Shared.Online;
 using Wobble;
 using Wobble.Bindables;
 using Wobble.Managers;
@@ -25,7 +27,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Borders.Footer
                             activeLeftPanel.Value = SelectContainerPanel.Leaderboard;
                     }
                     else
-                        activeLeftPanel.Value = SelectContainerPanel.MapPreview;
+                    {
+                        if (OnlineManager.CurrentGame is { EnablePreview: false })
+                            NotificationManager.Show(NotificationLevel.Warning, "Preview is disabled in this game!");
+                        else
+                            activeLeftPanel.Value = SelectContainerPanel.MapPreview;
+                    }
                 })
         {
         }


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.Server.Client/pull/33 and https://github.com/Quaver/Z/pull/51

Adds an `Enable Preview` toggle on multiplayer lobby. This can only be toggled by the host. When disabled, all players [ ] except the host will be forbidden from previewing the map.


https://github.com/user-attachments/assets/77684e62-9fe8-41ad-82a7-cc2d2347e8ea
