### PR TITLE
Playlist import

### DIFF
--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -438,9 +437,9 @@ namespace Quaver.Shared.Database.Maps
 
                 try
                 {
-                    dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(File.ReadAllText(metadata));
+                    var json = JsonConvert.DeserializeObject<Playlist.PlaylistExportMetadata>(File.ReadAllText(metadata));
 
-                    var onlineMapPoolId = (int)json.OnlineMapPoolId;
+                    var onlineMapPoolId = json.OnlineMapPoolId;
                     if (onlineMapPoolId > -1)
                     {
                         PlaylistManager.ImportPlaylist(onlineMapPoolId);
@@ -458,7 +457,7 @@ namespace Quaver.Shared.Database.Maps
                             Description = json.Description,
                             Creator = json.Creator,
                             OnlineMapPoolId = onlineMapPoolId,
-                            OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
+                            OnlineMapPoolCreatorId = json.OnlineMapPoolCreatorId
                         };
                     }
                     else

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -137,14 +137,14 @@ namespace Quaver.Shared.Database.Maps
         /// <param name="path">Path to file</param>
         private static bool AcceptedMapType(string path)
         {
-            return path.EndsWith(".qp") || path.EndsWith(".qpl") || path.EndsWith(".osz") || path.EndsWith(".sm") || path.EndsWith(".mcz") || path.EndsWith(".mc");
+            return path.EndsWith(".qp") || path.EndsWith(".osz") || path.EndsWith(".sm") || path.EndsWith(".mcz") || path.EndsWith(".mc");
         }
 
         /// <summary>
         ///     Adds the map dragged into the window to be scheduled to import
         /// </summary>
         /// <param name="path"></param>
-        private static void AddMapImportToQueue(string path)
+        private static void AddMapImportToQueue(string path, bool silent = false)
         {
             // Only one .mc file under the same directory should be imported
             // since .mc import
@@ -156,7 +156,9 @@ namespace Quaver.Shared.Database.Maps
                 }
             }
 
-            NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
+            if(! silent)
+                NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
+
             Queue.Add(path);
             PostMapQueue();
         }
@@ -165,7 +167,7 @@ namespace Quaver.Shared.Database.Maps
         ///     Tries to import the given file, be it a map, a replay, a skin, etc.
         ///     <param name="path">path to the file to import</param>
         /// </summary>
-        public static void ImportFile(string path)
+        public static void ImportFile(string path, bool silent = false)
         {
             var game = GameBase.Game as QuaverGame;
             var screen = game.CurrentScreen;
@@ -173,7 +175,7 @@ namespace Quaver.Shared.Database.Maps
             // Mapset files (or directory of Mapset files)
             if (AcceptedMapType(path))
             {
-                AddMapImportToQueue(path);
+                AddMapImportToQueue(path, silent);
             }
             // Quaver Replay
             else if (path.EndsWith(".qr"))
@@ -284,7 +286,7 @@ namespace Quaver.Shared.Database.Maps
                 NotificationManager.Show(NotificationLevel.Success, $"Successfully set the path for your .db file");
             }
             // Archive with maps (batch import)
-            else if (path.EndsWith(".zip"))
+            else if (path.EndsWith(".zip") || path.EndsWith(".qpl"))
             {
                 var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
                 var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}";
@@ -294,10 +296,23 @@ namespace Quaver.Shared.Database.Maps
                     archive.ExtractToDirectory(tempFolder);
                 }
 
-                foreach (var file in Directory.GetFiles(tempFolder, "*", SearchOption.AllDirectories))
+                ImportFile(tempFolder, true);
+
+                if(path.EndsWith(".qpl"))
                 {
-                    ImportFile(file);
+                    var metadata = Directory.GetFiles(tempFolder, "metadata.json").FirstOrDefault();
+                    if (metadata == null)
+                    {
+                        Logger.Log($"metadata not found for playlist {Path.GetFileName(path)}", LogLevel.Important, LogType.Runtime);
+                    }
+
+                    Queue.Add(metadata);
                 }
+
+                // Add parent folder for deletion after import
+                Queue.Add(tempFolder);
+
+                NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
 
                 // delete zip file after all maps have been extracted
                 if (ConfigManager.DeleteOriginalFileAfterImport.Value)
@@ -313,12 +328,12 @@ namespace Quaver.Shared.Database.Maps
                 {
                     if (AcceptedMapType(subPath))
                     {
-                        AddMapImportToQueue(subPath);
+                        AddMapImportToQueue(subPath, silent);
                     }
                 }
                 foreach (var subDir in dirs)
                 {
-                    ImportFile(subDir);
+                    ImportFile(subDir, silent);
                 }
 
                 PostMapQueue();
@@ -337,9 +352,17 @@ namespace Quaver.Shared.Database.Maps
 
             var done = -1;
 
