### PR TITLE
Per map scroll speed overriding

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -212,6 +212,12 @@ namespace Quaver.Shared.Database.Maps
         ///     Retroactively fixed offset for ranked maps.
         /// </summary>
         public int OnlineOffset { get; set; }
+        
+        /// <summary>
+        ///     Fixed custom scroll speed for this map.
+        ///     If 0, uses the user's scroll speed.
+        /// </summary>
+        public int CustomScrollSpeed { get; set; }
 
         /// <summary>
         ///    Returns the notes per second a map has

--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -214,6 +214,12 @@ namespace Quaver.Shared.Database.Maps
         public int OnlineOffset { get; set; }
         
         /// <summary>
+        ///     Default value for CustomScrollSpeed.
+        ///     If this is used, the scroll speed will be determined by the user's global settings instead.
+        /// </summary>
+        public const int DefaultCustomScrollSpeed = 0;
+
+        /// <summary>
         ///     Fixed custom scroll speed for this map.
         ///     If 0, uses the user's scroll speed.
         /// </summary>

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -40,11 +40,6 @@ namespace Quaver.Shared.Database.Maps
     public static class MapManager
     {
         /// <summary>
-        ///     Default value for CustomScrollSpeed.
-        ///     If this is used, the scroll speed will be determined by the user's global settings instead.
-        /// </summary>
-        private const int DefaultCustomScrollSpeed = 0;
-        /// <summary>
         ///     The currently selected map.
         /// </summary>
         public static Bindable<Map> Selected { get; set; } = new Bindable<Map>(null);
@@ -599,7 +594,7 @@ namespace Quaver.Shared.Database.Maps
             get
             {
                 var scrollSpeed = Selected.Value?.CustomScrollSpeed;
-                return scrollSpeed == DefaultCustomScrollSpeed ? null : scrollSpeed;
+                return scrollSpeed == Map.DefaultCustomScrollSpeed ? null : scrollSpeed;
             }
             set
             {
@@ -608,7 +603,7 @@ namespace Quaver.Shared.Database.Maps
                 if (map == null)
                     return;
 
-                map.CustomScrollSpeed = value ?? DefaultCustomScrollSpeed;
+                map.CustomScrollSpeed = value ?? Map.DefaultCustomScrollSpeed;
 
                 // Update the map in the background
                 ThreadScheduler.Run(() => MapDatabaseCache.UpdateMap(map));

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -588,6 +588,11 @@ namespace Quaver.Shared.Database.Maps
             );
 
         /// <summary>
+        ///     The custom scroll speed for the selected map.
+        ///     Null indicates that the selected map does not have a custom scroll speed,
+        ///     and therefore should use the global one.
+        ///
+        ///     Setting this to null will reset the map's custom scroll speed to the global one.
         /// </summary>
         public static int? CustomScrollSpeed
         {

--- a/Quaver.Shared/Database/Maps/MapManager.cs
+++ b/Quaver.Shared/Database/Maps/MapManager.cs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
-*/
+ */
 
 using System;
 using System.Collections.Generic;
@@ -26,6 +26,7 @@ using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Online.API.Maps;
+using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Selection.UI.Maps;
 using RestSharp;
 using RestSharp.Extensions;
@@ -38,6 +39,11 @@ namespace Quaver.Shared.Database.Maps
 {
     public static class MapManager
     {
+        /// <summary>
+        ///     Default value for CustomScrollSpeed.
+        ///     If this is used, the scroll speed will be determined by the user's global settings instead.
+        /// </summary>
+        private const int DefaultCustomScrollSpeed = 0;
         /// <summary>
         ///     The currently selected map.
         /// </summary>
@@ -580,5 +586,28 @@ namespace Quaver.Shared.Database.Maps
                     onYes
                 )
             );
+
+        /// <summary>
+        /// </summary>
+        public static int? CustomScrollSpeed
+        {
+            get
+            {
+                var scrollSpeed = Selected.Value?.CustomScrollSpeed;
+                return scrollSpeed == DefaultCustomScrollSpeed ? null : scrollSpeed;
+            }
+            set
+            {
+                // Ignore if no map is selected
+                var map = Selected.Value;
+                if (map == null)
+                    return;
+
+                map.CustomScrollSpeed = value ?? DefaultCustomScrollSpeed;
+
+                // Update the map in the background
+                ThreadScheduler.Run(() => MapDatabaseCache.UpdateMap(map));
+            }
+        }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -510,6 +510,12 @@ namespace Quaver.Shared.Screens.Gameplay
                 ScreenExiting += (_, _) => SkinManager.StopWatching();
             }
 
+            if (!IsSongSelectPreview && MapManager.CustomScrollSpeed != null)
+            {
+                NotificationManager.Show(NotificationLevel.Info,
+                    $"Scroll speed (local) is set to: {MapManager.CustomScrollSpeed / 10:0.0}", forceShow: true);
+            }
+
             base.OnFirstUpdate();
         }
 

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -513,7 +513,7 @@ namespace Quaver.Shared.Screens.Gameplay
             if (!IsSongSelectPreview && MapManager.CustomScrollSpeed != null)
             {
                 NotificationManager.Show(NotificationLevel.Info,
-                    $"Scroll speed (local) is set to: {MapManager.CustomScrollSpeed / 10:0.0}", forceShow: true);
+                    $"Scroll speed (local) is set to: {MapManager.CustomScrollSpeed / 10f:0.0}", forceShow: true);
             }
 
             base.OnFirstUpdate();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -12,6 +12,7 @@ using Quaver.API.Enums;
 using Quaver.API.Maps.Processors.Scoring;
 using Quaver.API.Maps.Processors.Scoring.Data;
 using Quaver.Shared.Config;
