### PR TITLE
Add support for a different hitobject sheet for lns

### DIFF
--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -744,10 +744,14 @@ namespace Quaver.Shared.Skinning
 
                     var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
-                      
-                    NoteHitObjects.Add(hitobjects);
 
-                    if (Directory.GetFiles($@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}").Any(file => new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet")).IsMatch(Path.GetFileName(file))))
+                    var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
+                    var files = Directory.GetFiles(dir);
+                    var holdsheetRegex = new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet"));
+
+                    NoteHitObjects.Add(hitobjects);
+                    
+                    if (files.Any(file => holdsheetRegex.IsMatch(Path.GetFileName(file))))
                         NoteHoldHitObjects.Add(holdobjects);
                     else
                         NoteHoldHitObjects.Add(hitobjects);
@@ -756,7 +760,7 @@ namespace Quaver.Shared.Skinning
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
-                            NoteHitObjects[i].Add(NoteHitObjects[i].Last());
+                        NoteHitObjects[i].Add(NoteHitObjects[i].Last());
 
                     for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
                         NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -744,19 +744,26 @@ namespace Quaver.Shared.Skinning
 
                     var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
-
-                    var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
-                    var files = Directory.GetFiles(dir);
-                    var holdsheetRegex = new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet"));
-
                     NoteHitObjects.Add(hitobjects);
                     
-                    if (files.Any(file => holdsheetRegex.IsMatch(Path.GetFileName(file))))
-                        NoteHoldHitObjects.Add(holdobjects);
-                    else
-                        NoteHoldHitObjects.Add(hitobjects);
+                    try
+                    {
+                        var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
+                        var files = Directory.GetFiles(dir);
+                        var holdsheetRegex = new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet"));
 
-                    
+
+
+                        if (files.Any(file => holdsheetRegex.IsMatch(Path.GetFileName(file))))
+                            NoteHoldHitObjects.Add(holdobjects);
+                        else
+                            NoteHoldHitObjects.Add(hitobjects);
+                    }
+                    catch (DirectoryNotFoundException e)
+                    {
+                        NoteHoldHitObjects.Add(hitobjects);
+                    }
+
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -746,28 +746,26 @@ namespace Quaver.Shared.Skinning
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
                     NoteHitObjects.Add(hitobjects);
                     
-                    try
+                    var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
+
+                    if (Directory.Exists(dir))
                     {
-                        var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
                         var files = Directory.GetFiles(dir);
                         var holdsheetRegex = new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet"));
-
-
 
                         if (files.Any(file => holdsheetRegex.IsMatch(Path.GetFileName(file))))
                             NoteHoldHitObjects.Add(holdobjects);
                         else
                             NoteHoldHitObjects.Add(hitobjects);
                     }
-                    catch (DirectoryNotFoundException e)
-                    {
+                    else
                         NoteHoldHitObjects.Add(hitobjects);
-                    }
+
 
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
-                        NoteHitObjects[i].Add(NoteHitObjects[i].Last());
+                            NoteHitObjects[i].Add(NoteHitObjects[i].Last());
 
                     for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
                         NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -742,9 +742,14 @@ namespace Quaver.Shared.Skinning
                     const int snapCount = 9;
 
                     var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
+                    var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
+                    if (holdobjects.Count == 1) // if the hold objects sheet does not exist then it is set to only hold one item with a value of null for some reason??
+                    {
+                        holdobjects=objects;
+                    }
 
                     NoteHitObjects.Add(objects);
-                    NoteHoldHitObjects.Add(objects);
+                    NoteHoldHitObjects.Add(holdobjects);
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -20,6 +20,7 @@ using Quaver.API.Enums;
 using Quaver.API.Helpers;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield.Health;
 using Quaver.Shared.Screens.Gameplay.UI.Bubble;
 using Quaver.Shared.Screens.Gameplay.UI.Health;