-            var skipPlaylistReload = true;
+            // Remove temp folder from import queue
+            var tempFolders = Queue.FindAll(f => File.GetAttributes(f).HasFlag(FileAttributes.Directory));
+            tempFolders.ForEach(tf => Queue.Remove(tf));
+
+            // Handle playlist import
+            var playlistsMetadata = Queue.FindAll(f => f.EndsWith("metadata.json"));
+            playlistsMetadata.ForEach(pl => Queue.Remove(pl));
 
             MapsetInfoRetriever.InfoUpdateEnabled = false;
+
+            // Import map
             Parallel.For(0, Queue.Count, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
             {
                 var file = Queue[i];
@@ -362,12 +385,6 @@ namespace Quaver.Shared.Database.Maps
                     if (file.EndsWith(".qp"))
                     {
                         ExtractQuaverMapset(file, extractDirectory);
-                        deleteOriginalFile = true;
-                    }
-                    else if (file.EndsWith(".qpl"))
-                    {
-                        selectedMap = ExtractQuaverPlaylist(file);
-                        skipPlaylistReload = false;
                         deleteOriginalFile = true;
                     }
                     else if (file.EndsWith(".osz"))
@@ -393,8 +410,7 @@ namespace Quaver.Shared.Database.Maps
                     || file.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
                         File.Delete(file);
 
-                    if (!file.EndsWith(".qpl"))
-                        selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
+                    selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
                     
                     Logger.Important($"Successfully imported {file}", LogType.Runtime);
 
@@ -408,7 +424,68 @@ namespace Quaver.Shared.Database.Maps
                 }
             });
 
-            MapDatabaseCache.OrderAndSetMapsets(skipPlaylistReload);
+            // Import playlist
+            Parallel.For(0, playlistsMetadata.Count, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
+            {
+                var metadata = playlistsMetadata[i];
+
+                try
+                {
+                    dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(File.ReadAllText(metadata));
+
+                    var onlineMapPoolId = (int)json.OnlineMapPoolId;
+                    if (onlineMapPoolId > -1)
+                        PlaylistManager.ImportPlaylist(onlineMapPoolId);
+                    else
+                    {
+                        var isNewPlaylist = false;
+                        var playlist = PlaylistManager.Playlists.Find(p => p.Name == json.Name && p.Description == json.Description && p.Creator == json.Creator);
+                        if (playlist == null)
+                        {
+                            isNewPlaylist = true;
+                            playlist = new Playlist()
+                            {
+                                Name = json.Name,
+                                Description = json.Description,
+                                Creator = json.Creator,
+                                OnlineMapPoolId = onlineMapPoolId,
+                                OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
+                            };
+                        }
+                        else
+                        {
+                            // Update playlist content to match metadata's content
+                            playlist.Maps.Where(m => !json.Maps.Contains(m.Md5Checksum)).ToList().ForEach(m =>
+                            {
+                                PlaylistManager.RemoveMapFromPlaylist(playlist, m);
+                            });
+                        }
+
+                        foreach (var map in json.Maps)
+                        {
+                            if (playlist.Maps.Find(m => m.Md5Checksum == map) != null)
+                                continue;
+
+                            playlist.Maps.Add(new Map { Md5Checksum = map });
+                        }
+
+                        if (isNewPlaylist)
+                            PlaylistManager.AddPlaylist(playlist);
+
+                        playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                    NotificationManager.Show(NotificationLevel.Error, $"Failed to import playlist");
+                }
+            });
+
+            // delete temp files associated to batch import
+            tempFolders.ForEach(d => Directory.Delete(d, true));
+
+            MapDatabaseCache.OrderAndSetMapsets(playlistsMetadata.Count == 0);
             Queue.Clear();
             MapsetInfoRetriever.InfoUpdateEnabled = true;
 
@@ -486,95 +563,6 @@ namespace Quaver.Shared.Database.Maps
                     }
                 }
             }
