### PR TITLE
fix trying to load non existant resource

### DIFF
--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -673,21 +673,24 @@ namespace Quaver.Shared.Skinning
         /// <param name="columns"></param>
         /// <param name="extension"></param>
         /// <returns></returns>
-        private List<Texture2D> LoadSpritesheet(SkinKeysFolder folder, string element, bool shared, int rows, int columns, string extension = ".png")
+        private List<Texture2D> LoadSpritesheet(SkinKeysFolder folder, string element, bool shared, int rows, int columns, bool noResource = false)
         {
-            string resource;
-            if (shared)
+            string resource = null;
+            if (!noResource)
             {
-                resource = $"Quaver.Resources/Textures/Skins/Shared/{folder.ToString()}/{element}";
-            }
-            else
-            {
-                resource = $"Quaver.Resources/Textures/Skins/{DefaultSkin}/{Mode.ToString()}/{folder.ToString()}" +
-                           $"/{GetResourcePath(element)}";
+                if (shared)
+                {
+                    resource = $"Quaver.Resources/Textures/Skins/Shared/{folder.ToString()}/{element}";
+                }
+                else
+                {
+                    resource = $"Quaver.Resources/Textures/Skins/{DefaultSkin}/{Mode.ToString()}/{folder.ToString()}" +
+                               $"/{GetResourcePath(element)}";
+                }
             }
 
             var folderName = shared ? folder.ToString() : $"/{ModeHelper.ToShortHand(Mode).ToLower()}/{folder.ToString()}/";
-            return Store.LoadSpritesheet(folderName, element, resource, rows, columns, extension);
+            return Store.LoadSpritesheet(folderName, element, resource, rows, columns);
         }
 
         /// <summary>
@@ -768,7 +771,7 @@ namespace Quaver.Shared.Skinning
                     const int snapCount = 9;
 
                     var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
-                    var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1);
+                    var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1, true);
                     NoteHitObjects.Add(hitobjects);
 
                     // LoadSpriteSheet returns one UserInterface.BlankBox on error

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -409,8 +409,7 @@ namespace Quaver.Shared.Skinning
         /// <param name="columns"></param>
         /// <param name="extension"></param>
         /// <returns></returns>
-        internal List<Texture2D> LoadSpritesheet(string folder, string element, string resource, int rows, int columns,
-            string extension = ".png")
+        internal List<Texture2D> LoadSpritesheet(string folder, string element, string resource, int rows, int columns)
         {
             try
             {
@@ -446,6 +445,9 @@ namespace Quaver.Shared.Skinning
                 // if 0x0 is specified for the default, then it'll simply load the element without rowsxcolumns
                 if (rows == 0 && columns == 0)
                     return new List<Texture2D> { LoadSingleTexture($"{dir}/{element}", resource + ".png") };
+
+                if (resource == null)
+                    return new List<Texture2D> { UserInterface.BlankBox };
 
                 return AssetLoader.LoadSpritesheetFromTexture(AssetLoader.LoadTexture2D(
                     GameBase.Game.Resources.Get($"{resource}@{rows}x{columns}.png")), rows, columns);
@@ -505,7 +507,7 @@ namespace Quaver.Shared.Skinning
         {
             // Load Grades
             HitBubbles = LoadSingleTexture($"{Dir}/HitBubbles/bubble", $"Quaver.Resources/Textures/Skins/Shared/HitBubbles/bubble.png");
-            
+
             var hitBubblesFolder = $"/HitBubbles/";
 
             const string bubblesBackground = "bubbles-background";
@@ -757,7 +759,7 @@ namespace Quaver.Shared.Skinning
             const string soundSelect = "sound-select";
             if (File.Exists($"{sfxFolder}/{soundSelect}.wav"))
                 SoundSelect = LoadSoundEffect($"{sfxFolder}/{soundSelect}", soundSelect, "Menu");
-            
+
             const string soundComboAlert = "sound-combo-alert";
             SoundComboAlerts = new List<AudioSample>();
 


### PR DESCRIPTION
fixes:
```
RUNTIME - ERROR: System.ArgumentNullException: Buffer cannot be null. (Parameter 'buffer')
   at System.IO.MemoryStream..ctor(Byte[] buffer, Boolean writable)
   at System.IO.MemoryStream..ctor(Byte[] buffer)
   at Wobble.Assets.AssetLoader.LoadTexture2D(Byte[] data)
   at Quaver.Shared.Skinning.SkinStore.LoadSpritesheet(String folder, String element, String resource, Int32 rows, Int32 columns, String extension)
```
when loading a skin without note-holdobject-sheet