### PR TITLE
[BREAKING] Rename vector.Length to vector.Count

### DIFF
--- a/Quaver.Shared/Scripting/LuaVectorWrapper.cs
+++ b/Quaver.Shared/Scripting/LuaVectorWrapper.cs
@@ -45,6 +45,15 @@ namespace Quaver.Shared.Scripting
                 }
             );
 
+        public static int Count(DynValue value) =>
+            CoerceToVectorOrFloat(value) switch
+            {
+                float or Vector2 => 2,
+                Vector3 => 3,
+                Vector4 => 4,
+                _ => throw Unreachable(value),
+            };
+
         public static Vector3 Cross(DynValue first, DynValue second) =>
             0 switch
             {
@@ -92,12 +101,13 @@ namespace Quaver.Shared.Scripting
                 _ => throw Unreachable(first, second),
             };
 
-        public static int Length(DynValue value) =>
+        public static float Length(DynValue value) =>
             CoerceToVectorOrFloat(value) switch
             {
-                float or Vector2 => 2,
-                Vector3 => 3,
-                Vector4 => 4,
+                float f => f,
+                Vector2 v => v.Length(),
+                Vector3 v => v.Length(),
+                Vector4 v => v.Length(),
                 _ => throw Unreachable(value),
             };
 
@@ -359,12 +369,12 @@ namespace Quaver.Shared.Scripting
                     _ => null,
                 }) :
                 typeof(T) == typeof(Vector3) ? (T?)(object)(Vector3?)(val switch
-                    {
-                        float f => f.ToVector3(),
-                        Vector2 v => v.ToVector3(),
-                        Vector3 v => v,
-                        _ => null,
-                    }) :
+                {
+                    float f => f.ToVector3(),
+                    Vector2 v => v.ToVector3(),
+                    Vector3 v => v,
+                    _ => null,
+                }) :
                     typeof(T) == typeof(Vector4) ? (T?)(object)(Vector4?)(val switch
                     {
                         float f => f.ToVector4(),
@@ -384,9 +394,10 @@ namespace Quaver.Shared.Scripting
         private static DynValue Create(IFormattable value) => UserData.Create(value);
 
         private static IFormattable CoerceToVectorOrFloat(DynValue value) =>
-            value is {
-                Type: DataType.UserData, UserData.Object: not Vector2 and not Vector3 and not Vector4,
-            } or { Type: DataType.Nil }
+            value is
+        {
+            Type: DataType.UserData, UserData.Object: not Vector2 and not Vector3 and not Vector4,
+        } or { Type: DataType.Nil }
                 ? 0
                 : value.TryCoerceToFloat() ??
                 (value.Type is DataType.UserData ? (IFormattable)value.UserData.Object :

--- a/Quaver.Shared/Scripting/LuaVectorWrapper.cs
+++ b/Quaver.Shared/Scripting/LuaVectorWrapper.cs
@@ -111,6 +111,17 @@ namespace Quaver.Shared.Scripting
                 _ => throw Unreachable(value),
             };
 
+        public static float LengthSquared(DynValue value) =>
+            CoerceToVectorOrFloat(value) switch
+            {
+                float f => f,
+                Vector2 v => v.LengthSquared(),
+                Vector3 v => v.LengthSquared(),
+                Vector4 v => v.LengthSquared(),
+                _ => throw Unreachable(value),
+            };
+
+
         public static DynValue Lerp(DynValue first, DynValue second, DynValue third) =>
             Create(
                 0 switch

--- a/Quaver.Shared/Scripting/LuaVectorWrapper.cs
+++ b/Quaver.Shared/Scripting/LuaVectorWrapper.cs
@@ -405,10 +405,10 @@ namespace Quaver.Shared.Scripting
         private static DynValue Create(IFormattable value) => UserData.Create(value);
 
         private static IFormattable CoerceToVectorOrFloat(DynValue value) =>
-            value is
-        {
-            Type: DataType.UserData, UserData.Object: not Vector2 and not Vector3 and not Vector4,
-        } or { Type: DataType.Nil }
+            value is {
+                Type: DataType.UserData,
+                UserData.Object: not Vector2 and not Vector3 and not Vector4,
+            } or { Type: DataType.Nil }
                 ? 0
                 : value.TryCoerceToFloat() ??
                 (value.Type is DataType.UserData ? (IFormattable)value.UserData.Object :


### PR DESCRIPTION
This has been bothering me for so long and I don't think it'd break anything significant (most people dont even know the vector global exists)

## OLD:
`vector.Length(vctr)` would return the NUMBER of ITEMS in a vector. This is similar to `Vector<T>Count(vctr)` in C#.

## NEW:
`vector.Length(vctr)` now returns the mathematical length of the vector (its magnitude).
`vector.Count(vctr)` now returns the number of items in a vector.