### PR TITLE
properly skip ranked status check when offline

### DIFF
--- a/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemUpdateRankedStatuses.cs
+++ b/Quaver.Shared/Screens/Options/Items/Custom/OptionsItemUpdateRankedStatuses.cs
@@ -54,10 +54,6 @@ namespace Quaver.Shared.Screens.Options.Items.Custom
                     return;
                 }
 
-                IsRunning = true;
-
-                NotificationManager.Show(NotificationLevel.Info, "Your maps' ranked statuses are now being updated in the background...");
-
                 Run();
             };
         }
@@ -65,7 +61,16 @@ namespace Quaver.Shared.Screens.Options.Items.Custom
         public static void Run(bool fromOptions = true)
         {
             // Don't run if client is not connected
-            if (!OnlineManager.Connected) return;
+            if (!OnlineManager.Connected)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "Cannot update ranked statuses when not online.");
+                return;
+            }
+
+            if (fromOptions)
+                IsRunning = true;
+
+            NotificationManager.Show(NotificationLevel.Info, "Your maps' ranked statuses are now being updated in the background...");
 
             var mapsets = new List<Mapset>(MapManager.Mapsets);
 


### PR DESCRIPTION
using the "update ranked statuses" button when offline doesnt notify the user that the action was cancelled. it also sets IsRunning to true, but Run() returns early without ever resetting it it to false, so subsequent runs will always say the action is still running