-        }
-
-        /// <summary>
-        ///     Responsible for extracting the files from the .qpl
-        /// </summary>
-        /// <param name="fileName"></param>
-        /// <param name="extractPath"></param>
-        private static Map ExtractQuaverPlaylist(string fileName)
-        {
-            var options = new ExtractionOptions { ExtractFullPath = true, Overwrite = true };
-
-            var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
-            var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(fileName)} - {time}";
-
-            if (Directory.Exists(tempFolder))
-                Directory.Delete(tempFolder, true);
-
-            Directory.CreateDirectory(tempFolder);
-
-            // Extract files to temp directory
-            using (var archive = ArchiveFactory.Open(fileName))
-            {
-                foreach (var entry in archive.Entries)
-                {
-                    if (!entry.IsDirectory)
-                        entry.WriteToDirectory(tempFolder, options);
-                }
-            }
-
-            // Import mapsets
-            Map selectedMap = null;
-            foreach (var path in Directory.GetFiles(tempFolder, "*.qp", SearchOption.AllDirectories))
-            {
-                // Basically recreate the import process
-                var extractDirectory = $@"{ConfigManager.SongDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}/";
-
-                ExtractQuaverMapset(path, extractDirectory);
-                if (ConfigManager.DeleteOriginalFileAfterImport.Value || path.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
-                    File.Delete(path);
-
-                Logger.Important($"Successfully imported {path}", LogType.Runtime);
-
-                selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
-            }
-
-            // Find metadata file
-            var metadata = Directory.GetFiles(tempFolder, "metadata.json").FirstOrDefault();
-            if (metadata == null)
-            {
-                Logger.Log("metadata not found", LogLevel.Important, LogType.Runtime);
-                return selectedMap;
-            }
-
-            // Create playlist
-            dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(File.ReadAllText(metadata));
-
-            var onlineMapPoolId = (int)json.OnlineMapPoolId;
-            if(onlineMapPoolId > -1)
-                PlaylistManager.ImportPlaylist(onlineMapPoolId);
-            else
-            {
-                var isNewPlaylist = false;
-                var playlist = PlaylistManager.Playlists.Find(p => p.Name == json.Name && p.Description == json.Description && p.Creator == json.Creator);
-                if(playlist == null)
-                {
-                    isNewPlaylist = true;
-                    playlist = new Playlist()
-                    {
-                        Name = json.Name,
-                        Description = json.Description,
-                        Creator = json.Creator,
-                        OnlineMapPoolId = onlineMapPoolId,
-                        OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
-                    };
-                }
-                foreach (var map in json.Maps)
-                {
-                    playlist.Maps.Add(new Map { Md5Checksum = map });
-                }
-
-                if(isNewPlaylist)
-                    PlaylistManager.AddPlaylist(playlist);
-                    
-                playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x));
-            }
-            
-            Directory.Delete(tempFolder, true);
-
-            return selectedMap;
         }
 
         /// <summary>

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
 using Quaver.API.Helpers;
@@ -276,6 +277,27 @@ namespace Quaver.Shared.Database.Maps
 
                 ConfigManager.AutoLoadOsuBeatmaps.Value = true;
                 NotificationManager.Show(NotificationLevel.Success, $"Successfully set the path for your .db file");
+            }
+            // Archive with maps (playlists)
+            else if (path.EndsWith(".zip"))
+            {
+                var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
+                var tempFolder = $@"{ConfigManager.TempDirectory}";
+
+                if (Directory.Exists(tempFolder))
+                    Directory.Delete(tempFolder, true);
+
+                Directory.CreateDirectory(tempFolder);
+
+                using (ZipArchive archive = ZipFile.OpenRead(path))
+                {
+                    archive.ExtractToDirectory(tempFolder);
+                }
+
+                foreach (var file in Directory.GetFiles(tempFolder))
+                {
+                    ImportFile(file);
+                }
             }
             // Folder with maps
             else if (File.GetAttributes(path).HasFlag(FileAttributes.Directory))

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -7,10 +7,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Quaver.API.Helpers;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Processors.Difficulty.Rulesets.Keys;
@@ -20,10 +22,12 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Converters.Malody;
 using Quaver.Shared.Converters.Osu;
 using Quaver.Shared.Converters.StepMania;
+using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Graphics.Backgrounds;
 using Quaver.Shared.Graphics.Notifications;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens;
 using Quaver.Shared.Screens.Edit;
 using Quaver.Shared.Screens.Importing;
@@ -35,6 +39,7 @@ using SharpCompress.Archives;
 using SharpCompress.Common;
 using Wobble;
 using Wobble.Logging;
+using YamlDotNet.Serialization;
 
 namespace Quaver.Shared.Database.Maps
 {
@@ -132,7 +137,7 @@ namespace Quaver.Shared.Database.Maps
         /// <param name="path">Path to file</param>
         private static bool AcceptedMapType(string path)
         {
-            return path.EndsWith(".qp") || path.EndsWith(".osz") || path.EndsWith(".sm") || path.EndsWith(".mcz") || path.EndsWith(".mc");
+            return path.EndsWith(".qp") || path.EndsWith(".qpl") || path.EndsWith(".osz") || path.EndsWith(".sm") || path.EndsWith(".mcz") || path.EndsWith(".mc");
         }
 
         /// <summary>
@@ -278,16 +283,11 @@ namespace Quaver.Shared.Database.Maps
                 ConfigManager.AutoLoadOsuBeatmaps.Value = true;
                 NotificationManager.Show(NotificationLevel.Success, $"Successfully set the path for your .db file");
             }
