### PR TITLE
Prevent fullscreen on MacOS

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -453,20 +453,13 @@ namespace Quaver.Shared
             ConfigManager.FpsLimiterType.ValueChanged += (sender, e) => InitializeFpsLimiting();
             ConfigManager.CustomFpsLimit.ValueChanged += (sender, e) => InitializeFpsLimiting();
             
-            bool suppressWindowFullScreenEvent = false;
-            
             ConfigManager.WindowFullScreen.ValueChanged += (sender, e) =>
             {
-                if (suppressWindowFullScreenEvent)
-                    return;
-                
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    NotificationManager.Show(NotificationLevel.Info, "Full screen mode is not supported on macOS. Please use the borderless window mode instead.");
+                    NotificationManager.Show(NotificationLevel.Info, "Full screen is not supported on macOS. Use the borderless window mode instead.");
                     
-                    suppressWindowFullScreenEvent = true;
-                    ConfigManager.WindowFullScreen.Value = false;
-                    suppressWindowFullScreenEvent = false;
+                    ConfigManager.WindowFullScreen.ChangeWithoutTrigger(!ConfigManager.WindowFullScreen.Value);
                 }
                 else
                 {

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -452,7 +452,28 @@ namespace Quaver.Shared
 
             ConfigManager.FpsLimiterType.ValueChanged += (sender, e) => InitializeFpsLimiting();
             ConfigManager.CustomFpsLimit.ValueChanged += (sender, e) => InitializeFpsLimiting();
-            ConfigManager.WindowFullScreen.ValueChanged += (sender, e) => Graphics.IsFullScreen = e.Value;
+            
+            bool suppressWindowFullScreenEvent = false;
+            
+            ConfigManager.WindowFullScreen.ValueChanged += (sender, e) =>
+            {
+                if (suppressWindowFullScreenEvent)
+                    return;
+                
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    NotificationManager.Show(NotificationLevel.Info, "Full screen mode is not supported on macOS. Please use the borderless window mode instead.");
+                    
+                    suppressWindowFullScreenEvent = true;
+                    ConfigManager.WindowFullScreen.Value = false;
+                    suppressWindowFullScreenEvent = false;
+                }
+                else
+                {
+                    Graphics.IsFullScreen = e.Value;
+                }
+            };
+            
             ConfigManager.WindowBorderless.ValueChanged += (sender, e) => Window.IsBorderless = e.Value;
             ConfigManager.SelectedGameMode.ValueChanged += (sender, args) =>
             {

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -459,7 +459,7 @@ namespace Quaver.Shared
                 {
                     NotificationManager.Show(NotificationLevel.Info, "Full screen is not supported on macOS. Use the borderless window mode instead.");
                     
-                    ConfigManager.WindowFullScreen.ChangeWithoutTrigger(!ConfigManager.WindowFullScreen.Value);
+                    ConfigManager.WindowFullScreen.ChangeWithoutTrigger(false);
                 }
                 else
                 {


### PR DESCRIPTION
Prevent fullscreen toggle on MacOS, due to it not being needed.
Plus prevents weird issues where if fullscreen is enabled, you cannot alt tab and switch between spaces.

Maximizing the window from MacOS still works and can be used as alternative to fullscreen.