### PR TITLE
During play test, pressing pause key should return to editor.

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -710,27 +710,28 @@ namespace Quaver.Shared.Screens.Gameplay
                 return;
             }
 
+            // Go back to editor if we're currently play testing.
+            if (IsPlayTesting)
+            {
+                if (AudioEngine.Track.IsPlaying)
+                {
+                    AudioEngine.Track.Pause();
+                    AudioEngine.Track.Seek(PlayTestAudioTime);
+                }
+
+                CustomAudioSampleCache.StopAll();
+
+                if (IsTestPlayingInNewEditor)
+                    ExitToNewEditor();
+                else
+                    Exit(() => new EditorScreen(OriginalEditorMap));
+            }
+
             // If the pause key was just pressed...
             if (GenericKeyManager.IsUniquePress(ConfigManager.KeyPause.Value))
             {
-                // Go back to editor if we're currently play testing.
-                if (IsPlayTesting)
-                {
-                    if (AudioEngine.Track.IsPlaying)
-                    {
-                        AudioEngine.Track.Pause();
-                        AudioEngine.Track.Seek(PlayTestAudioTime);
-                    }
-
-                    CustomAudioSampleCache.StopAll();
-
-                    if (IsTestPlayingInNewEditor)
-                        ExitToNewEditor();
-                    else
-                        Exit(() => new EditorScreen(OriginalEditorMap));
-                }
                 // Exit the offset calibration.
-                else if (IsCalibratingOffset)
+                if (IsCalibratingOffset)
                 {
                     OffsetConfirmDialog.Exit(this);
                 }


### PR DESCRIPTION
This is a fix to #4447.

I have followed the steps in the latest version of Quaver and found the following:
- Gameplay pause menu appears even thought it should not 
- The back option didn't cause any problem on the editor side

This PR only fix the gameplay pause menu that should not appear.

Pause wasn't considered has uniquely pressed.