-            // Archive with maps (playlists)
+            // Archive with maps (batch import)
             else if (path.EndsWith(".zip"))
             {
                 var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
-                var tempFolder = $@"{ConfigManager.TempDirectory}";
-
-                if (Directory.Exists(tempFolder))
-                    Directory.Delete(tempFolder, true);
-
-                Directory.CreateDirectory(tempFolder);
+                var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}";
 
                 using (ZipArchive archive = ZipFile.OpenRead(path))
                 {
@@ -298,6 +298,10 @@ namespace Quaver.Shared.Database.Maps
                 {
                     ImportFile(file);
                 }
+
+                // delete zip file after all maps have been extracted
+                if (ConfigManager.DeleteOriginalFileAfterImport.Value)
+                    File.Delete(path);
             }
             // Folder with maps
             else if (File.GetAttributes(path).HasFlag(FileAttributes.Directory))
@@ -333,6 +337,8 @@ namespace Quaver.Shared.Database.Maps
 
             var done = -1;
 
+            var skipPlaylistReload = true;
+
             MapsetInfoRetriever.InfoUpdateEnabled = false;
             Parallel.For(0, Queue.Count, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
             {
@@ -358,6 +364,12 @@ namespace Quaver.Shared.Database.Maps
                         ExtractQuaverMapset(file, extractDirectory);
                         deleteOriginalFile = true;
                     }
+                    else if (file.EndsWith(".qpl"))
+                    {
+                        selectedMap = ExtractQuaverPlaylist(file);
+                        skipPlaylistReload = false;
+                        deleteOriginalFile = true;
+                    }
                     else if (file.EndsWith(".osz"))
                     {
                         Osu.ConvertOsz(file, extractDirectory);
@@ -378,11 +390,12 @@ namespace Quaver.Shared.Database.Maps
                     // If we are importing a mapset downloaded from in-game downloader,
                     // We should delete it no matter what
                     if ((deleteOriginalFile && ConfigManager.DeleteOriginalFileAfterImport.Value)
-                        || file.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
+                    || file.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
                         File.Delete(file);
 
-                    selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
-
+                    if (!file.EndsWith(".qpl"))
+                        selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
+                    
                     Logger.Important($"Successfully imported {file}", LogType.Runtime);
 
                     done++;
@@ -395,7 +408,7 @@ namespace Quaver.Shared.Database.Maps
                 }
             });
 
-            MapDatabaseCache.OrderAndSetMapsets(true);
+            MapDatabaseCache.OrderAndSetMapsets(skipPlaylistReload);
             Queue.Clear();
             MapsetInfoRetriever.InfoUpdateEnabled = true;
 
@@ -473,6 +486,95 @@ namespace Quaver.Shared.Database.Maps
                     }
                 }
             }
+        }
+
+        /// <summary>
+        ///     Responsible for extracting the files from the .qpl
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="extractPath"></param>
+        private static Map ExtractQuaverPlaylist(string fileName)
+        {
+            var options = new ExtractionOptions { ExtractFullPath = true, Overwrite = true };
+
+            var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
+            var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(fileName)} - {time}";
+
+            if (Directory.Exists(tempFolder))
+                Directory.Delete(tempFolder, true);
+
+            Directory.CreateDirectory(tempFolder);
+
+            // Extract files to temp directory
+            using (var archive = ArchiveFactory.Open(fileName))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    if (!entry.IsDirectory)
+                        entry.WriteToDirectory(tempFolder, options);
+                }
+            }
+
+            // Import mapsets
+            Map selectedMap = null;
+            foreach (var path in Directory.GetFiles(tempFolder, "*.qp", SearchOption.AllDirectories))
+            {
+                // Basically recreate the import process
+                var extractDirectory = $@"{ConfigManager.SongDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}/";
+
+                ExtractQuaverMapset(path, extractDirectory);
+                if (ConfigManager.DeleteOriginalFileAfterImport.Value || path.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
+                    File.Delete(path);
+
+                Logger.Important($"Successfully imported {path}", LogType.Runtime);
+
+                selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
+            }
+
+            // Find metadata file
+            var metadata = Directory.GetFiles(tempFolder, "metadata.json").FirstOrDefault();
+            if (metadata == null)
+            {
+                Logger.Log("metadata not found", LogLevel.Important, LogType.Runtime);
+                return selectedMap;
+            }
+
+            // Create playlist
+            dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(File.ReadAllText(metadata));
+
+            var onlineMapPoolId = (int)json.OnlineMapPoolId;
+            if(onlineMapPoolId > -1)
+                PlaylistManager.ImportPlaylist(onlineMapPoolId);
+            else
+            {
+                var isNewPlaylist = false;
+                var playlist = PlaylistManager.Playlists.Find(p => p.Name == json.Name && p.Description == json.Description && p.Creator == json.Creator);
+                if(playlist == null)
+                {
+                    isNewPlaylist = true;
+                    playlist = new Playlist()
+                    {
+                        Name = json.Name,
+                        Description = json.Description,
+                        Creator = json.Creator,
+                        OnlineMapPoolId = onlineMapPoolId,
+                        OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
+                    };
+                }
+                foreach (var map in json.Maps)
+                {
+                    playlist.Maps.Add(new Map { Md5Checksum = map });
+                }
+
+                if(isNewPlaylist)
+                    PlaylistManager.AddPlaylist(playlist);
+
+                ThreadScheduler.Run(() => playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x)));
+            }
+            
+            Directory.Delete(tempFolder, true);
+
+            return selectedMap;
         }
 
         /// <summary>

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -416,7 +416,7 @@ namespace Quaver.Shared.Database.Maps
                         File.Delete(file);
 
                     selectedMap = InsertAndUpdateSelectedMap(extractDirectory);
