### PR TITLE
Expose HitObjectColoring to plugins

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -63,6 +63,7 @@ using Quaver.Shared.Screens.Edit.Actions.TimingGroups.MoveObjectsToTimingGroup;
 using Quaver.Shared.Screens.Edit.Actions.TimingGroups.Remove;
 using Quaver.Shared.Screens.Edit.Actions.TimingGroups.Rename;
 using Quaver.Shared.Screens.Edit.Components;
+using Quaver.Shared.Screens.Edit.UI.Playfield;
 using Quaver.Shared.Scripting;
 using Wobble.Logging;
 
@@ -828,6 +829,15 @@ namespace Quaver.Shared.Screens.Edit.Actions
         /// <param name="bookmarks"></param>
         /// <param name="offset"></param>
         public void ChangeBookmarkBatchOffset(List<BookmarkInfo> bookmarks, int offset, bool fromLua = false) => Perform(new EditorActionChangeBookmarkOffsetBatch(this, WorkingMap, bookmarks, offset), fromLua);
+
+        /// <summary>
+        ///     Sets the hit object coloring mode of the editor
+        /// </summary>
+        /// <param name="type"></param>
+        public void SetViewColoring(HitObjectColoring hitObjectColoringType)
+        {
+            EditScreen.ObjectColoring.Value = hitObjectColoringType;
+        }
 
         /// <summary>
         ///     Triggers an event of a specific action type

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -6,6 +6,7 @@ using Quaver.API.Enums;
 using Quaver.API.Maps;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Screens.Edit.Components;
+using Quaver.Shared.Screens.Edit.UI.Playfield;
 
 namespace Quaver.Shared.Screens.Edit.Actions
 {
@@ -254,6 +255,8 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         public void MoveObjectsToTimingGroup(List<HitObjectInfo> hitObjects, string timingGroupId) =>
             ActionManager.MoveObjectsToTimingGroup(hitObjects, timingGroupId, true);
+
+        public void SetViewColoring(HitObjectColoring hitObjectColoringType) => ActionManager.SetViewColoring(hitObjectColoringType);
 
         public void Destroy()
         {

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPlugin.cs
@@ -7,6 +7,7 @@ using Quaver.API.Enums;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Config;
 using Quaver.Shared.Screens.Edit.Actions;
+using Quaver.Shared.Screens.Edit.UI.Playfield;
 using Quaver.Shared.Scripting;
 
 namespace Quaver.Shared.Screens.Edit.Plugins
@@ -18,6 +19,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         static readonly DynValue s_hitSounds = DefineEnum<HitSounds>();
 
         static readonly DynValue s_hitObjectType = DefineEnum<HitObjectType>();
+
+        static readonly DynValue s_hitObjectColoring = DefineEnum<HitObjectColoring>();
 
         static readonly DynValue s_gameMode = DefineEnum<GameMode>();
 
@@ -113,6 +116,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
                 globals["action_type"] = s_actionType;
                 globals["actions"] = Editor.ActionManager.PluginActionManager;
                 globals["map"] = EditorPluginMap;
+                globals["coloring_type"] = s_hitObjectColoring;
             }
 
             base.SetFrameState();


### PR DESCRIPTION
Adds a new enum `coloring_mode` with Timing/Layer/None which specifies the coloring mode of the Edit screen
Adds an action function that allows changing of the Edit screen's color mode via the `actions.SetViewColoring` function