### PR TITLE
Fix EditorPluginUtils.EditScreen being set to null when destroying EditScreen A after creation of EditScreen B

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -364,6 +364,7 @@ namespace Quaver.Shared.Screens.Edit
         /// </summary>
         public EditScreen(Map map, IAudioTrack track = null, EditorVisualTestBackground visualTestBackground = null)
         {
+            EditorPluginUtils.EditScreen = this;
             Map = map;
             BackgroundStore = visualTestBackground;
 
@@ -569,7 +570,8 @@ namespace Quaver.Shared.Screens.Edit
             View = null;
             ActionManager = null;
             BackupScheduler = null;
-            EditorPluginUtils.EditScreen = null;
+            if (EditorPluginUtils.EditScreen == this)
+                EditorPluginUtils.EditScreen = null;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -80,7 +80,6 @@ namespace Quaver.Shared.Screens.Edit.Plugins
             IsBuiltIn = isResource;
             Directory = directory;
             IsWorkshop = isWorkshop;
-            EditorPluginUtils.EditScreen = editScreen;
             EditorPluginMap = new EditorPluginMap();
             Script.GlobalOptions.CustomConverters.SetScriptToClrCustomConversion(
                 DataType.String,


### PR DESCRIPTION
As title says, this fixes the issue where, when switching from `EditScreen A` to `EditScreen B`, since B is created before A got destroyed, `EditorPluginUtils.EditScreen` will first be set to `EditScreen B` upon creation, but then set to `null` when A got destoyed. This is what caused the BPM detection plugin to explode.