### PR TITLE
optimize skin loading

### DIFF
--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -528,8 +528,8 @@ namespace Quaver.Shared.Skinning
             HoldLightingScale = ConfigHelper.ReadInt32(HitLightingScale, ini["HoldLightingScale"]);
             HitBubbleScale = ConfigHelper.ReadFloat(HitBubbleScale, ini["HitBubbleScale"]);
             HitBubblesAlignment = ConfigHelper.ReadEnum(HitBubblesAlignment, ini["HitBubblesAlignment"]);
-            HitBubblesPosX = ConfigHelper.ReadInt32((int) HitBubblesPosX, ini["HitBubblesPosX"]);
-            HitBubblesPosY = ConfigHelper.ReadInt32((int) HitBubblesPosY, ini["HitBubblesPosY"]);
+            HitBubblesPosX = ConfigHelper.ReadInt32((int)HitBubblesPosX, ini["HitBubblesPosX"]);
+            HitBubblesPosY = ConfigHelper.ReadInt32((int)HitBubblesPosY, ini["HitBubblesPosY"]);
             HitBubblesScale = ConfigHelper.ReadFloat(HitBubblesScale, ini["HitBubblesScale"]);
             HitBubbleBorderPadding = ConfigHelper.ReadFloat(HitBubbleBorderPadding, ini["HitBubbleBorderPadding"]);
             HitBubblePadding = ConfigHelper.ReadFloat(HitBubblePadding, ini["HitBubblePadding"]);
@@ -660,7 +660,7 @@ namespace Quaver.Shared.Skinning
             }
 
             var folderName = shared ? folder.ToString() : $"/{ModeHelper.ToShortHand(Mode).ToLower()}/{folder.ToString()}";
-            return SkinStore.LoadSingleTexture($"{Store.Dir}/{folderName}/{element}", resource);
+            return Store.LoadSingleTexture($"{Store.Dir}/{folderName}/{element}", resource);
         }
 
         /// <summary>
@@ -768,23 +768,34 @@ namespace Quaver.Shared.Skinning
                 }
                 else
                 {
-                    const int snapCount = 9;
+                    if (i == 0)
+                    {
 
-                    var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
-                    var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1, true);
-                    NoteHitObjects.Add(hitobjects);
+                        const int snapCount = 9;
 
-                    // LoadSpriteSheet returns one UserInterface.BlankBox on error
-                    if (holdobjects.Any() && holdobjects[0] != UserInterface.BlankBox)
-                        NoteHoldHitObjects.Add(holdobjects);
+                        var hitobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-hitobject-sheet", false, snapCount, 1);
+                        var holdobjects = LoadSpritesheet(SkinKeysFolder.HitObjects, "note-holdobject-sheet", false, snapCount, 1, true);
+                        NoteHitObjects.Add(hitobjects);
+
+                        // LoadSpriteSheet returns one UserInterface.BlankBox on error
+                        if (holdobjects.Any() && holdobjects[0] != UserInterface.BlankBox)
+                            NoteHoldHitObjects.Add(holdobjects);
+                        else
+                            NoteHoldHitObjects.Add(hitobjects);
+
+                        for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
+                            NoteHitObjects[i].Add(NoteHitObjects[i].Last());
+
+                        for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
+                            NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());
+                    }
                     else
-                        NoteHoldHitObjects.Add(hitobjects);
-
-                    for (var j = 0; j < snapCount - NoteHitObjects[i].Count; j++)
-                        NoteHitObjects[i].Add(NoteHitObjects[i].Last());
-
-                    for (var j = 0; j < snapCount - NoteHoldHitObjects[i].Count; j++)
-                        NoteHoldHitObjects[i].Add(NoteHoldHitObjects[i].Last());
+                    {
+                        // no need to load the same image several times
+                        // should also reduce memory usage slightly
+                        NoteHitObjects.Add(NoteHitObjects[0]);
+                        NoteHoldHitObjects.Add(NoteHoldHitObjects[0]);
+                    }
                 }
 
                 // LNS

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -7,9 +7,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using IniFileParser;
 using IniFileParser.Model;
@@ -50,6 +52,10 @@ namespace Quaver.Shared.Skinning
                 return $"{ConfigManager.SteamWorkshopDirectory.Value}/{Skin}";
             }
         }
+
+        // byte[].GetHashCode() is unreliable so we use int instead
+        private readonly Dictionary<int, Texture2D> _textureCache = new();
+        private int _cacheCount = 0;
 
         /// <summary>
         ///     The skin.ini file.
