### PR TITLE
Fix hit lighting scaling and positioning in mapset preview

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -17,6 +17,8 @@ using Quaver.Shared.Skinning;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 
+using Wobble.Window;
+
 namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 {
     public class HitLighting : AnimatableSprite
@@ -89,15 +91,16 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             Alpha = 1;
 
             var skinScale = IsHoldingLongNote ? skin.HoldLightingScale : skin.HitLightingScale;
-            var scale = skinScale / 100f;
+            var previewScale = Playfield.LaneSize / (skin.ColumnSize * WindowManager.BaseToVirtualRatio);
+            var scale = (skinScale / 100f) * previewScale;
 
             Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
 
             var relativeRect = new RectangleF(0, 0, RelativeRectangle.Width, RelativeRectangle.Height);
             var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect, Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);
 
-            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + skin.HitLightingX,
-                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + skin.HitLightingY);
+            Position = new ScalableVector2(pos.X - Playfield.ForegroundContainer.ScreenRectangle.X + (skin.HitLightingX * previewScale),
+                pos.Y - Playfield.ForegroundContainer.ScreenRectangle.Y + (skin.HitLightingY * previewScale));
 
             // Rotation
             var rotate = IsHoldingLongNote ? skin.HoldLightingColumnRotation : skin.HitLightingColumnRotation;


### PR DESCRIPTION
Adjusts the scale and position calculations for hit lighting to account for the preview scale based on lane size and window ratio. This ensures correct visual alignment and sizing of hit lighting effects in the playfield. Works in editor too.

https://github.com/user-attachments/assets/fbb18466-10e2-4a6b-b9dc-fceb4ea36c1f


https://github.com/user-attachments/assets/c09ef782-5feb-4484-ac03-10aeab70890a

