### PR TITLE
Customizable LN Missed Release Judgements

### DIFF
--- a/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
+++ b/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.Shared.Config;
-using Quaver.Shared.Database.Settings;
-using SQLite;
 using Wobble.Bindables;
 using Wobble.Logging;
 
@@ -95,7 +94,7 @@ namespace Quaver.Shared.Database.Judgements
         {
             var windows = DatabaseManager.Connection.Table<JudgementWindows>().ToList();
             foreach (var w in windows)
-                w.LNMissJudgement ??= API.Enums.Judgement.Good;
+                w.LNMissJudgement ??= Judgement.Good;
             return windows;
         }
 

--- a/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
+++ b/Quaver.Shared/Database/Judgements/JudgementWindowsDatabaseCache.cs
@@ -93,7 +93,10 @@ namespace Quaver.Shared.Database.Judgements
         /// </summary>
         private static List<JudgementWindows> FetchAllWindows()
         {
-            return DatabaseManager.Connection.Table<JudgementWindows>().ToList();
+            var windows = DatabaseManager.Connection.Table<JudgementWindows>().ToList();
+            foreach (var w in windows)
+                w.LNMissJudgement ??= API.Enums.Judgement.Good;
+            return windows;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -608,6 +608,9 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             // The release window. (Window * Multiplier)
             var window = Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay] * Ruleset.ScoreProcessor.WindowReleaseMultiplier[Judgement.Okay];
 
