### PR TITLE
Editor improvements test

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -71,12 +71,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             CreateSelectionSprite();
 
             Refresh();
-
-            Coloring.ValueChanged += OnViewLayersChanged;
-            SelectedHitObjects.ItemAdded += OnSelectedHitObject;
-            SelectedHitObjects.ItemRemoved += OnDeselectedHitObject;
-            SelectedHitObjects.ListCleared += OnAllObjectsDeselected;
-            SelectedHitObjects.MultipleItemsAdded += OnMultipleItemsAdded;
         }
 
         /// <inheritdoc />
@@ -97,14 +91,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             base.Destroy();
             Body?.Destroy();
             Tail?.Destroy();
-
-            // ReSharper disable twice DelegateSubtraction
-            Coloring.ValueChanged -= OnViewLayersChanged;
-
-            SelectedHitObjects.ItemAdded -= OnSelectedHitObject;
-            SelectedHitObjects.ItemRemoved -= OnDeselectedHitObject;
-            SelectedHitObjects.ListCleared -= OnAllObjectsDeselected;
-            SelectedHitObjects.MultipleItemsAdded -= OnMultipleItemsAdded;
         }
 
         /// <inheritdoc />
@@ -335,7 +321,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnViewLayersChanged(object sender, BindableValueChangedEventArgs<HitObjectColoring> e)
+        public void OnViewLayersChanged(object sender, BindableValueChangedEventArgs<HitObjectColoring> e)
         {
             UpdateTextures();
             SetSize();
@@ -351,11 +337,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnSelectedHitObject(object sender, BindableListItemAddedEventArgs<HitObjectInfo> e)
+        public void OnSelectedHitObject(object sender, BindableListItemAddedEventArgs<HitObjectInfo> e)
         {
-            if (e.Item != Info)
-                return;
-
             SelectionSprite.Visible = true;
         }
 
@@ -363,19 +346,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnDeselectedHitObject(object sender, BindableListItemRemovedEventArgs<HitObjectInfo> e)
-        {
-            if (e.Item != Info)
-                return;
-
-            SelectionSprite.Visible = false;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void OnAllObjectsDeselected(object sender, BindableListClearedEventArgs e)
+        public void OnDeselectedHitObject(object sender, BindableListItemRemovedEventArgs<HitObjectInfo> e)
         {
             SelectionSprite.Visible = false;
         }
@@ -384,11 +355,17 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnMultipleItemsAdded(object sender, BindableListMultipleItemsAddedEventArgs<HitObjectInfo> e)
+        public void OnAllObjectsDeselected(object sender, BindableListClearedEventArgs e)
         {
-            if (!e.Items.Contains(Info))
-                return;
+            SelectionSprite.Visible = false;
+        }
 
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        public void OnMultipleItemsAdded(object sender, BindableListMultipleItemsAddedEventArgs<HitObjectInfo> e)
+        {
             SelectionSprite.Visible = true;
         }
     }

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -189,6 +189,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         private List<EditorHitObjectKeys> HitObjects { get; set; }
 
         /// <summary>
+        ///     A dictionary of the hitobjects for quick lookup
+        /// </summary>
+        private Dictionary<HitObjectInfo, EditorHitObjectKeys> HitObjectMap { get; set; }
+
+        /// <summary>
         ///     The objects that are currently visible and ready to be drawn to the screen
         /// </summary>
         private List<EditorHitObjectKeys> HitObjectPool { get; set; }
@@ -405,6 +410,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Skin.ValueChanged += OnSkinChanged;
             WaveFormAudioDirection.ValueChanged += OnWaveFormAudioDirectionChanged;
             WaveformFilter.ValueChanged += OnWaveformFilterChanged;
+            Coloring.ValueChanged += OnViewLayersChanged;
+            SelectedHitObjects.ItemAdded += OnSelectedHitObject;
+            SelectedHitObjects.ItemRemoved += OnDeselectedHitObject;
+            SelectedHitObjects.ListCleared += OnAllObjectsDeselected;
+            SelectedHitObjects.MultipleItemsAdded += OnMultipleItemsAdded;
             SpectrogramFftSize.ValueChanged += OnSpectrogramFftSizeChanged;
             ConfigManager.EditorSpectrogramMaximumFrequency.ValueChanged += OnSpectrogramFrequencyWindowSizeChanged;
             ConfigManager.EditorSpectrogramMinimumFrequency.ValueChanged += OnSpectrogramMinimumFrequencyChanged;
@@ -531,11 +541,14 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
 
             ThreadScheduler.Run(() =>
             {
-                HitObjects.ForEach(x => x.Destroy());
+                if (HitObjects.Count < 1000)
+                    HitObjects.ForEach(x => x.Destroy());
+
                 Timeline?.Destroy();
                 LineContainer?.Destroy();
 
                 HitObjects.Clear();
+                HitObjectMap.Clear();
                 LineContainer = null;
                 Timeline = null;
             });
@@ -566,6 +579,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Skin.ValueChanged -= OnSkinChanged;
             WaveFormAudioDirection.ValueChanged -= OnWaveFormAudioDirectionChanged;
             WaveformFilter.ValueChanged -= OnWaveformFilterChanged;
+
+            Coloring.ValueChanged -= OnViewLayersChanged;
+            SelectedHitObjects.ItemAdded -= OnSelectedHitObject;
+            SelectedHitObjects.ItemRemoved -= OnDeselectedHitObject;
+            SelectedHitObjects.ListCleared -= OnAllObjectsDeselected;
+            SelectedHitObjects.MultipleItemsAdded -= OnMultipleItemsAdded;
 
             SpectrogramFftSize.ValueChanged -= OnSpectrogramFftSizeChanged;
             ConfigManager.EditorSpectrogramMaximumFrequency.ValueChanged -= OnSpectrogramFrequencyWindowSizeChanged;
@@ -648,6 +667,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         private void CreateHitObjects()
         {
             HitObjects = new List<EditorHitObjectKeys>();
+            HitObjectMap = new Dictionary<HitObjectInfo, EditorHitObjectKeys>();
             Map.HitObjects.ForEach(x => CreateHitObject(x));
         }
 
@@ -746,6 +766,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             }
             else
                 HitObjects.Add(ho);