-                    
+
                     Logger.Important($"Successfully imported {file}", LogType.Runtime);
 
                     done++;

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -290,33 +290,39 @@ namespace Quaver.Shared.Database.Maps
             {
                 var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
                 var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}";
-
-                using (ZipArchive archive = ZipFile.OpenRead(path))
+                try
                 {
-                    archive.ExtractToDirectory(tempFolder);
-                }
-
-                ImportFile(tempFolder, true);
-
-                if(path.EndsWith(".qpl"))
-                {
-                    var metadata = Directory.GetFiles(tempFolder, "metadata.json").FirstOrDefault();
-                    if (metadata == null)
+                    using (ZipArchive archive = ZipFile.OpenRead(path))
                     {
-                        Logger.Log($"metadata not found for playlist {Path.GetFileName(path)}", LogLevel.Important, LogType.Runtime);
+                        archive.ExtractToDirectory(tempFolder);
                     }
 
-                    Queue.Add(metadata);
+                    ImportFile(tempFolder, true);
+
+                    if (path.EndsWith(".qpl"))
+                    {
+                        var metadata = Directory.GetFiles(tempFolder, "metadata.json").FirstOrDefault();
+                        if (metadata != null)
+                            Queue.Add(metadata);
+                        else 
+                            Logger.Log($"metadata not found for playlist {Path.GetFileName(path)}", LogLevel.Important, LogType.Runtime);
+                    }
+
+                    // Add parent folder for deletion after import
+                    Queue.Add(tempFolder);
+
+                    NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
+
+                    // delete file after all maps have been extracted
+                    if (ConfigManager.DeleteOriginalFileAfterImport.Value)
+                        File.Delete(path);
                 }
-
-                // Add parent folder for deletion after import
-                Queue.Add(tempFolder);
-
-                NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
-
-                // delete zip file after all maps have been extracted
-                if (ConfigManager.DeleteOriginalFileAfterImport.Value)
-                    File.Delete(path);
+                catch (Exception e)
+                {
+                    Logger.Error(e, LogType.Runtime);
+                    NotificationManager.Show(NotificationLevel.Error, $"Failed to import playlist");
+                }
+                
             }
             // Folder with maps
             else if (File.GetAttributes(path).HasFlag(FileAttributes.Directory))
@@ -352,7 +358,7 @@ namespace Quaver.Shared.Database.Maps
 
             var done = -1;
 
-            // Remove temp folder from import queue
+            // Remove batch import temp folder from queue
             var tempFolders = Queue.FindAll(f => File.GetAttributes(f).HasFlag(FileAttributes.Directory));
             tempFolders.ForEach(tf => Queue.Remove(tf));
 
@@ -425,6 +431,7 @@ namespace Quaver.Shared.Database.Maps
             });
 
             // Import playlist
+            var importedPlaylist = new List<Playlist>();
             Parallel.For(0, playlistsMetadata.Count, new ParallelOptions { MaxDegreeOfParallelism = 4 }, i =>
             {
                 var metadata = playlistsMetadata[i];
@@ -435,45 +442,54 @@ namespace Quaver.Shared.Database.Maps
 
                     var onlineMapPoolId = (int)json.OnlineMapPoolId;
                     if (onlineMapPoolId > -1)
+                    {
                         PlaylistManager.ImportPlaylist(onlineMapPoolId);
+                        return;
+                    }
+
+                    var isNewPlaylist = false;
+                    var playlist = PlaylistManager.Playlists.Find(p => p.Name == json.Name && p.Description == json.Description && p.Creator == json.Creator);
+                    if (playlist == null)
+                    {
+                        isNewPlaylist = true;
+                        playlist = new Playlist()
+                        {
+                            Name = json.Name,
+                            Description = json.Description,
+                            Creator = json.Creator,
+                            OnlineMapPoolId = onlineMapPoolId,
+                            OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
+                        };
+                    }
                     else
                     {
-                        var isNewPlaylist = false;
-                        var playlist = PlaylistManager.Playlists.Find(p => p.Name == json.Name && p.Description == json.Description && p.Creator == json.Creator);
-                        if (playlist == null)
+                        // Update playlist content to match metadata's content
+                        playlist.Maps.Where(m => !json.Maps.Contains(m.Md5Checksum)).ToList().ForEach(m =>
                         {
-                            isNewPlaylist = true;
-                            playlist = new Playlist()
-                            {
-                                Name = json.Name,
-                                Description = json.Description,
-                                Creator = json.Creator,
-                                OnlineMapPoolId = onlineMapPoolId,
-                                OnlineMapPoolCreatorId = (int)json.OnlineMapPoolCreatorId
-                            };
-                        }
-                        else
-                        {
-                            // Update playlist content to match metadata's content
-                            playlist.Maps.Where(m => !json.Maps.Contains(m.Md5Checksum)).ToList().ForEach(m =>
-                            {
-                                PlaylistManager.RemoveMapFromPlaylist(playlist, m);
-                            });
-                        }
-
-                        foreach (var map in json.Maps)
-                        {
-                            if (playlist.Maps.Find(m => m.Md5Checksum == map) != null)
-                                continue;
-
-                            playlist.Maps.Add(new Map { Md5Checksum = map });
-                        }
-
-                        if (isNewPlaylist)
-                            PlaylistManager.AddPlaylist(playlist);
-
-                        playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x));
+                            PlaylistManager.RemoveMapFromPlaylist(playlist, m);
+                        });
                     }
