### PR TITLE
Prevent pausing a replay before the track has started

### DIFF
--- a/Quaver.Shared/Graphics/PausePlayButton.cs
+++ b/Quaver.Shared/Graphics/PausePlayButton.cs
@@ -30,7 +30,7 @@ namespace Quaver.Shared.Graphics
 
             Clicked += (sender, args) =>
             {
-                if (Track == null || Track.IsDisposed)
+                if (Track == null || Track.IsDisposed || Track.Time == 0)
                     return;
 
                 if (Track.IsPlaying)

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -206,6 +206,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
 
             ProgressBarButton.Clicked += (sender, args) =>
             {
+                if (Screen == null || AudioEngine.Track.Time == 0)
+                    return;
+
                 var percentage = (MouseManager.CurrentState.X - ProgressBarButton.AbsolutePosition.X) / ProgressBarButton.AbsoluteSize.X;
                 Screen?.HandleReplaySeeking(Screen.Map.Length * percentage);
             };

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -19,6 +19,7 @@ using Wobble.Graphics.UI;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
+using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Gameplay.UI.Replays
@@ -253,7 +254,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
 
             PausePlayButton.Clicked += (sender, args) =>
             {
-                if (Screen == null)
+                if (Screen == null || AudioEngine.Track.Time == 0)
                     return;
 
                 Screen.IsPaused = !Screen.IsPaused;

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -274,8 +274,14 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                 Size = new ScalableVector2(BUTTON_SIZE, BUTTON_SIZE),
                 X = BUTTON_SIZE + BUTTON_SPACING
             };
-
-            FastForwardButton.Clicked += (sender, args) => Screen?.HandleReplaySeeking(AudioEngine.Track.Time + 10000);
+            
+            FastForwardButton.Clicked += (sender, args) => 
+            {
+                if (Screen == null || AudioEngine.Track.Time == 0)
+                    return;
+                    
+                Screen?.HandleReplaySeeking(AudioEngine.Track.Time + 10000);
+            };
         }
 
         /// <summary>
@@ -291,7 +297,13 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                 X = -BUTTON_SIZE - BUTTON_SPACING
             };
 
-            BackwardButton.Clicked += (sender, args) => Screen?.HandleReplaySeeking(AudioEngine.Track.Time - 10000);
+            BackwardButton.Clicked += (sender, args) => 
+            {
+                if (Screen == null || AudioEngine.Track.Time == 0)
+                    return;
+
+                Screen?.HandleReplaySeeking(AudioEngine.Track.Time - 10000);
+            };
         }
 
         /// <summary>
@@ -306,7 +318,13 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                 X = BackwardButton.X - BackwardButton.Width - BUTTON_SPACING
             };
 
-            RestartButton.Clicked += (sender, args) => Screen?.HandleReplaySeeking(0);
+            RestartButton.Clicked += (sender, args) => 
+            {
+                if (Screen == null || AudioEngine.Track.Time == 0)
+                    return;
+                    
+                Screen?.HandleReplaySeeking(0);
+            };
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -279,7 +279,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
             {
                 if (Screen == null || AudioEngine.Track.Time == 0)
                     return;
-                    
+
                 Screen?.HandleReplaySeeking(AudioEngine.Track.Time + 10000);
             };
         }
@@ -324,6 +324,11 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                     return;
                     
                 Screen?.HandleReplaySeeking(0);
+                Screen.IsPaused = false;
+
+                if (!AudioEngine.Track.IsPlaying)
+                    AudioEngine.Track.Play();
+                    
             };
         }
 
@@ -339,7 +344,13 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                 X = FastForwardButton.X + FastForwardButton.Width + BUTTON_SPACING
             };
 
-            SkipToEndButton.Clicked += (sender, args) => Screen?.HandleReplaySeeking(Screen.Map.Length);
+            SkipToEndButton.Clicked += (sender, args) => 
+            {
+                if (Screen == null || AudioEngine.Track.Time == 0)
+                    return;
+                
+                Screen?.HandleReplaySeeking(Screen.Map.Length);
+            };
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -19,7 +19,6 @@ using Wobble.Graphics.UI;
 using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.UI.Dialogs;
 using Wobble.Input;
-using Wobble.Logging;
 using Wobble.Managers;
 
 namespace Quaver.Shared.Screens.Gameplay.UI.Replays


### PR DESCRIPTION
This prevents that one bug where the audio and chart progress can be desynced