### PR TITLE
Fixing animations in preview map

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeys.cs
@@ -382,7 +382,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         public void Update(GameTime gameTime)
         {
             Stage.Update(gameTime);
-            Container?.Update(gameTime);
+
+            // In Song Select Preview, the Container is parented to SelectMapPreviewContainer,
+            // so it gets updated via the scene graph. Updating it here would cause a double update (2x speed).
+            if (!Screen.IsSongSelectPreview)
+                Container?.Update(gameTime);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
The Playfield container is updated twice every frame: once automatically via the scene hierarchy (since it is parented to SelectMapPreviewContainer) and a second time manually via the GameplayPlayfieldKeys.Update method.

This causes all animations inside, including HitLighting, to run at double speed (2x faster), which gives the impression of "weird scaling" or ignoring FPS settings (e.g., at 60 FPS it visually looks like 120 FPS).