### PR TITLE
Make wrapper tables over lists instead of copying them

### DIFF
--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -208,6 +208,7 @@ namespace Quaver.Shared.Scripting
             RegisterList<SoundEffectInfo>();
             RegisterList<HitObjectInfo>();
             RegisterList<BookmarkInfo>();
+            RegisterList<KeySoundInfo>();
             RegisterList<string>();
             UserData.RegisterType<nuint>();
             UserData.RegisterType<nint>();

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -200,10 +200,12 @@ namespace Quaver.Shared.Scripting
             RegisterWithConversion<Vector2>();
             RegisterWithConversion<Vector3>();
             RegisterWithConversion<Vector4>();
+            RegisterList<CustomAudioSampleInfo>();
             RegisterList<ScrollSpeedFactorInfo>();
             RegisterList<SliderVelocityInfo>();
             RegisterList<TimingPointInfo>();
             RegisterList<EditorLayerInfo>();
+            RegisterList<SoundEffectInfo>();
             RegisterList<HitObjectInfo>();
             RegisterList<BookmarkInfo>();
             RegisterList<string>();

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -200,6 +200,13 @@ namespace Quaver.Shared.Scripting
             RegisterWithConversion<Vector2>();
             RegisterWithConversion<Vector3>();
             RegisterWithConversion<Vector4>();
+            RegisterList<ScrollSpeedFactorInfo>();
+            RegisterList<SliderVelocityInfo>();
+            RegisterList<TimingPointInfo>();
+            RegisterList<EditorLayerInfo>();
+            RegisterList<HitObjectInfo>();
+            RegisterList<BookmarkInfo>();
+            RegisterList<string>();
             UserData.RegisterType<nuint>();
             UserData.RegisterType<nint>();
         }
@@ -368,8 +375,8 @@ namespace Quaver.Shared.Scripting
             var values = Enum.GetValues<T>();
 
             DynValue Inext(ScriptExecutionContext context, CallbackArguments args) =>
-                (int)args[1].Number + 1 is var x && x < values.Length
-                    ? DynValue.NewTuple(DynValue.NewNumber(x), DynValue.FromObject(context.OwnerScript, values[x]))
+                (int)args[1].Number + 1 is var x && x <= values.Length
+                    ? DynValue.NewTuple(DynValue.NewNumber(x), DynValue.FromObject(context.OwnerScript, values[x - 1]))
                     : DynValue.Nil;
 
             DynValue Next(ScriptExecutionContext context, CallbackArguments args)
@@ -423,6 +430,57 @@ namespace Quaver.Shared.Scripting
                     table[key] = value;
 
             return DynValue.NewTable(table).AsReadOnly();
+        }
+
+        private static void RegisterList<T>()
+        {
+            static DynValue ListNewIndex(ScriptExecutionContext _, CallbackArguments args) =>
+                throw new InvalidOperationException(
+                    "For performance reasons, this table must be immutable. Consider performing a deep copy to a new table to mutate instead."
+                );
+
+            Script.GlobalOptions.CustomConverters.SetClrToScriptCustomConversion(
+                typeof(List<T>),
+                (_, obj) =>
+                {
+                    var list = (List<T>)obj;
+
+                    DynValue ListIndex(ScriptExecutionContext s, CallbackArguments args) =>
+                        DynValue.FromObject(
+                            null,
+                            args.RawGet(1, false) is { Type: DataType.Number, Number: >= 1 and var x } &&
+                            x % 1 is 0 &&
+                            x <= list.Count
+                                ? list[(int)x - 1]
+                                : DynValue.Nil
+                        );
+
+                    DynValue ListLen(ScriptExecutionContext _, CallbackArguments __) => DynValue.NewNumber(list.Count);
+
+                    DynValue ListNext(ScriptExecutionContext context, CallbackArguments args) =>
+                        (int)args[1].Number + 1 is var x && x <= list.Count
+                            ? DynValue.NewTuple(DynValue.NewNumber(x), DynValue.FromObject(null, list[x - 1]))
+                            : DynValue.Nil;
+
+                    var next = DynValue.NewCallback(ListNext);
+
+                    DynValue ListPairs(ScriptExecutionContext context, CallbackArguments args) => next;
+
+                    return DynValue.NewTable(
+                        new Table(null)
+                        {
+                            MetaTable = new(null)
+                            {
+                                ["__len"] = ListLen,
+                                ["__pairs"] = ListPairs,
+                                ["__ipairs"] = ListPairs,
+                                ["__index"] = ListIndex,
+                                ["__newindex"] = ListNewIndex,
+                            }
+                        }
+                    );
+                }
+            );
         }
 
         /// <summary>


### PR DESCRIPTION
Improves complexity of `map.ScrollVelocities` and similar to `O(1)` (previously `O(n)`) by creating a table that has access to the underlying list, instead of copying each element one by one into a new `Table`. This substantially increases performance on existing plugins. However, it is a breaking change, mutation of these tables now results in an error. Currently, no known plugin relies on this behavior.

```lua
local svs = map.ScrollVelocities

-- Previously worked, now gives the error:
-- "For performance reasons, this table must be immutable. Consider performing a deep copy to a new table to mutate instead."
svs[1] = "foo"

-- What should be done instead
local new_svs = {}

for k, v in ipairs(svs) do
    new_svs[k] = v
end

new_svs[1] = "foo"
```