### PR TITLE
Playlist consistent sorting and indication when there is no maps

### DIFF
--- a/Quaver.Shared/Database/Playlists/PlaylistManager.cs
+++ b/Quaver.Shared/Database/Playlists/PlaylistManager.cs
@@ -172,7 +172,7 @@ namespace Quaver.Shared.Database.Playlists
 
                 Task.WaitAll(tasks.ToArray());
 
-                Playlists = Playlists.Concat(playlists).ToList();
+                Playlists = Playlists.Concat(playlists).OrderBy(x => x.Name).ToList();
 
                 foreach (var playlist in playlists)
                     Logger.Important($"Loaded Quaver playlist: {playlist.Name ?? ""} w/ {playlist.Maps?.Count ?? 0} maps!", LogType.Runtime);

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -224,7 +224,9 @@ namespace Quaver.Shared.Screens.Selection
                 ActiveScrollContainer.Value = SelectScrollContainerType.Playlists;
 
             // If the user is playing maps from a playlist, then automatically use the mapset container
-            if (PlaylistManager.Selected.Value != null && ConfigManager.SelectGroupMapsetsBy.Value == GroupMapsetsBy.Playlists)
+            // this is except when the selected playlist has no maps
+            if (PlaylistManager.Selected.Value != null && ConfigManager.SelectGroupMapsetsBy.Value == GroupMapsetsBy.Playlists
+                && PlaylistManager.Selected.Value.Maps.Count > 0)
                 ActiveScrollContainer.Value = SelectScrollContainerType.Mapsets;
         }
 

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -428,8 +428,7 @@ namespace Quaver.Shared.Screens.Selection
                     PlaylistContainer.MoveToX(inactivePosition, easing, animTime);
                     break;
                 case SelectScrollContainerType.Playlists:
-                    if (PlaylistManager.Playlists.Count != 0)
-                        PlaylistContainer.MoveToX(activePosition, easing, animTime);
+                    PlaylistContainer.MoveToX(activePosition, easing, animTime);
 
                     MapsetContainer.MoveToX(inactivePosition, easing, animTime);
                     MapContainer.MoveToX(inactivePosition, easing, animTime);

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistContainer.cs
@@ -2,12 +2,16 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Graphics.Containers;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;
 using Wobble.Bindables;
+using Wobble.Graphics;
+using Wobble.Graphics.Sprites.Text;
 using Wobble.Input;
+using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Selection.UI.Playlists
 {
@@ -36,6 +40,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// </summary>
         private bool HasReinitialized { get; set; }
 
+        /// <summary>
+        ///     Shows if there are no playlists
+        /// </summary>
+        private SpriteTextPlus NoPlaylistText { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -43,6 +52,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         public PlaylistContainer(Bindable<SelectScrollContainerType> activeScrollContainer) : base(PlaylistManager.Playlists, 12)
         {
             ActiveScrollContainer = activeScrollContainer;
+            NoPlaylistText = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoHeavy), "No playlists created!", 30)
+            {
+                Parent = this,
+                Alignment = Alignment.MidCenter,
+                Tint = Color.White,
+                Visible = PlaylistManager.Playlists.Count == 0
+            };
         }
 
         /// <inheritdoc />
@@ -155,6 +171,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
 
                 // Snap to it immediately
                 SnapToSelected();
+
+                NoPlaylistText.Visible = AvailableItems.Count == 0;
             }
 
             HasReinitialized = true;


### PR DESCRIPTION
Resolves #4457 
+ Sorts playlists alphabetically on startup
+ Shows a text indicating that there is no playlist created.
+ Prevents showing the list of maps of an empty playlist when first entering the selection screen

The latter two are to eliminate the confusion of players being shown 0 maps all of a sudden without realising they are viewing playlists.