### PR TITLE
Fix Skin Sounds Not Loaded On Startup

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -417,7 +417,7 @@ namespace Quaver.Shared
         {
             DeleteTemporaryFiles();
 
-            SetAudioDevice();
+            SetAudioDevice(true);
             DatabaseManager.Initialize();
             ScoreDatabaseCache.CreateTable();
             MapDatabaseCache.Load(false);
@@ -985,7 +985,7 @@ namespace Quaver.Shared
             if (!reloadResources)
                 return;
 
-            AudioEngine.Track.Stop();
+            AudioEngine.Track?.Stop();
             CustomAudioSampleCache.Dispose();
             SkinManager.Skin.LoadSoundEffects();
         }

--- a/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
+++ b/Quaver.Shared/Screens/Initialization/InitializationScreen.cs
@@ -38,7 +38,8 @@ namespace Quaver.Shared.Screens.Initialization
             GameBase.Game.GlobalUserInterface.Cursor.Alpha = 0;
 
             Logger.Important($"Loading skin...", LogType.Runtime);
-            SkinManager.Load();
+            // Avoid loading SoundEffects before Audio Device hasn't been set yet which leads to sound effects not working. 
+            SkinManager.Load(UniversalSkinElementsLoadFlags.All & ~UniversalSkinElementsLoadFlags.SoundEffects);
 
             Logger.Important($"Loading fonts...", LogType.Runtime);
             Fonts.LoadWobbleFonts();

--- a/Quaver.Shared/Skinning/SkinManager.cs
+++ b/Quaver.Shared/Skinning/SkinManager.cs
@@ -72,9 +72,9 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     Loads the currently selected skin
         /// </summary>
-        public static void Load()
+        public static void Load(UniversalSkinElementsLoadFlags loadFlags = UniversalSkinElementsLoadFlags.All)
         {
-            Skin = new SkinStore();
+            Skin = new SkinStore(loadFlags: loadFlags);
 
             if (ConfigManager.TournamentPlayer2Skin.Value == null ||
                 ConfigManager.TournamentPlayer2Skin.Value == ConfigManager.Skin.Value)

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -798,7 +798,7 @@ namespace Quaver.Shared.Skinning
         /// </summary>
         public void LoadSoundEffects()
         {
-            var sfxFolder = $"{Dir}/SFX/";
+            var sfxFolder = Path.Combine(Dir, "SFX").Replace("\\", "/");
 
             const string soundHit = "sound-hit";
             SoundHit = LoadSoundEffect($"{sfxFolder}/{soundHit}", soundHit, "Gameplay");

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -305,7 +305,7 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     Ctor - Loads up a skin from a given directory.
         /// </summary>
-        internal SkinStore(string skin = null, bool editor = false)
+        internal SkinStore(string skin = null, bool editor = false, UniversalSkinElementsLoadFlags loadFlags = UniversalSkinElementsLoadFlags.All)
         {
             Stopwatch totalSW = new();
             Dictionary<GameMode, (Stopwatch sw, int cacheHits)> keyTimingInfo = new();
@@ -342,7 +342,7 @@ namespace Quaver.Shared.Skinning
                 Logger.Error(e, LogType.Runtime);
             }
 
-            LoadUniversalElements();
+            LoadUniversalElements(loadFlags);
 
             // Change cursor image.
             GameBase.Game.GlobalUserInterface.Cursor.Image = Cursor;
@@ -396,23 +396,23 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     Loads universal skin elements used across every single game mode.
         /// </summary>
-        private void LoadUniversalElements()
+        private void LoadUniversalElements(UniversalSkinElementsLoadFlags loadFlags)
         {
             const string cursor = "main-cursor";
             Cursor = LoadSingleTexture($"{Dir}/Cursor/{cursor}", $"Quaver.Resources/Textures/Skins/Shared/Cursor/{cursor}.png");
 
-            LoadGradeElements();
-            LoadHitBubbleElements();
-            LoadJudgements();
-            LoadNumberDisplays();
-            LoadPause();
-            LoadScoreboard();
-            LoadHealthBar();
-            LoadSkip();
-            LoadComboAlert();
-            LoadMultiplayerElements();
-            LoadBackgrounds();
-            LoadSoundEffects();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Grade)) LoadGradeElements();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.HitBubble)) LoadHitBubbleElements();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Judgements)) LoadJudgements();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.NumberDisplays)) LoadNumberDisplays();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Pause)) LoadPause();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Scoreboard)) LoadScoreboard();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.HealthBar)) LoadHealthBar();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Skip)) LoadSkip();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.ComboAlert)) LoadComboAlert();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.MultiplayerElements)) LoadMultiplayerElements();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.Backgrounds)) LoadBackgrounds();
+            if (loadFlags.HasFlag(UniversalSkinElementsLoadFlags.SoundEffects)) LoadSoundEffects();
         }
 
         private Texture2D GetTextureFromCacheOr(byte[] buffer, Func<byte[], Texture2D> func)
@@ -958,5 +958,31 @@ namespace Quaver.Shared.Skinning
             options.AddRange(skins);
             return options;
         }
+    }
+
+    /// <summary>
+    /// Which types of skin elements to load.
+    /// </summary>
+    [Flags]
+    public enum UniversalSkinElementsLoadFlags
+    {
+        // IMPORTANT:
+        // If adding a new flag remember to include it in 'All'
+        
+        Grade = 1 << 0,
+        HitBubble = 1 << 1,
+        Judgements = 1 << 2,
+        NumberDisplays = 1 << 3,
+        Pause = 1 << 4,
+        Scoreboard = 1 << 5,
+        HealthBar = 1 << 6,
+        Skip = 1 << 7,
+        ComboAlert = 1 << 8,
+        MultiplayerElements = 1 << 9,
+        Backgrounds = 1 << 10,
+        SoundEffects = 1 << 11,
+    
+        All = Grade | HitBubble | Judgements | NumberDisplays | Pause | Scoreboard | 
+              HealthBar | Skip | ComboAlert | MultiplayerElements | Backgrounds | SoundEffects
     }
 }


### PR DESCRIPTION
the fix here is to call ``SkinManager.Skin.LoadSoundEffects()``, seeing as ``QuaverGame.SetAudioDevice`` already did so I decided to set ``reloadResources`` to true and add null condition to ``AudioEngine.Track?.Stop()``.

\+ fixed formating of sfxFolder (not really needed but now the path doesn't have double slashes and mixed slashes "/" and "\\")

Fixes #4510