### PR TITLE
Implicitly convert timing group from strings in editor plugins

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using ImGuiNET;
 using MoonSharp.Interpreter;
 using Quaver.API.Enums;
+using Quaver.API.Maps.Structures;
 using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Edit.Actions;
 using Quaver.Shared.Scripting;
@@ -81,6 +82,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             IsWorkshop = isWorkshop;
             EditorPluginUtils.EditScreen = editScreen;
             EditorPluginMap = new EditorPluginMap();
+            Script.GlobalOptions.CustomConverters.SetScriptToClrCustomConversion(
+                DataType.String,
+                typeof(ScrollGroup),
+                x => EditorPluginMap.GetTimingGroup(x.String)
+            );
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Though a bit away from #4474 we now make it so that you can refer to timing groups by strings when feeding timing group parameters to plugin APIs:
```lua
actions.placeScrollVelocity(utils.createScrollVelocity(1000, 2), "$Global")
 ```
A simple test plugin is attached:
[a.zip](https://github.com/user-attachments/files/20589094/a.zip)

Resolves #4474