### PR TITLE
Fix #4578: Timing Point Editor, Clamp BPM to a minimum of 0

### DIFF
--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -339,7 +339,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (ImGui.InputFloat("##bpm", ref bpm, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
             {
-                bpm = Math.Max(0f, bpm);
+                bpm = Math.Max(0.1f, bpm);
                 if (SelectedTimingPoints.Count == 1)
                     Screen.ActionManager.ChangeTimingPointBpm(SelectedTimingPoints.First(), bpm);
                 else

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -339,7 +339,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (ImGui.InputFloat("##bpm", ref bpm, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
             {
-                bpm = Math.Max(0.1f, bpm);
+                bpm = Math.Max(0f, bpm);
                 if (SelectedTimingPoints.Count == 1)
                     Screen.ActionManager.ChangeTimingPointBpm(SelectedTimingPoints.First(), bpm);
                 else

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -339,6 +339,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
 
             if (ImGui.InputFloat("##bpm", ref bpm, 1, 0.1f, format, ImGuiInputTextFlags.EnterReturnsTrue | ImGuiInputTextFlags.AutoSelectAll))
             {
+                bpm = Math.Max(0f, bpm);
                 if (SelectedTimingPoints.Count == 1)
                     Screen.ActionManager.ChangeTimingPointBpm(SelectedTimingPoints.First(), bpm);
                 else


### PR DESCRIPTION
# Fix #4578

## What I could reproduce:
When I'm in the Editor, in Timing Point Editor, and I make the BPM value go below 0 then Quaver crash.
Nothing logged inside 'runtime.log'.

## What I did to fix this:
I added a clamp of the BPM value to a minimum of 0 post-change.
I don't know much about what should be a correct BPM value but [0;+inf[ seemed to works so I kept it as is.
Maybe a [1;+inf[ range would be preferable?