+            // The judgement that is given when a user completely fails to release.
+            var missedReleaseJudgement = Ruleset.ScoreProcessor.Windows.LNMissJudgement;
+
             // Check to see if any LN releases were missed (Counts as a good instead of a miss.)
             foreach (var lane in HeldLongNoteLanes)
             {
@@ -615,9 +618,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 {
                     // Current hit object
                     var info = lane.Dequeue();
-
-                    // The judgement that is given when a user completely fails to release.
-                    var missedReleaseJudgement = Judgement.Good;
 
                     // Add new hit stat data and update score
                     var stat = new HitStat(HitStatType.Miss, KeyPressType.None, info.HitObjectInfo, info.EndTime, missedReleaseJudgement,

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -609,7 +609,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             var window = Ruleset.ScoreProcessor.JudgementWindow[Judgement.Okay] * Ruleset.ScoreProcessor.WindowReleaseMultiplier[Judgement.Okay];
 
             // The judgement that is given when a user completely fails to release.
-            var missedReleaseJudgement = Ruleset.ScoreProcessor.Windows.LNMissJudgement;
+            var missedReleaseJudgement = Ruleset.ScoreProcessor.Windows.LNMissJudgement.Value;
 
             // Check to see if any LN releases were missed (Counts as a good instead of a miss.)
             foreach (var lane in HeldLongNoteLanes)

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowComboBreakDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowComboBreakDropdown.cs
@@ -1,17 +1,29 @@
 ﻿using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
+using System.Collections.Generic;
 using Wobble.Bindables;
 
 namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 {
     public class JudgementWindowComboBreakDropdown : JudgementWindowDropdown
     {
+        // This dropdown excludes Marvelous (`(Judgement)0`), since that would entirely disable combo.
+        // This means we need to offset the dropdown value by one.
         protected override int Target
         {
             get => (int)SelectedWindow.Value.ComboBreakJudgement - 1;
             set => SelectedWindow.Value.ComboBreakJudgement = (Judgement)(value + 1);
         }
 
-        public JudgementWindowComboBreakDropdown(Bindable<JudgementWindows> selectedWindow) : base(selectedWindow, "Combo Break Judgement: ") { }
+        public JudgementWindowComboBreakDropdown(Bindable<JudgementWindows> selectedWindow) : base(selectedWindow, "Combo Break Judgement: ", GetDropdownItems()) { }
+
+        private static List<string> GetDropdownItems() => new()
+            {
+                "Perfect",
+                "Great",
+                "Good",
+                "Okay",
+                "Miss"
+            };
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowComboBreakDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowComboBreakDropdown.cs
@@ -1,62 +1,17 @@
-﻿using System.Collections.Generic;
-using Microsoft.Xna.Framework;
-using Quaver.API.Enums;
+﻿using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
-using Quaver.Shared.Graphics.Form.Dropdowns;
-using Quaver.Shared.Graphics.Form.Dropdowns.Custom;
-using Quaver.Shared.Helpers;
 using Wobble.Bindables;
-using Wobble.Graphics;
 
 namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 {
-    public class JudgementWindowComboBreakDropdown : LabelledDropdown
+    public class JudgementWindowComboBreakDropdown : JudgementWindowDropdown
     {
-        private Bindable<JudgementWindows> SelectedWindow { get; }
-
-        public JudgementWindowComboBreakDropdown(Bindable<JudgementWindows> selectedWindow) : base("Combo Break Judgement: ", 24,
-            new Dropdown(GetDropdownItems(), new ScalableVector2(150, 40), 24, ColorHelper.HexToColor("#10C8F6")))
+        protected override int Target
         {
-            SelectedWindow = selectedWindow;
-            SelectedWindow.ValueChanged += OnSelectedWindowChanged;
-            SetSelectedItem();
-
-            Dropdown.ItemSelected += OnItemSelected;
+            get => (int)SelectedWindow.Value.ComboBreakJudgement - 1;
+            set => SelectedWindow.Value.ComboBreakJudgement = (Judgement)(value + 1);
         }
 
-        public override void Update(GameTime gameTime)
-        {
-            if (SelectedWindow.Value.IsDefault && Dropdown.Opened)
-                Dropdown.Close();
-
-            Dropdown.IsClickable = !SelectedWindow.Value.IsDefault;
-            base.Update(gameTime);
-        }
-
-        public override void Destroy()
-        {
-            // ReSharper disable once DelegateSubtraction
-            SelectedWindow.ValueChanged -= OnSelectedWindowChanged;
-            base.Destroy();
-        }
-
-        private static List<string> GetDropdownItems() => new List<string>
-        {
-            "Perfect",
-            "Great",
-            "Good",
-            "Okay",
-            "Miss"
-        };
-
-        private void SetSelectedItem() => ScheduleUpdate(() =>
-        {
-            Dropdown.SelectItem(Dropdown.Items[(int) SelectedWindow.Value.ComboBreakJudgement - 1]);
-        });
-
-        private void OnSelectedWindowChanged(object sender, BindableValueChangedEventArgs<JudgementWindows> e) => SetSelectedItem();
-
-        private void OnItemSelected(object sender, DropdownClickedEventArgs e)
-            => SelectedWindow.Value.ComboBreakJudgement = (Judgement) (e.Index + 1);
+        public JudgementWindowComboBreakDropdown(Bindable<JudgementWindows> selectedWindow) : base(selectedWindow, "Combo Break Judgement: ") { }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
@@ -7,7 +7,6 @@ using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Database.Judgements;
-using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics.Form;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Scheduling;

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
@@ -92,7 +92,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 
         /// <summary>
         /// </summary>
-        private JudgementWindowComboBreakDropdown ComboBreak { get; set; }
+        private JudgementWindowDropdown ComboBreak { get; set; }
+
+        /// <summary>
+        /// </summary>
+        private JudgementWindowDropdown LNMiss { get; set; }
 
         /// <inheritdoc />
         /// <summary>
@@ -200,7 +204,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
             {
                 Parent = this,
                 Alignment = Alignment.MidCenter,
-                Size = new ScalableVector2(1308, 704),
+                Size = new ScalableVector2(1308, 724),
                 Image = UserInterface.JudgementWindowPanel
             };
         }
@@ -408,6 +412,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
                 Y = NameTextbox.Y - 10,
                 X = -22
             };
+
+            LNMiss = new JudgementWindowLNMissDropdown(JudgementWindowsDatabaseCache.Selected)
+            {
+                Parent = ContentBackground,
+                Alignment = Alignment.TopRight,
+                Y = NameTextbox.Y + ComboBreak.Height,
+                X = -22
+            };
         }
 
         /// <summary>
@@ -507,7 +519,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
                 {
                     Parent = ContentBackground,
                     X = JudgementWindowScrollContainer.Width + 22,
-                    Y = NameTextbox.Textbox.Y + NameTextbox.Textbox.Height + 70 + 80 * (int) judgement
+                    Y = NameTextbox.Textbox.Y + NameTextbox.Textbox.Height + 90 + 80 * (int) judgement
                 };
 
                 Sliders.Add(judgement, slider);

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
@@ -128,7 +128,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
             CreateJudgementWindowScrollContainer();
             CreateNameTextbox();
             CreateSliders();
-            CreateComboBreakDropdown();
+            CreateDropdowns();
 
             HandleButtonVisibility();
         }
@@ -402,7 +402,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
             NameTextbox.Textbox.Alignment = Alignment.MidLeft;
         }
 
-        private void CreateComboBreakDropdown()
+        private void CreateDropdowns()
         {
             LNMiss = new JudgementWindowLNMissDropdown(JudgementWindowsDatabaseCache.Selected)
             {

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDialog.cs
@@ -405,6 +405,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 
         private void CreateComboBreakDropdown()
         {
+            LNMiss = new JudgementWindowLNMissDropdown(JudgementWindowsDatabaseCache.Selected)
+            {
+                Parent = ContentBackground,
+                Alignment = Alignment.TopRight,
+                X = -22
+            };
+
             ComboBreak = new JudgementWindowComboBreakDropdown(JudgementWindowsDatabaseCache.Selected)
             {
                 Parent = ContentBackground,
@@ -413,13 +420,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
                 X = -22
             };
 
-            LNMiss = new JudgementWindowLNMissDropdown(JudgementWindowsDatabaseCache.Selected)
-            {
-                Parent = ContentBackground,
-                Alignment = Alignment.TopRight,
-                Y = NameTextbox.Y + ComboBreak.Height,
-                X = -22
-            };
+            LNMiss.Y = NameTextbox.Y + ComboBreak.Height;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Quaver.API.Enums;
+using Quaver.API.Maps.Processors.Scoring;
+using Quaver.Shared.Graphics.Form.Dropdowns;
+using Quaver.Shared.Graphics.Form.Dropdowns.Custom;
+using Quaver.Shared.Helpers;
+using Wobble.Bindables;
+using Wobble.Graphics;
+
+namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
+{
+    public abstract class JudgementWindowDropdown : LabelledDropdown
+    {
+        protected abstract int Target { get; set; }
+
+        protected Bindable<JudgementWindows> SelectedWindow { get; }
+
+        public JudgementWindowDropdown(Bindable<JudgementWindows> selectedWindow, string label, List<string>? options = null) : base(label, 24,
+            new Dropdown(options ?? GetDropdownItems(), new ScalableVector2(150, 40), 24, ColorHelper.HexToColor("#10C8F6")))
+        {
+            SelectedWindow = selectedWindow;
+            SelectedWindow.ValueChanged += OnSelectedWindowChanged;
+            SetSelectedItem();
+
+            Dropdown.ItemSelected += OnItemSelected;
+        }
+
+        public override void Update(GameTime gameTime)
+        {
+            if (SelectedWindow.Value.IsDefault && Dropdown.Opened)
+                Dropdown.Close();
+
+            Dropdown.IsClickable = !SelectedWindow.Value.IsDefault;
+            base.Update(gameTime);
+        }
+
+        public override void Destroy()
+        {
+            // ReSharper disable once DelegateSubtraction
+            SelectedWindow.ValueChanged -= OnSelectedWindowChanged;
+            base.Destroy();
+        }
+
+        private static List<string> GetDropdownItems() => new()
+            {
+                "Perfect",
+                "Great",
+                "Good",
+                "Okay",
+                "Miss"
+            };
+
+        private void SetSelectedItem() =>
+            ScheduleUpdate(() => Dropdown.SelectItem(Dropdown.Items[Target]));
+
+        private void OnSelectedWindowChanged(object sender, BindableValueChangedEventArgs<JudgementWindows> e) =>
+            SetSelectedItem();
+
+        private void OnItemSelected(object sender, DropdownClickedEventArgs e) =>
+            Target = e.Index;
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 
         protected Bindable<JudgementWindows> SelectedWindow { get; }
 
-        public JudgementWindowDropdown(Bindable<JudgementWindows> selectedWindow, string label, List<string>? options = null) : base(label, 24,
+        public JudgementWindowDropdown(Bindable<JudgementWindows> selectedWindow, string label, List<string> options = null) : base(label, 24,
             new Dropdown(options ?? GetDropdownItems(), new ScalableVector2(150, 40), 24, ColorHelper.HexToColor("#10C8F6")))
         {
             SelectedWindow = selectedWindow;

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowDropdown.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Graphics.Form.Dropdowns.Custom;
@@ -16,8 +15,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
 
         protected Bindable<JudgementWindows> SelectedWindow { get; }
 
-        public JudgementWindowDropdown(Bindable<JudgementWindows> selectedWindow, string label, List<string> options = null) : base(label, 24,
-            new Dropdown(options ?? GetDropdownItems(), new ScalableVector2(150, 40), 24, ColorHelper.HexToColor("#10C8F6")))
+        public JudgementWindowDropdown(Bindable<JudgementWindows> selectedWindow, string label, List<string> options) : base(label, 24,
+            new Dropdown(options, new ScalableVector2(150, 40), 24, ColorHelper.HexToColor("#10C8F6")))
         {
             SelectedWindow = selectedWindow;
             SelectedWindow.ValueChanged += OnSelectedWindowChanged;
@@ -41,15 +40,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
             SelectedWindow.ValueChanged -= OnSelectedWindowChanged;
             base.Destroy();
         }
-
-        private static List<string> GetDropdownItems() => new()
-            {
-                "Perfect",
-                "Great",
-                "Good",
-                "Okay",
-                "Miss"
-            };
 
         private void SetSelectedItem() =>
             ScheduleUpdate(() => Dropdown.SelectItem(Dropdown.Items[Target]));

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowLNMissDropdown.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowLNMissDropdown.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Quaver.API.Enums;
+using Quaver.API.Maps.Processors.Scoring;
+using Wobble.Bindables;
+
+namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
+{
+    public class JudgementWindowLNMissDropdown : JudgementWindowDropdown
+    {
+        protected override int Target
+        {
+            get => (int)SelectedWindow.Value.LNMissJudgement;
+            set => SelectedWindow.Value.LNMissJudgement = (Judgement)value;
+        }
+
+        public JudgementWindowLNMissDropdown(Bindable<JudgementWindows> selectedWindow) : base(selectedWindow, "LN Miss Judgement: ", GetDropdownItems()) { }
+
+        private static List<string> GetDropdownItems() => new()
+            {
+                "Marvelous",
+                "Perfect",
+                "Great",
+                "Good",
+                "Okay",
+                "Miss"
+            };
+    }
+}


### PR DESCRIPTION
Requires https://github.com/Quaver/Quaver.API/pull/202

Implements https://github.com/Quaver/Quaver/issues/4271, and should be usable for https://github.com/Quaver/Quaver/issues/4290 by setting it to Marvelous.

https://github.com/user-attachments/assets/ce9621df-2d2d-48e9-af7a-aacd20bd1cdd

Releasing an LN late will not give a worse judgement than never releasing it.
Additionally, if the judgement is set to Okay or Miss (i.e. stricter than default), it becomes possible to get an Okay by releasing within the relevant window.