### PR TITLE
Fix Map Search Ignoring Other Map Fields

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetHelper.cs
+++ b/Quaver.Shared/Database/Maps/MapsetHelper.cs
@@ -16,6 +16,7 @@ using Quaver.API.Helpers;
 using Quaver.Shared.Config;
 using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Helpers;
 using WilliamQiufeng.SearchParser.AST;
 using WilliamQiufeng.SearchParser.Parsing;
 using WilliamQiufeng.SearchParser.Tokenizing;
@@ -672,14 +673,14 @@ namespace Quaver.Shared.Database.Maps
                 var termContent = (string)searchQuery.Value.Value!;
                 try
                 {
-                    var containsText = !map.Artist.ToLower().Contains(termContent) &&
-                                       !map.Title.ToLower().Contains(termContent) &&
-                                       !map.Creator.ToLower().Contains(termContent) &&
-                                       !map.Source.ToLower().Contains(termContent) &&
-                                       !map.Description.ToLower().Contains(termContent) &&
-                                       !map.Tags.ToLower().Contains(termContent) &&
-                                       !map.DifficultyName.ToLower().Contains(termContent) &&
-                                       !map.Genre.ToLower().Contains(termContent);
+                    var containsText = !StringHelper.ContainsIgnoreCase(map.Artist, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Title, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Creator, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Source, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Description, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Tags, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.DifficultyName, termContent) &&
+                                    !StringHelper.ContainsIgnoreCase(map.Genre, termContent);
                     if (containsText)
                     {
                         return false;

--- a/Quaver.Shared/Helpers/StringHelper.cs
+++ b/Quaver.Shared/Helpers/StringHelper.cs
@@ -55,6 +55,15 @@ namespace Quaver.Shared.Helpers
         internal static string ColorToString(Color color) => $"{color.R},{color.G},{color.G},{color.A}";
 
         /// <summary>
+        ///     Returns a value indicating whether a specified string occurs within this string,
+        /// using ordinal (binary) sort rules and ignoring the case of the strings being compared..
+        /// </summary>
+        /// <param name="strA"></param>
+        /// <param name="strB"></param>
+        /// <returns></returns>
+        internal static bool ContainsIgnoreCase(string strA, string strB) => strA?.Contains(strB, StringComparison.OrdinalIgnoreCase) == true;
+
+        /// <summary>
         ///     Adds an ordinal to a string.
         /// </summary>
         /// <param name="num"></param>


### PR DESCRIPTION
Fix for:
- #4471 

## Cause of the bug:

in `MapsetHelper.cs` in ``MapsetHelper.EvaluateMapAgainstQuery``
```cs
var containsText = !map.Artist.ToLower().Contains(termContent) &&
                                       !map.Title.ToLower().Contains(termContent) &&
                                       !map.Creator.ToLower().Contains(termContent) &&
                                       !map.Source.ToLower().Contains(termContent) &&
                                       !map.Description.ToLower().Contains(termContent) &&
                                       !map.Tags.ToLower().Contains(termContent) &&
                                       !map.DifficultyName.ToLower().Contains(termContent) &&
                                       !map.Genre.ToLower().Contains(termContent);
```
Map fields can still be null so when a string is null, for example ``map.Description`` the other fields don't get checked as a result of a null reference exception. Which is exactly what happens in the original issue.

## Fix:

made a helper method in StringHelper for checking the containing text, Reason for the being:
1. no need to use ``string.ToLower`` because we check using ``string.Contains`` with a cmp type.
2. it looks very ugly without the function call.

also instead of just getting null references and discarding the exception, we gracefully handle null fields.
```cs
// line 689
                catch (Exception)
                {
                    // Some values can be null and they break the game.
                    return false;
                }
```

This is my first time contributing here, if there are any problems let me know.

Fixes #4471