### PR TITLE
Add pitch toggle to be changed. Add new key bind to remove all mods

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -234,6 +234,18 @@ namespace Quaver.Shared.Config
         ///     Dictates whether or not the song audio is pitched while using the ManiaModSpeed gameplayModifier.
         /// </summary>
         internal static Bindable<bool> Pitched { get; private set; }
+        
+        /// <summary>
+        ///     Key to toggle the pitch of the audio
+        /// </summary>
+        
+        internal static Bindable<Keys> KeyTogglePitch { get; private set; }
+        
+        /// <summary>
+        ///     Key to remove all mods
+        /// </summary>
+        
+        internal static Bindable<Keys> KeyRemoveAllMods { get; private set; }
 
         /// <summary>
         ///     The path of the osu!.db file
@@ -1045,6 +1057,8 @@ namespace Quaver.Shared.Config
             DefaultSkin = ReadValue(@"DefaultSkin", DefaultSkins.Bar, data);
             DefaultEditorSkin = ReadValue<DefaultSkins?>(@"DefaultEditorSkin", null, data);
             Pitched = ReadValue(@"Pitched", true, data);
+            KeyTogglePitch = ReadValue(@"KeyTogglePitch", Keys.OemPipe, data);
+            KeyRemoveAllMods = ReadValue(@"KeyRemoveAllMods", Keys.D0, data);
             ScoreboardVisible = ReadValue(@"ScoreboardVisible", true, data);
             DisplayRankedAccuracy = ReadValue(@"DisplayRankedAccuracy", false, data);
             LeaderboardRankedAccuracy = ReadValue(@"LeaderboardRankedAccuracy", false, data);

--- a/Quaver.Shared/Modifiers/ModManager.cs
+++ b/Quaver.Shared/Modifiers/ModManager.cs
@@ -228,11 +228,13 @@ namespace Quaver.Shared.Modifiers
         /// </summary>
         public static void RemoveAllMods(bool invokeEvent = true)
         {
+            var oldMods = (Mods == 0) ? ModIdentifier.None : Mods; // Why does ModIdentifier.None = -1L and not 0
+
             CurrentModifiersList.Clear();
             CheckModInconsistencies();
             UpdateMultiplayerMods();
 
-            ModsChanged?.Invoke(typeof(ModManager), new ModsChangedEventArgs(ModChangeType.RemoveAll, Mods, ModIdentifier.None));
+            ModsChanged?.Invoke(typeof(ModManager), new ModsChangedEventArgs(ModChangeType.RemoveAll, Mods, oldMods));
 
             Logger.Debug("Removed all modifiers", LogType.Runtime, false);
         }

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -273,6 +273,8 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemKeybind(containerRect, "Decrease Gameplay Rate", ConfigManager.KeyDecreaseGameplayAudioRate),
                         new OptionsItemKeybind(containerRect, "Increase Gameplay Rate", ConfigManager.KeyIncreaseGameplayAudioRate),
                         new OptionsItemKeybind(containerRect, "Toggle Mirror Mod", ConfigManager.KeyToggleMirror),
+                        new OptionsItemKeybind(containerRect, "Toggle Pitch", ConfigManager.KeyTogglePitch),
+                        new OptionsItemKeybind(containerRect, "Remove All Mods", ConfigManager.KeyRemoveAllMods),
                     }),
                     new OptionsSubcategory("Editor", new List<OptionsItem>()
                     {

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -437,8 +437,12 @@ namespace Quaver.Shared.Screens.Selection
                 ModManager.AddSpeedMods(GetNextRate(false, shiftHeld));
 
             // Change from pitched to non-pitched
-            if (KeyboardManager.IsUniqueKeyPress(Keys.D0))
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyTogglePitch.Value))
                 ConfigManager.Pitched.Value = !ConfigManager.Pitched.Value;
+            
+            // Remove all mods
+            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyRemoveAllMods.Value))
+                ModManager.RemoveAllMods();
 
             // Toggle Mirror
             if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyToggleMirror.Value))

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -433,29 +433,25 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         /// <param name="e"></param>
         private void OnModsChanged(object sender, ModsChangedEventArgs e)
         {
-            var isNone = e.ChangedMods.HasFlag(ModIdentifier.None);
+            if (e.ChangedMods.HasFlag(ModIdentifier.None)) // why is ModIdentifier.None not 0
+                return;
 
-            if (!isNone)
-            {
-                if (e.ChangedMods.HasFlag(ModIdentifier.Autoplay) || e.ChangedMods.HasFlag(ModIdentifier.Coop) || e.ChangedMods.HasFlag(ModIdentifier.Randomize))
-                    return;
-            }
-
-            var isSpeedMod = e.ChangedMods >= ModIdentifier.Speed05X && e.ChangedMods <= ModIdentifier.Speed20X ||
-                             e.ChangedMods >= ModIdentifier.Speed055X && e.ChangedMods <= ModIdentifier.Speed095X ||
-                             e.ChangedMods >= ModIdentifier.Speed105X && e.ChangedMods <= ModIdentifier.Speed195X || isNone;
-
-            if (isSpeedMod)
+            if ((e.ChangedMods & ModIdentifier.SpeedMods) != 0)
             {
                 ScheduleUpdate(() =>
                 {
                     CreateSeekBar(LoadedGameplayScreen?.Map, (GameplayPlayfieldKeys)LoadedGameplayScreen?.Ruleset?.Playfield, false);
                 });
-                return;
             }
 
-            // Reload the entire
-            RunLoadTask();
+            var reloadTriggers = e.ChangedMods
+                                 & ~ModIdentifier.SpeedMods
+                                 & ~ModIdentifier.Autoplay
+                                 & ~ModIdentifier.Coop
+                                 & ~ModIdentifier.Randomize;
+
+            if (reloadTriggers != 0) //  once again why is ModIdentifier.None not 0
+                RunLoadTask();
         }
 
         /// <summary>


### PR DESCRIPTION
We change the default pitch key toggle from `0` (Zero) to `\` (Slash) 
Remove all mods now uses `0` as default.

Both can be changed from Options, if someone wants to use 0 as their pitch toggle key.

Also closes https://github.com/Quaver/Quaver/issues/2861