+
+                    foreach (var map in json.Maps)
+                    {
+                        if (playlist.Maps.Find(m => m.Md5Checksum == map) != null)
+                            continue;
+
+                        playlist.Maps.Add(new Map { Md5Checksum = map });
+                    }
+
+                    // Check if current playlist hasn't already been imported during this import
+                    if (importedPlaylist.Contains(playlist))
+                    {
+                        Logger.Important($"Playlist {playlist.Name} has already been imported, skipping...", LogType.Runtime);
+                        return;
+                    }
+
+                    if (isNewPlaylist)
+                        PlaylistManager.AddPlaylist(playlist);
+
+                    playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x));
+                    importedPlaylist.Add(playlist);
                 }
                 catch (Exception e)
                 {
@@ -482,7 +498,7 @@ namespace Quaver.Shared.Database.Maps
                 }
             });
 
-            // delete temp files associated to batch import
+            // delete temp folders
             tempFolders.ForEach(d => Directory.Delete(d, true));
 
             MapDatabaseCache.OrderAndSetMapsets(playlistsMetadata.Count == 0);

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -294,7 +294,7 @@ namespace Quaver.Shared.Database.Maps
                     archive.ExtractToDirectory(tempFolder);
                 }
 
-                foreach (var file in Directory.GetFiles(tempFolder))
+                foreach (var file in Directory.GetFiles(tempFolder, "*", SearchOption.AllDirectories))
                 {
                     ImportFile(file);
                 }
@@ -568,8 +568,8 @@ namespace Quaver.Shared.Database.Maps
 
                 if(isNewPlaylist)
                     PlaylistManager.AddPlaylist(playlist);
-
-                ThreadScheduler.Run(() => playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x)));
+                    
+                playlist.Maps.ForEach(x => PlaylistManager.AddMapToPlaylist(playlist, x));
             }
             
             Directory.Delete(tempFolder, true);

--- a/Quaver.Shared/Database/Maps/MapsetImporter.cs
+++ b/Quaver.Shared/Database/Maps/MapsetImporter.cs
@@ -155,7 +155,7 @@ namespace Quaver.Shared.Database.Maps
                 }
             }
 
-            if(! silent)
+            if(!silent)
                 NotificationManager.Show(NotificationLevel.Info, $"Scheduled {Path.GetFileName(path)} to be imported!");
 
             Queue.Add(path);
