### PR TITLE
Fix #4517: Don't consider workshop content without skin.ini as a skin

### DIFF
--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -947,8 +947,6 @@ namespace Quaver.Shared.Skinning
                         workshopList.Add($"Unknown <{new DirectoryInfo(directory).Name}>");
                     }
                 }
-                else
-                    workshopList.Add($"({new DirectoryInfo(directory).Name})");
             }
 
             workshopList.Sort();


### PR DESCRIPTION
# Fix 4517
## What I could reproduce
- I Installed Workshop plugin "Pattern Master"
- Found the plugin inside Skin selection
## What I have modified to fix this
If there is no "skin.ini" inside workshop content it should not be considered as a skin and should not be returned as a value in "GetSkins".