### PR TITLE
Add tints to hit error chevron to reflect whether a hit is early/late or just in time.

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -510,6 +510,12 @@ namespace Quaver.Shared.Config
         /// </summary>
         internal static BindableInt HitErrorFadeTime { get; private set; }
 
+        /// <summary>
+        /// The amount of time in milliseconds a hit need to deviate from the expected hit time such that
+        /// the chevron will change its color to reflect if the hit is an early/late
+        /// </summary>
+        internal static BindableInt HitErrorEarlyLateWindow { get; private set; }
+
         /// <summary></summary>
         ///     If true, the user will skip the results screen after quitting the game.
         /// </summary>
@@ -1134,6 +1140,7 @@ namespace Quaver.Shared.Config
             DisplaySongTimeProgressNumbers = ReadValue(@"DisplaySongTimeProgressNumbers", true, data);
             DisplayJudgementCounter = ReadValue(@"DisplayJudgementCounter", true, data);
             HitErrorFadeTime = ReadInt(@"HitErrorFadeTime", 1000, 100, 5000, data);
+            HitErrorEarlyLateWindow = ReadInt(@"HitErrorEarlyLateWindow", 10, 0, 100, data);
             SkipResultsScreenAfterQuit = ReadValue(@"SkipResultsScreenAfterQuit", false, data);
             LockWinkeyDuringGameplay = ReadValue(@"LockWinkeyDuringGameplay", true, data);
             DisplayComboAlerts = ReadValue(@"DisplayComboAlerts", true, data);

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -94,7 +94,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 Alpha = 1,
                 Image = FontAwesome.Get(FontAwesomeIcon.fa_caret_down),
                 Y = -Height - 3,
-                Size = new ScalableVector2(chevronSize, chevronSize)
+                Size = new ScalableVector2(chevronSize, chevronSize),
+                Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorNeutralColor
             };
         }
 
@@ -131,6 +132,19 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             LineObjectPool[CurrentLinePoolIndex].X = -(float)hitTime / ModHelper.GetRateFromMods(ModManager.Mods) * SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorWidthScale;
             LineObjectPool[CurrentLinePoolIndex].Alpha = Alpha;
+
+            if (ConfigManager.HitErrorEarlyLateWindow.Value <= hitTime)
+            {
+                LastHitCheveron.Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorEarlyColor;
+            }
+            else if (hitTime <= -ConfigManager.HitErrorEarlyLateWindow.Value)
+            {
+                LastHitCheveron.Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorLateColor;
+            }
+            else
+            {
+                LastHitCheveron.Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorNeutralColor;
+            }
         }
     }
 }

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -367,6 +367,8 @@ namespace Quaver.Shared.Screens.Options
                         new OptionsItemCheckbox(containerRect, "Show Spectators", ConfigManager.ShowSpectators),
                         new OptionsItemCheckbox(containerRect, "Display Ranked Accuracy With Custom Judgements", ConfigManager.DisplayRankedAccuracy),
                         new OptionsSlider(containerRect, "Hit Error Fade Time", ConfigManager.HitErrorFadeTime, i => $"{i / 1000f:0.0} sec"),
+                        new OptionsSlider(containerRect, "Hit Error Early Late Window",
+                            ConfigManager.HitErrorEarlyLateWindow, i => $"{i} ms"),
                         new OptionsItemCheckbox(containerRect, "Enable Combo Alerts", ConfigManager.DisplayComboAlerts),
                         //new OptionsItemCheckbox(containerRect, "[Donator] Enable Real-time Top 5 Online Scoreboard", ConfigManager.EnableRealtimeOnlineScoreboard),
                         new OptionsItemCheckbox(containerRect, "Display Unbeatable Scores", ConfigManager.DisplayUnbeatableScoresDuringGameplay),

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -231,6 +231,12 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float HitErrorChevronSize { get; private set; }
 
+        internal Color HitErrorEarlyColor { get; private set; } = Colors.MainBlue;
+
+        internal Color HitErrorLateColor { get; private set; } = Colors.Negative;
+
+        internal Color HitErrorNeutralColor { get; private set; } = Color.White;
+        
         internal HealthBarType HealthBarType { get; private set; }
 
         internal HealthBarKeysAlignment HealthBarKeysAlignment { get; private set; }
@@ -656,6 +662,9 @@ namespace Quaver.Shared.Skinning
             HitErrorHeight = ConfigHelper.ReadInt32((int)HitErrorHeight, ini["HitErrorHeight"]);
             HitErrorWidthScale = ConfigHelper.ReadFloat(HitErrorWidthScale, ini["HitErrorWidthScale"]);
             HitErrorChevronSize = ConfigHelper.ReadInt32((int)HitErrorChevronSize, ini["HitErrorChevronSize"]);
+            HitErrorEarlyColor = ConfigHelper.ReadColor(HitErrorEarlyColor, ini["HitErrorEarlyColor"]);
+            HitErrorLateColor = ConfigHelper.ReadColor(HitErrorLateColor, ini["HitErrorLateColor"]);
+            HitErrorNeutralColor = ConfigHelper.ReadColor(HitErrorNeutralColor, ini["HitErrorNeutralColor"]);
             TimingLineColor = ConfigHelper.ReadColor(TimingLineColor, ini["TimingLineColor"]);
             SongTimeProgressInactiveColor = ConfigHelper.ReadColor(SongTimeProgressInactiveColor, ini["SongTimeProgressInactiveColor"]);
             SongTimeProgressActiveColor = ConfigHelper.ReadColor(SongTimeProgressActiveColor, ini["SongTimeProgressActiveColor"]);


### PR DESCRIPTION


https://github.com/user-attachments/assets/341c9ffb-6904-48c4-a254-29b32b3f0cbd



* Added skinning options `HitErrorEarlyColor`, `HitErrorLateColor` and `HitErrorNeutralColor`: colors to represent early/late/correct
* Added option `HitErrorEarlyLateWindow`: the number of milliseconds of deviation to consider a hit as early/late instead of neutral