### PR TITLE
Prevent the replay pause button from being locked in unintended contexts

### DIFF
--- a/Quaver.Shared/Graphics/PausePlayButton.cs
+++ b/Quaver.Shared/Graphics/PausePlayButton.cs
@@ -16,11 +16,13 @@ namespace Quaver.Shared.Graphics
 
         private Texture2D PlayButton { get; }
 
+        private bool LockButton { get; }
+
         /// <summary>
         /// </summary>
         private IAudioTrack Track { get; }
 
-        public PausePlayButton(Texture2D pauseButton = null, Texture2D playButton = null, IAudioTrack track = null)
+        public PausePlayButton(Texture2D pauseButton = null, Texture2D playButton = null, IAudioTrack track = null, bool LockButton = false)
             : base(pauseButton ?? FontAwesome.Get(FontAwesomeIcon.fa_pause_symbol))
         {
             Track = track ?? AudioEngine.Track;
@@ -30,7 +32,7 @@ namespace Quaver.Shared.Graphics
 
             Clicked += (sender, args) =>
             {
-                if (Track == null || Track.IsDisposed || Track.Time == 0)
+                if (Track == null || Track.IsDisposed || (Track.Time == 0 && LockButton == true))
                     return;
 
                 if (Track.IsPlaying)

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -246,7 +246,6 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
         /// </summary>
         private void CreatePausePlayButton()
         {
-            PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton)
             PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton,null,true)
             {
                 Parent = this,

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -247,6 +247,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
         private void CreatePausePlayButton()
         {
             PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton)
+            PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton,null,true)
             {
                 Parent = this,
                 Alignment = Alignment.BotCenter,
@@ -303,6 +304,10 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                     return;
 
                 Screen?.HandleReplaySeeking(AudioEngine.Track.Time - 10000);
+
+                if (AudioEngine.Track.IsPlaying == false && AudioEngine.Track.Time == 0)
+                    AudioEngine.Track.Play();
+                    Screen.IsPaused = false;
             };
         }
 
@@ -320,9 +325,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
 
             RestartButton.Clicked += (sender, args) => 
             {
-                if (Screen == null || AudioEngine.Track.Time == 0)
+                if (Screen == null || (AudioEngine.Track.Time == 0 && Screen.InReplayMode))
                     return;
-                    
+
                 Screen?.HandleReplaySeeking(0);
                 Screen.IsPaused = false;
 
@@ -346,7 +351,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
 
             SkipToEndButton.Clicked += (sender, args) => 
             {
-                if (Screen == null || AudioEngine.Track.Time == 0)
+                if (Screen == null || AudioEngine.Track.Time == 0 && Screen.InReplayMode)
                     return;
                 
                 Screen?.HandleReplaySeeking(Screen.Map.Length);

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -305,8 +305,10 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
                 Screen?.HandleReplaySeeking(AudioEngine.Track.Time - 10000);
 
                 if (AudioEngine.Track.IsPlaying == false && AudioEngine.Track.Time == 0)
+                {
                     AudioEngine.Track.Play();
                     Screen.IsPaused = false;
+                }
             };
         }
 

--- a/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Replays/ReplayController.cs
@@ -246,7 +246,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Replays
         /// </summary>
         private void CreatePausePlayButton()
         {
-            PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton,null,true)
+            PausePlayButton = new PausePlayButton(UserInterface.JukeboxPauseButton, UserInterface.JukeboxPlayButton, null, true)
             {
                 Parent = this,
                 Alignment = Alignment.BotCenter,


### PR DESCRIPTION
Fixes #4554 

Should also prevent the button in the multiplayer header from being locked but I can't test that