### PR TITLE
Add keybind for mines

### DIFF
--- a/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputConfig.cs
@@ -223,6 +223,7 @@ namespace Quaver.Shared.Screens.Edit.Input
             {ChangeToolToSelect, new KeybindList(Keys.Q)},
             {ChangeToolToNote, new KeybindList(Keys.W)},
             {ChangeToolToLongNote, new KeybindList(Keys.E)},
+            {ChangeToolToMine, new KeybindList(Keys.R)},
             {IncreaseSnap, new KeybindList(new[] {new Keybind(Keys.Right), new Keybind(KeyModifiers.Shift, Keys.Right), new Keybind(KeyModifiers.Free, Keys.L), new Keybind(KeyModifiers.Ctrl, MouseScrollDirection.Up)})},
             {DecreaseSnap, new KeybindList(new[] {new Keybind(Keys.Left), new Keybind(KeyModifiers.Shift, Keys.Left), new Keybind(KeyModifiers.Free, Keys.J), new Keybind(KeyModifiers.Ctrl, MouseScrollDirection.Down)})},
             {ChangeSnapTo1, new KeybindList(new [] {new Keybind(KeyModifiers.Shift, Keys.D1)})},
@@ -313,7 +314,7 @@ namespace Quaver.Shared.Screens.Edit.Input
             {Save, new KeybindList(new[] {new Keybind(Keys.S), new Keybind(KeyModifiers.Ctrl, Keys.S)})},
             {Deselect, new KeybindList(new[] {new Keybind(Keys.D), new Keybind(KeyModifiers.Ctrl, Keys.D)})},
             {ApplyOffsetToMap, new KeybindList()},
-            {ResnapToCurrentBeatSnap, new KeybindList(new[] {new Keybind(Keys.R), new Keybind(KeyModifiers.Ctrl, Keys.R)})},
+            {ResnapToCurrentBeatSnap, new KeybindList(new[] {new Keybind(KeyModifiers.Ctrl, Keys.R)})},
             {AddBookmark, new KeybindList(KeyModifiers.Ctrl, Keys.B)},
             {SeekToLastBookmark, new KeybindList(KeyModifiers.Ctrl, Keys.Left)},
             {SeekToNextBookmark, new KeybindList(KeyModifiers.Ctrl, Keys.Right)}

--- a/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
+++ b/Quaver.Shared/Screens/Edit/Input/EditorInputManager.cs
@@ -393,6 +393,9 @@ namespace Quaver.Shared.Screens.Edit.Input
                 case KeybindActions.ChangeToolToLongNote:
                     Screen.ChangeToolTo(EditorCompositionTool.LongNote);
                     break;
+                case KeybindActions.ChangeToolToMine:
+                    Screen.ChangeToolTo(EditorCompositionTool.Mine);
+                    break;
                 case KeybindActions.IncreaseSnap:
                     Screen.ChangeBeatSnap(Direction.Forward);
                     break;

--- a/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
+++ b/Quaver.Shared/Screens/Edit/Input/KeybindActions.cs
@@ -42,6 +42,7 @@ namespace Quaver.Shared.Screens.Edit.Input
         ChangeToolToSelect,
         ChangeToolToNote,
         ChangeToolToLongNote,
+        ChangeToolToMine,
         IncreaseSnap,
         DecreaseSnap,
         ChangeSnapTo1,


### PR DESCRIPTION
Self-explanatory; follows the paradigm in #4586 (QWER paradigm) and removes `R` default from resnap.