### PR TITLE
Create SSF action hooks for plugins

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -524,7 +524,6 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Places a batch of scroll speed factors into the map
         /// </summary>
         /// <param name="sfs"></param>
-        public void PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup) => Perform(new EditorActionAddScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup));
         public void PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup, bool fromLua = false) => Perform(new EditorActionAddScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup), fromLua);
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -518,26 +518,27 @@ namespace Quaver.Shared.Screens.Edit.Actions
         ///     Places an sf down in the map
         /// </summary>
         /// <param name="sf"></param>
-        public void PlaceScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup) => Perform(new EditorActionAddScrollSpeedFactor(this, WorkingMap, sf, scrollGroup));
+        public void PlaceScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup, bool fromLua = false) => Perform(new EditorActionAddScrollSpeedFactor(this, WorkingMap, sf, scrollGroup), fromLua);
 
         /// <summary>
         ///     Places a batch of scroll speed factors into the map
         /// </summary>
         /// <param name="sfs"></param>
         public void PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup) => Perform(new EditorActionAddScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup));
+        public void PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup, bool fromLua = false) => Perform(new EditorActionAddScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup), fromLua);
 
         /// <summary>
         ///     Removes a batch of scroll speed factors from the map
         /// </summary>
         /// <param name="sfs"></param>
-        public void RemoveScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup) => Perform(new EditorActionRemoveScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup));
+        public void RemoveScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup, bool fromLua = false) => Perform(new EditorActionRemoveScrollSpeedFactorBatch(this, WorkingMap, sfs, scrollGroup), fromLua);
 
         /// <summary>
         ///     Changes the offset of a batch of scroll speed factors
         /// </summary>
         /// <param name="sfs"></param>
         /// <param name="offset"></param>
-        public void ChangeScrollSpeedFactorOffsetBatch(List<ScrollSpeedFactorInfo> sfs, float offset) => Perform(new EditorActionChangeScrollSpeedFactorOffsetBatch(this, WorkingMap, sfs, offset));
+        public void ChangeScrollSpeedFactorOffsetBatch(List<ScrollSpeedFactorInfo> sfs, float offset, bool fromLua = false) => Perform(new EditorActionChangeScrollSpeedFactorOffsetBatch(this, WorkingMap, sfs, offset), fromLua);
 
         /// <summary>
         ///     Changes the multiplier of a batch of scroll speed factors

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -112,6 +112,33 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
+        /// <param name="sf"></param>
+        /// <param name="scrollGroup"></param>
+        public void PlaceScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup) => ActionManager.PlaceScrollSpeedFactor(sf, scrollGroup, true);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sfs"></param>
+        /// <param name="scrollGroup"></param>
+        public void PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup) =>
+            ActionManager.PlaceScrollSpeedFactorBatch(sfs, scrollGroup, true);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sf"></param>
+        /// <param name="scrollGroup"></param>
+        public void RemoveScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup) =>
+            ActionManager.RemoveScrollSpeedFactorBatch(new List<ScrollSpeedFactorInfo> { sf }, scrollGroup, true);
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sfs"></param>
+        /// <param name="scrollGroup"></param>
+        public void RemoveScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup) =>
+            ActionManager.RemoveScrollSpeedFactorBatch(sfs, scrollGroup, true);
+
+        /// <summary>
+        /// </summary>
         /// <param name="tp"></param>
         public void PlaceTimingPoint(TimingPointInfo tp) => ActionManager.PlaceTimingPoint(tp, true);
 

--- a/Quaver.Shared/Screens/Edit/Actions/SF/Add/EditorActionAddScrollSpeedFactor.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SF/Add/EditorActionAddScrollSpeedFactor.cs
@@ -18,7 +18,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SF.Add
 
         public ScrollGroup ScrollGroup { get; }
 
-        private ScrollSpeedFactorInfo ScrollSpeedFactor { get; }
+        public ScrollSpeedFactorInfo ScrollSpeedFactor { get; }
 
         [MoonSharpVisible(false)]
         public EditorActionAddScrollSpeedFactor(EditorActionManager manager, Qua workingMap, ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup)

--- a/Quaver.Shared/Screens/Edit/Actions/SF/AddBatch/EditorActionAddScrollSpeedFactorBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SF/AddBatch/EditorActionAddScrollSpeedFactorBatch.cs
@@ -17,7 +17,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SF.AddBatch
 
         private Qua WorkingMap { get; }
 
-        private List<ScrollSpeedFactorInfo> ScrollSpeedFactors { get; }
+        public List<ScrollSpeedFactorInfo> ScrollSpeedFactors { get; }
 
         public ScrollGroup ScrollGroup { get; }
 

--- a/Quaver.Shared/Screens/Edit/Actions/SF/Remove/EditorActionRemoveScrollSpeedFactor.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SF/Remove/EditorActionRemoveScrollSpeedFactor.cs
@@ -15,7 +15,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SF.Remove
 
         private Qua WorkingMap { get; }
 
-        private ScrollSpeedFactorInfo ScrollSpeedFactor { get; }
+        public ScrollSpeedFactorInfo ScrollSpeedFactor { get; }
 
         public ScrollGroup ScrollGroup { get; }
 

--- a/Quaver.Shared/Screens/Edit/Actions/SF/RemoveBatch/EditorActionRemoveScrollSpeedFactorBatch.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/SF/RemoveBatch/EditorActionRemoveScrollSpeedFactorBatch.cs
@@ -16,7 +16,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SF.RemoveBatch
 
         private Qua WorkingMap { get; }
 
-        private List<ScrollSpeedFactorInfo> ScrollSpeedFactors { get; }
+        public List<ScrollSpeedFactorInfo> ScrollSpeedFactors { get; }
 
         public ScrollGroup ScrollGroup { get; }
 
@@ -32,9 +32,7 @@ namespace Quaver.Shared.Screens.Edit.Actions.SF.RemoveBatch
         [MoonSharpVisible(false)]
         public void Perform()
         {
-            foreach (var sf in ScrollSpeedFactors)
-                ScrollGroup.ScrollSpeedFactors.Remove(sf);
-
+            ScrollGroup.ScrollSpeedFactors.RemoveAll(sf => ScrollSpeedFactors.Contains(sf));
             ActionManager.TriggerEvent(Type, new EditorScrollSpeedFactorBatchRemovedEventArgs(ScrollSpeedFactors, ScrollGroup));
         }
 


### PR DESCRIPTION
Saw a minor inconsistency that all object types EXCEPT SSFs had their associated actions (without the need to run Perform or PerformBatch). This PR adds four new methods:
```cs
action.PlaceScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup)
action.PlaceScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup)
action.RemoveScrollSpeedFactor(ScrollSpeedFactorInfo sf, ScrollGroup scrollGroup)
action.RemoveScrollSpeedFactorBatch(List<ScrollSpeedFactorInfo> sfs, ScrollGroup scrollGroup)
```
All of the above methods were implemented in the same way as their SV counterparts, and I only publicized some fields of the associated action classes.