@@ -745,24 +746,12 @@ namespace Quaver.Shared.Skinning
                     var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
                     NoteHitObjects.Add(hitobjects);
-                    
-                    var dir = $@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}";
 
-                    if (Directory.Exists(dir))
-                    {
-                        var files = Directory.GetFiles(dir);
-                        var holdsheetRegex = new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet"));
-
-                        if (files.Any(file => holdsheetRegex.IsMatch(Path.GetFileName(file))))
-                            NoteHoldHitObjects.Add(holdobjects);
-                        else
-                            NoteHoldHitObjects.Add(hitobjects);
-                    }
+                    // LoadSpriteSheet returns one UserInterface.BlankBox on error
+                    if (holdobjects.Any() && holdobjects[0] != UserInterface.BlankBox)
+                        NoteHoldHitObjects.Add(holdobjects);
                     else
                         NoteHoldHitObjects.Add(hitobjects);
-
-
-
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
                         NoteHitObjects[i].Add(NoteHitObjects[i].Last());

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -745,7 +745,7 @@ namespace Quaver.Shared.Skinning
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
 
                     if (holdobjects.Count == 1)
-                        holdobjects=objects;
+                        holdobjects = objects;
 
                     NoteHitObjects.Add(objects);
                     NoteHoldHitObjects.Add(holdobjects);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -743,10 +743,9 @@ namespace Quaver.Shared.Skinning
 
                     var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
-                    if (holdobjects.Count == 1) // if the hold objects sheet does not exist then it is set to only hold one item with a value of null for some reason??
-                    {
+
+                    if (holdobjects.Count == 1)
                         holdobjects=objects;
-                    }
 
                     NoteHitObjects.Add(objects);
                     NoteHoldHitObjects.Add(holdobjects);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -744,7 +744,7 @@ namespace Quaver.Shared.Skinning
                     var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
 
-                    if (holdobjects.Count == 1)
+                    if (!File.Exists($"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}/note-holdobject-sheet@9x1.png"))
                         holdobjects = objects;
 
                     NoteHitObjects.Add(objects);

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -765,7 +765,7 @@ namespace Quaver.Shared.Skinning
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
-                            NoteHitObjects[i].Add(NoteHitObjects[i].Last());
+                        NoteHitObjects[i].Add(NoteHitObjects[i].Last());
 
                     for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
                         NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using IniFileParser;
 using IniFileParser.Model;
 using Microsoft.Xna.Framework;
@@ -741,18 +742,21 @@ namespace Quaver.Shared.Skinning
                 {
                     const int snapCount = 9;
 
-                    var objects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
+                    var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
                     var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
+                      
+                    NoteHitObjects.Add(hitobjects);
 
-                    if (!File.Exists($"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}/note-holdobject-sheet@9x1.png"))
-                        holdobjects = objects;
+                    if (Directory.GetFiles($@"{Store.Dir}/{ModeHelper.ToShortHand(Mode).ToLower()}/{SkinKeysFolder.HitObjects}").Any(file => new Regex(SkinStore.SpritesheetRegex("note-holdobject-sheet")).IsMatch(Path.GetFileName(file))))
+                        NoteHoldHitObjects.Add(holdobjects);
+                    else
+                        NoteHoldHitObjects.Add(hitobjects);
 
-                    NoteHitObjects.Add(objects);
-                    NoteHoldHitObjects.Add(holdobjects);
+                    
 
 
                     for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
-                        NoteHitObjects[i].Add(NoteHitObjects[i].Last());
+                            NoteHitObjects[i].Add(NoteHitObjects[i].Last());
 
                     for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
                         NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());


### PR DESCRIPTION
Closes #4445 

If note-holdobject-sheet@9x1.png exists it is now used, else fall back to the hitobject sheet if enabled.

(ln heads are inverted in example)
![image](https://github.com/user-attachments/assets/19279697-5dc7-4ed5-85c2-7216d4f1f9ca)