+using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys;
@@ -378,17 +379,38 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 return;
 
             var speedIncrease = KeyboardManager.IsCtrlDown() ? 1 : 10;
-            BindableInt scrollSpeed;
 
-            scrollSpeed = ConfigManager.ScrollSpeeds[Ruleset.Screen.Map.Mode];
+            var scrollSpeed = ConfigManager.ScrollSpeeds[Ruleset.Screen.Map.Mode];
 
-            if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
-                scrollSpeed.Value += speedIncrease;
-            else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))
-                scrollSpeed.Value -= speedIncrease;
+            if (KeyboardManager.IsShiftDown())
+            {
+                var targetScrollSpeed = MapManager.CustomScrollSpeed ?? scrollSpeed.Value;
+                if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
+                {
+                    targetScrollSpeed += speedIncrease;
+                    MapManager.CustomScrollSpeed = targetScrollSpeed;
+                }
+                else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))
+                {
+                    targetScrollSpeed -= speedIncrease;
+                    MapManager.CustomScrollSpeed = targetScrollSpeed;
+                }
 
-            NotificationManager.Show(NotificationLevel.Info, $"Scroll speed has been changed to: {scrollSpeed.Value / 10f:0.0}",
-                null, true);
+                NotificationManager.Show(NotificationLevel.Info,
+                    $"Scroll speed (local) has been changed to: {targetScrollSpeed / 10f:0.0}",
+                    null, true);
+            }
+            else
+            {
+                if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
+                    scrollSpeed.Value += speedIncrease;
+                else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))
+                    scrollSpeed.Value -= speedIncrease;
+
+                NotificationManager.Show(NotificationLevel.Info,
+                    $"Scroll speed (global) has been changed to: {scrollSpeed.Value / 10f:0.0}",
+                    null, true);
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -388,17 +388,28 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
                 {
                     targetScrollSpeed += speedIncrease;
-                    MapManager.CustomScrollSpeed = targetScrollSpeed;
                 }
                 else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))
                 {
                     targetScrollSpeed -= speedIncrease;
-                    MapManager.CustomScrollSpeed = targetScrollSpeed;
                 }
 
