### PR TITLE
Copy all files recursively instead of just one layer for Malody chart import

### DIFF
--- a/Quaver.Shared/Converters/Malody/Malody.cs
+++ b/Quaver.Shared/Converters/Malody/Malody.cs
@@ -48,7 +48,7 @@ namespace Quaver.Shared.Converters.Malody
             Directory.CreateDirectory(extractDirectory);
 
             // Go through each file in the temp folder and add it to the target directory
-            foreach (var tempFile in Directory.GetFiles(tempFolder))
+            foreach (var tempFile in Directory.GetFiles(tempFolder, "*.*", SearchOption.AllDirectories))
             {
                 var fileName = $"{extractDirectory}/{Path.GetFileName(tempFile)}";
 


### PR DESCRIPTION
[Sterelogue.zip](https://github.com/user-attachments/files/25823269/Sterelogue.zip)

The attached file contains an .mcz file exported from Malody V, which, after import, will be unable to play due to it missing audio and background file. This is because the .mcz file's directory structure is a folder `0`, with all files under it, and our Malody importer just copied all files from the root directory instead of recursively. This PR changes it so that it copies all files recursively to the root directory of the resulting folder.