### PR TITLE
Revert "Add No-Fail to scores set with Keep Playing Upon Failing "

### DIFF
--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -124,8 +124,6 @@ namespace Quaver.Shared.Screens.Results
         /// </summary>
         public AudioSampleChannel ApplauseChannel { get; }
 
-        private bool removeNoFailOnExit = false;
-
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
@@ -250,9 +248,6 @@ namespace Quaver.Shared.Screens.Results
         /// </summary>
         public override void Destroy()
         {
-            if (removeNoFailOnExit)
-                ModManager.RemoveMod(ModIdentifier.NoFail);
-
             if (ApplauseChannel != null && ApplauseChannel.HasPlayed && !ApplauseChannel.HasStopped)
                 ApplauseChannel.Stop();
 
@@ -561,13 +556,6 @@ namespace Quaver.Shared.Screens.Results
         /// </summary>
         private void InitializeGameplayResultsScreen(GameplayScreen screen)
         {
-            if (screen.FailedDuringGameplay && ConfigManager.KeepPlayingUponFailing.Value)
-            {
-                ModManager.AddMod(ModIdentifier.NoFail);
-                screen.Ruleset.ScoreProcessor.Mods |= ModIdentifier.NoFail;
-                removeNoFailOnExit = true;
-            }
-
             Processor = new Bindable<ScoreProcessor>(screen.Ruleset.ScoreProcessor)
             {
                 Value =


### PR DESCRIPTION
Reverts Quaver/Quaver#4494

This implementation causes plays that would previously be correctly submitted as a pass to fail, in the case where the user passes on standard but fails on their own judge. I do not think we should have this behavior changed as it makes playing on higher judgement windows a lot stricter than before this update for no reason.