-                NotificationManager.Show(NotificationLevel.Info,
-                    $"Scroll speed (local) has been changed to: {targetScrollSpeed / 10f:0.0}",
-                    null, true);
+                if (targetScrollSpeed == scrollSpeed.Value)
+                {
+                    MapManager.CustomScrollSpeed = null;
+
+                    NotificationManager.Show(NotificationLevel.Info,
+                        $"Scroll speed (local) has been reset to global: {scrollSpeed.Value / 10f:0.0}",
+                        null, true);
+                }
+                else
+                {
+                    MapManager.CustomScrollSpeed = targetScrollSpeed;
+
+                    NotificationManager.Show(NotificationLevel.Info,
+                        $"Scroll speed (local) has been changed to: {targetScrollSpeed / 10f:0.0}",
+                        null, true);
+                }
             }
             else
             {

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -384,6 +384,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             if (KeyboardManager.IsShiftDown())
             {
+                // Handle local scroll speed changes with <shift> key held.
                 var targetScrollSpeed = MapManager.CustomScrollSpeed ?? scrollSpeed.Value;
                 if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
                 {
@@ -396,6 +397,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
                 if (targetScrollSpeed == scrollSpeed.Value)
                 {
+                    // Reset to global if the target speed is the same as global
                     MapManager.CustomScrollSpeed = null;
 
                     NotificationManager.Show(NotificationLevel.Info,
@@ -404,6 +406,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 }
                 else
                 {
+                    // Set custom local scroll speed
                     MapManager.CustomScrollSpeed = targetScrollSpeed;
 
                     NotificationManager.Show(NotificationLevel.Info,
@@ -413,6 +416,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             }
             else
             {
+                // Update the global scroll speed.
+                // If there is a custom local scroll speed set, this would not have any
+                // visual effect right away.
+
                 if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyIncreaseScrollSpeed.Value))
                     scrollSpeed.Value += speedIncrease;
                 else if (KeyboardManager.IsUniqueKeyPress(ConfigManager.KeyDecreaseScrollSpeed.Value))

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
@@ -11,6 +11,7 @@ using Quaver.Shared.Modifiers;
 using Quaver.Shared.Screens.Gameplay.Rulesets.HitObjects;
 using Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield;
 using Wobble;
+using Wobble.Bindables;
 using Wobble.Window;
 
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
@@ -20,6 +21,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 /// </summary>
 public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjectInfo, NoteControllerKeys>
 {
+    private readonly BindableInt _bindableScrollSpeed = ConfigManager.ScrollSpeeds[
+        MapManager.Selected.Value.Qua != null ? MapManager.Selected.Value.Qua.Mode : GameMode.Keys4];
+
+    private readonly float _rateScaling = 1 + (ModHelper.GetRateFromMods(ModManager.Mods) - 1) *
+        ConfigManager.NormaliseScrollVelocityByRatePercentage.Value / 100f;
+
     /// <summary>
     /// </summary>
     public HitObjectManagerKeys Manager { get; }
@@ -32,16 +39,13 @@ public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjec
     {
         get
         {
-            var speed = ConfigManager.ScrollSpeeds[MapManager.Selected.Value.Qua != null ? MapManager.Selected.Value.Qua.Mode : GameMode.Keys4];
+            var scrollSpeed = MapManager.CustomScrollSpeed ?? _bindableScrollSpeed.Value;
 
             if (!Manager.HasSignificantSVs)
-                return speed.Value;
-
-            var rateScaling = 1 + (ModHelper.GetRateFromMods(ModManager.Mods) - 1) *
-                ConfigManager.NormaliseScrollVelocityByRatePercentage.Value / 100f;
+                return scrollSpeed;
 
             // Cap the speed
-            var adjustedScrollSpeed = Math.Clamp(speed.Value * rateScaling, 50, 1000);
+            var adjustedScrollSpeed = Math.Clamp(scrollSpeed * _rateScaling, 50, 1000);
             return adjustedScrollSpeed;
         }
     }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/TimingGroupControllerKeys.cs
@@ -21,10 +21,10 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects;
 /// </summary>
 public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjectInfo, NoteControllerKeys>
 {
-    private readonly BindableInt _bindableScrollSpeed = ConfigManager.ScrollSpeeds[
+    private readonly BindableInt bindableGlobalScrollSpeed = ConfigManager.ScrollSpeeds[
         MapManager.Selected.Value.Qua != null ? MapManager.Selected.Value.Qua.Mode : GameMode.Keys4];
 
-    private readonly float _rateScaling = 1 + (ModHelper.GetRateFromMods(ModManager.Mods) - 1) *
+    private readonly float rateScaling = 1 + (ModHelper.GetRateFromMods(ModManager.Mods) - 1) *
         ConfigManager.NormaliseScrollVelocityByRatePercentage.Value / 100f;
 
     /// <summary>
@@ -39,13 +39,13 @@ public abstract class TimingGroupControllerKeys : TimingGroupController<HitObjec
     {
         get
         {
-            var scrollSpeed = MapManager.CustomScrollSpeed ?? _bindableScrollSpeed.Value;
+            var scrollSpeed = MapManager.CustomScrollSpeed ?? bindableGlobalScrollSpeed.Value;
 
             if (!Manager.HasSignificantSVs)
                 return scrollSpeed;
 
             // Cap the speed
-            var adjustedScrollSpeed = Math.Clamp(scrollSpeed * _rateScaling, 50, 1000);
+            var adjustedScrollSpeed = Math.Clamp(scrollSpeed * rateScaling, 50, 1000);
             return adjustedScrollSpeed;
         }
     }


### PR DESCRIPTION
Resolves #3957 (Nearly two years later, =w=)

* Allows players to override the scroll speed of a particular map with Shift+keybind for scroll speed change
* If a custom speed is used, notifies the player of that override