@@ -287,7 +287,7 @@ namespace Quaver.Shared.Database.Maps
             // Archive with maps (batch import)
             else if (path.EndsWith(".zip") || path.EndsWith(".qpl"))
             {
-                var time = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).Milliseconds;
+                var time = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 var tempFolder = $@"{ConfigManager.TempDirectory}/{Path.GetFileNameWithoutExtension(path)} - {time}";
                 try
                 {
@@ -412,7 +412,7 @@ namespace Quaver.Shared.Database.Maps
                     // If we are importing a mapset downloaded from in-game downloader,
                     // We should delete it no matter what
                     if ((deleteOriginalFile && ConfigManager.DeleteOriginalFileAfterImport.Value)
-                    || file.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
+                        || file.IsSubDirectoryOf(ConfigManager.DataDirectory.Value))
                         File.Delete(file);
 
                     selectedMap = InsertAndUpdateSelectedMap(extractDirectory);

--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using Microsoft.Xna.Framework.Media;
+using Newtonsoft.Json;
 using Quaver.API.Enums;
 using Quaver.API.Maps.Parsers;
 using Quaver.Shared.Config;
@@ -54,6 +57,7 @@ namespace Quaver.Shared.Database.Playlists
         ///     The maps that are inside of the playlist
         /// </summary>
         [Ignore]
+        [JsonIgnore]
         public List<Map> Maps { get; set; } = new List<Map>();
 
         /// <summary>
@@ -74,15 +78,17 @@ namespace Quaver.Shared.Database.Playlists
         public void Export()
         {
             var mapsetsAdded = new List<Mapset>();
+            var mapsMd5 = new List<string>();
 
             var tempFolder = $"{ConfigManager.TempDirectory}/{GameBase.Game.TimeRunning}/";
             Directory.CreateDirectory(tempFolder);
-            var outputPath = $"{ConfigManager.DataDirectory}/Exports/{StringHelper.FileNameSafeString(Name)}.zip";
+            var outputPath = $"{ConfigManager.DataDirectory}/Exports/{StringHelper.FileNameSafeString(Name)}.qpl";
 
             using (var archive = ZipArchive.Create())
             {
                 foreach (var map in Maps)
                 {
+                    mapsMd5.Add(map.Md5Checksum);
                     if (mapsetsAdded.Contains(map.Mapset))
                         continue;
 
@@ -132,7 +138,14 @@ namespace Quaver.Shared.Database.Playlists
                         mapsetsAdded.Add(map.Mapset);
                     }
                 }
+                // add playlist metadata
+                var json = JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+                dynamic obj = JsonConvert.DeserializeObject<ExpandoObject>(json);
+                obj.Maps = mapsMd5;
+                json = JsonConvert.SerializeObject(obj);
+                File.WriteAllText($"{tempFolder}/metadata.json", json);
 
+                archive.AddAllFromDirectory(tempFolder, "*.json");
                 archive.AddAllFromDirectory(tempFolder, "*.qp");
                 archive.SaveTo(outputPath, CompressionType.Deflate);
             }

--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -82,7 +82,10 @@ namespace Quaver.Shared.Database.Playlists
 
             var tempFolder = $"{ConfigManager.TempDirectory}/{GameBase.Game.TimeRunning}/";
             Directory.CreateDirectory(tempFolder);
-            var outputPath = $"{ConfigManager.DataDirectory}/Exports/{StringHelper.FileNameSafeString(Name)}.{(exportMode == ExportMode.Zip ? "zip" : "qpl")}";
+            var exportsDirectory = $"{ConfigManager.DataDirectory}/Exports";
+            Directory.CreateDirectory(exportsDirectory);
+            
+            var outputPath = $"{exportsDirectory}/{StringHelper.FileNameSafeString(Name)}.{(exportMode == ExportMode.Zip ? "zip" : "qpl")}";
 
             using (var archive = ZipArchive.Create())
             {

--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -75,14 +75,14 @@ namespace Quaver.Shared.Database.Playlists
         /// <summary>
         ///     Exports the playlist to a directory
         /// </summary>
-        public void Export()
+        public void Export(ExportMode exportMode)
         {
             var mapsetsAdded = new List<Mapset>();
             var mapsMd5 = new List<string>();
 
             var tempFolder = $"{ConfigManager.TempDirectory}/{GameBase.Game.TimeRunning}/";
             Directory.CreateDirectory(tempFolder);
-            var outputPath = $"{ConfigManager.DataDirectory}/Exports/{StringHelper.FileNameSafeString(Name)}.qpl";
+            var outputPath = $"{ConfigManager.DataDirectory}/Exports/{StringHelper.FileNameSafeString(Name)}.{(exportMode == ExportMode.Zip ? "zip" : "qpl")}";
 
             using (var archive = ZipArchive.Create())
             {
@@ -138,14 +138,18 @@ namespace Quaver.Shared.Database.Playlists
                         mapsetsAdded.Add(map.Mapset);
                     }
                 }
-                // add playlist metadata
-                var json = JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
-                dynamic obj = JsonConvert.DeserializeObject<ExpandoObject>(json);
-                obj.Maps = mapsMd5;
-                json = JsonConvert.SerializeObject(obj);
-                File.WriteAllText($"{tempFolder}/metadata.json", json);
 
-                archive.AddAllFromDirectory(tempFolder, "*.json");
+                // add playlist metadata
+                if (exportMode == ExportMode.Playlist)
+                {
+                    var json = JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+                    dynamic obj = JsonConvert.DeserializeObject<ExpandoObject>(json);
+                    obj.Maps = mapsMd5;
+                    json = JsonConvert.SerializeObject(obj);
+                    File.WriteAllText($"{tempFolder}/metadata.json", json);
+                    archive.AddAllFromDirectory(tempFolder, "*.json");
+                }
+                
                 archive.AddAllFromDirectory(tempFolder, "*.qp");
                 archive.SaveTo(outputPath, CompressionType.Deflate);
             }
@@ -182,5 +186,11 @@ namespace Quaver.Shared.Database.Playlists
         }
 
         public void OpenUrl() => BrowserHelper.OpenURL($"https://quavergame.com/playlist/{OnlineMapPoolId}");