+
+            HitObjectMap[info] = ho;
         }
 
         /// <summary>
@@ -1059,13 +1081,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (IsUneditable)
                 return;
 
-            var ho = HitObjects.Find(x => x.Info == e.HitObject);
-
-            if (ho == null)
+            if (!HitObjectMap.TryGetValue(e.HitObject, out var ho))
                 return;
 
             ho.Destroy();
             HitObjects.Remove(ho);
+            HitObjectMap.Remove(e.HitObject);
 
             InitializeHitObjectPool();
         }
@@ -1081,13 +1102,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
 
             foreach (var obj in e.HitObjects)
             {
-                var drawable = HitObjects.Find(x => x.Info == obj);
-
-                if (drawable == null)
+                if (!HitObjectMap.TryGetValue(obj, out var drawable))
                     continue;
 
                 drawable.Destroy();
                 HitObjects.Remove(drawable);
+                HitObjectMap.Remove(obj);
             }
 
             InitializeHitObjectPool();
@@ -1665,6 +1685,59 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
                     continue;
 
                 drawable.Refresh();
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnViewLayersChanged(object sender, BindableValueChangedEventArgs<HitObjectColoring> e)
+        {
+            for (var i = 0; i < HitObjects.Count; i++)
+                HitObjects[i].OnViewLayersChanged(sender, e);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnSelectedHitObject(object sender, BindableListItemAddedEventArgs<HitObjectInfo> e)
+        {
+            if (HitObjectMap.TryGetValue(e.Item, out var ho))
+                ho.OnSelectedHitObject(sender, e);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnDeselectedHitObject(object sender, BindableListItemRemovedEventArgs<HitObjectInfo> e)
+        {
+            if (HitObjectMap.TryGetValue(e.Item, out var ho))
+                ho.OnDeselectedHitObject(sender, e);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnAllObjectsDeselected(object sender, BindableListClearedEventArgs e)
+        {
+            for (var i = 0; i < HitObjects.Count; i++)
+                HitObjects[i].OnAllObjectsDeselected(sender, e);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnMultipleItemsAdded(object sender, BindableListMultipleItemsAddedEventArgs<HitObjectInfo> e)
+        {
+            for (var i = 0; i < e.Items.Count; i++)
+            {
+                if (HitObjectMap.TryGetValue(e.Items[i], out var ho))
+                    ho.OnMultipleItemsAdded(sender, e);
             }
         }
 


### PR DESCRIPTION
Summary of changes:

- **Centralized Event Dispatching**: Moved event subscriptions for `HitObjectColoring` and `SelectedHitObjects` from individual `EditorHitObjectKeys` instances to the `EditorPlayfield`.
- **Fast Lookup**: Added a `HitObjectMap` (Dictionary) in `EditorPlayfield` to allow $O(1)$ lookup of hit objects when events fire.
- **Improved Destruction Logic**:
    - Updated `EditorPlayfield.Destroy()` to skip the individual `Destroy()` loop for maps with more than 1,000 objects, relying on Garbage Collection for cleanup since event references are now handled centrally and dropped instantly.
    - Centrally unsubscribing from bindables in $O(1)$ time, avoiding the $O(N^2)$ bottleneck.
- **Enhanced Editor Performance**: By reducing the number of event subscriptions from 450,000 (90k objects * 5 events) to just 5, the overall performance of the editor during map loading and editing is also significantly improved.

These changes ensure that exiting the editor is near-instant even for maps with a very high number of hit objects, without affecting other editor components.


# Tests
Tested with https://quavergame.com/mapset/map/27824

Stats from Local build + https://github.com/Quaver/Wobble/pull/169 & https://github.com/Quaver/Quaver/pull/4564 vs Canary 1.7.0.12:

1. With Visualizer Enabled

Raw Measurements

| Stage            | Local (GB) | Canary (GB) | Δ Canary vs Local |
|------------------|------------|-------------|-------------------|
| Selecting song   | 1.14       | 1.20        | +0.06 (+5.3%)     |
| In editor        | 7.09       | 7.47        | +0.38 (+5.4%)     |
| Exiting editor   | 1.45       | 3.30        | +1.85 (+127.6%)   |

### Derived Stats

- **Peak memory (in editor):**
  - Local: **7.09 GB**
  - Canary: **7.47 GB**
  - Difference: **+0.38 GB (+5.4%)**

- **Memory retained after exit (vs selecting song):**
  - Local: **+0.31 GB** (1.45 − 1.14)
  - Canary: **+2.10 GB** (3.30 − 1.20)

- **Retention multiplier (Canary vs Local):**
  - **~6.8× higher retained memory** after exit


---

2. Without Visualizer

Raw Measurements

| Stage            | Local (GB) | Canary (GB) | Δ Canary vs Local |
|------------------|------------|------------|-------------------|
| Selecting song   | 1.02       | 1.35       | +0.33 (+32.4%)    |
| In editor        | 1.50       | 1.80       | +0.30 (+20.0%)    |
| Exiting editor   | 1.43       | 1.94       | +0.51 (+35.7%)    |

### Derived Stats

- **Peak memory (in editor):**
  - Local: **1.50 GB**
  - Canary: **1.80 GB**
  - Difference: **+0.30 GB (+20.0%)**

- **Memory retained after exit (vs selecting song):**
  - Local: **+0.41 GB** (1.43 − 1.02)
  - Canary: **+0.59 GB** (1.94 − 1.35)

- **Retention multiplier (Canary vs Local):**
  - **~1.4× higher retained memory** after exit