@@ -297,15 +303,25 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         internal SkinStore(string skin = null)
         {
+            Stopwatch totalSW = new();
+            Stopwatch k4SW = new();
+            Stopwatch k7SW = new();
+            totalSW.Restart();
+
             Skin = string.IsNullOrEmpty(skin) ? ConfigManager.Skin?.Value : skin;
             LoadConfig();
 
             // Load up Keys game mode skins.
-            Keys = new Dictionary<GameMode, SkinKeys>
-            {
-                {GameMode.Keys4, new SkinKeys(this, GameMode.Keys4)},
-                {GameMode.Keys7, new SkinKeys(this, GameMode.Keys7)}
-            };
+            Keys = new Dictionary<GameMode, SkinKeys>();
+
+            k4SW.Restart();
+            Keys.Add(GameMode.Keys4, new SkinKeys(this, GameMode.Keys4));
+            k4SW.Stop();
+            int k4CacheHits = _cacheCount;
+            k7SW.Restart();
+            Keys.Add(GameMode.Keys7, new SkinKeys(this, GameMode.Keys7));
+            k7SW.Stop();
+            int k7CacheHits = _cacheCount;
 
 
             try
@@ -325,6 +341,14 @@ namespace Quaver.Shared.Skinning
             // Change cursor image.
             GameBase.Game.GlobalUserInterface.Cursor.Image = Cursor;
             GameBase.Game.GlobalUserInterface.Cursor.Center = CenterCursor;
+
+            totalSW.Stop();
+
+            Logger.Important($"skin loading times:\n" +
+                $"total: {(double)totalSW.ElapsedTicks / Stopwatch.Frequency * 1000d:0.00} [{_cacheCount}]\n" +
+                $"4k: {(double)k4SW.ElapsedTicks / Stopwatch.Frequency * 1000d:0.00} [{k4CacheHits}]\n" +
+                $"7k: {(double)k7SW.ElapsedTicks / Stopwatch.Frequency * 1000d:0.00} [{k7CacheHits - k4CacheHits}]",
+            LogType.Runtime);
         }
 
         /// <summary>
@@ -376,21 +400,51 @@ namespace Quaver.Shared.Skinning
             LoadSoundEffects();
         }
 
+        private Texture2D GetTextureFromCacheOr(byte[] buffer, Func<byte[], Texture2D> func)
+        {
+            var md5 = MD5.HashData(buffer);
+
+            var hash = new HashCode();
+            hash.AddBytes(md5);
+            int hc = hash.ToHashCode();
+
+            if (_textureCache.ContainsKey(hc))
+            {
+                _cacheCount++;
+                return _textureCache[hc];
+            }
+
+            Texture2D texture = func(buffer);
+            _textureCache.Add(hc, texture);
+            return texture;
+        }
+
         /// <summary>
         ///     Loads a single texture element.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="resource"></param>
         /// <param name="extension"></param>
-        internal static Texture2D LoadSingleTexture(string path, string resource, string extension = ".png")
+        internal Texture2D LoadSingleTexture(string path, string resource, string extension = ".png")
         {
             path += extension;
 
             try
             {
-                return File.Exists(path) ? AssetLoader.LoadTexture2DFromFile(path) :
-                    GameBase.Game.Resources.Get(resource) is { } buffer ? AssetLoader.LoadTexture2D(buffer) :
-                    UserInterface.BlankBox;
+                byte[] buffer;
+                if (File.Exists(path))
+                {
+                    buffer = File.ReadAllBytes(path);
+                }
+                else
+                {
+                    buffer = GameBase.Game.Resources.Get(resource);
+                    if (buffer == null)
+                    {
+                        return UserInterface.BlankBox;
+                    }
+                }
+                return GetTextureFromCacheOr(buffer, AssetLoader.LoadTexture2D);
             }
             catch (Exception)
             {
@@ -427,8 +481,10 @@ namespace Quaver.Shared.Skinning
                         // See if the file matches the regex.
                         if (match.Success)
                         {
+                            byte[] file = File.ReadAllBytes(f);
+
                             // Load it up if so.
-                            var texture = AssetLoader.LoadTexture2DFromFile(f);
+                            var texture = GetTextureFromCacheOr(file, AssetLoader.LoadTexture2D);
 
                             return AssetLoader.LoadSpritesheetFromTexture(texture, int.Parse(match.Groups[1].Value),
                                 int.Parse(match.Groups[2].Value));


### PR DESCRIPTION
[cache hits] bigger = better

default arrow
```
before
total: 248.58
4k:    88.64
7k:    113.32

after
total: 95.41 [31]
4k:    27.82 [3]
7k:    19.90 [23]
```

my skin (alot of duplicate textures)
```
before
total: 313.88
4k:    69.92
7k:    119.83

after
total: 178.04 [90]
4k:    25.95  [66]
7k:    26.78  [19]
```