+
+        public enum ExportMode
+        {
+            Zip,
+            Playlist
+        }
     }
 }

--- a/Quaver.Shared/Database/Playlists/Playlist.cs
+++ b/Quaver.Shared/Database/Playlists/Playlist.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -145,10 +144,17 @@ namespace Quaver.Shared.Database.Playlists
                 // add playlist metadata
                 if (exportMode == ExportMode.Playlist)
                 {
-                    var json = JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
-                    dynamic obj = JsonConvert.DeserializeObject<ExpandoObject>(json);
-                    obj.Maps = mapsMd5;
-                    json = JsonConvert.SerializeObject(obj);
+                    var metadata = new PlaylistExportMetadata
+                    {
+                        Name = Name,
+                        Creator = Creator,
+                        Description = Description,
+                        OnlineMapPoolId = OnlineMapPoolId,
+                        OnlineMapPoolCreatorId = OnlineMapPoolCreatorId,
+                        Maps = mapsMd5
+                    };
+
+                    var json = JsonConvert.SerializeObject(metadata);
                     File.WriteAllText($"{tempFolder}/metadata.json", json);
                     archive.AddAllFromDirectory(tempFolder, "*.json");
                 }
@@ -194,6 +200,21 @@ namespace Quaver.Shared.Database.Playlists
         {
             Zip,
             Playlist
+        }
+
+        internal class PlaylistExportMetadata
+        {
+            public string Name { get; set; }
+
+            public string Creator { get; set; }
+
+            public string Description { get; set; }
+
+            public int OnlineMapPoolId { get; set; }
+
+            public int OnlineMapPoolCreatorId { get; set; }
+
+            public List<string> Maps { get; set; }
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/Dialogs/ExportPlaylistDialog.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/Dialogs/ExportPlaylistDialog.cs
@@ -1,12 +1,13 @@
 using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Graphics;
+using static Quaver.Shared.Database.Playlists.Playlist;
 
 namespace Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs
 {
     public class ExportPlaylistDialog : LoadingDialog
     {
-        public ExportPlaylistDialog(Playlist playlist) : base("Export Playlist",
-            "Please wait while your playlist is being exported...", () => playlist.Export())
+        public ExportPlaylistDialog(Playlist playlist, ExportMode exportMode) : base("Export Playlist",
+            "Please wait while your playlist is being exported...", () => playlist.Export(exportMode))
         {
         }
     }

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistRightClickOptions.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Screens.Selection.UI.Playlists.Dialogs.Create;
 using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Dialogs;
+using static Quaver.Shared.Database.Playlists.Playlist;
 using ColorHelper = Quaver.Shared.Helpers.ColorHelper;
 
 namespace Quaver.Shared.Screens.Selection.UI.Playlists
@@ -31,6 +32,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         private const string Delete = "Delete";
 
         private const string Sync = "Sync Map Pool";
+
+        private const string ExportToPlaylist = "Export To Playlist";
 
         private const string ExportToZip = "Export To Zip";
 
@@ -81,7 +84,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                         DialogManager.Show(new SyncPlaylistDialog(Playlist));
                         break;
                     case ExportToZip:
-                        DialogManager.Show(new ExportPlaylistDialog(Playlist));
+                        DialogManager.Show(new ExportPlaylistDialog(Playlist, ExportMode.Zip));
+                        break;
+                    case ExportToPlaylist:
+                        DialogManager.Show(new ExportPlaylistDialog(Playlist, ExportMode.Playlist));
                         break;
                     case Edit:
                         if (Playlist.IsOnlineMapPool() && Playlist.OnlineMapPoolCreatorId != OnlineManager.Self.OnlineUser.Id)
@@ -136,6 +142,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
                 {Edit, ColorHelper.HexToColor("#F2994A")},
                 {Delete, ColorHelper.HexToColor($"#FF6868")},
                 {ExportToZip, ColorHelper.HexToColor("#0787E3")},
+                {ExportToPlaylist, ColorHelper.HexToColor("#27B06E")},
                 {Copy, ColorHelper.HexToColor("#0FBAE5")}
             };
 

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/PlaylistRightClickOptions.cs
@@ -33,7 +33,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
 
         private const string Sync = "Sync Map Pool";
 
-        private const string ExportToPlaylist = "Export To Playlist";
+        private const string ExportToPlaylist = "Export Playlist";
 
         private const string ExportToZip = "Export To Zip";
 


### PR DESCRIPTION
Add new ways of importing / exporting Playlists

**Exporting**
- Export to zip: old exporting method, all map files are archived to a zip file
- Export to Playlist: new way of exporting, export maps to a .qpl file

**Importing**
- Importing .zip files: batch import of maps
- Importing .qpl files:  create / update playlists. A playlist will  be updated if we find a playlist online id or if an existing playlist already have the same Name, Description and Creator as the file being imported