### PR TITLE
Song select menus optimizations

### DIFF
--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -497,15 +497,15 @@ namespace Quaver.Shared.Screens.Options
         private void CreateContentContainers()
         {
             ContentContainers = new Dictionary<OptionsSection, OptionsContentContainer>();
-
-            foreach (var section in Sections)
-                ContentContainers.Add(section, new OptionsContentContainer(section, Content.Size));
         }
 
         /// <summary>
         /// </summary>
         private void SetActiveContentContainer()
         {
+            if (!ContentContainers.ContainsKey(SelectedSection.Value))
+                ContentContainers.Add(SelectedSection.Value, new OptionsContentContainer(SelectedSection.Value, Content.Size));
+
             foreach (var container in ContentContainers)
                 container.Value.Parent = SelectedSection.Value == container.Key ? Content : null;
         }

--- a/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreenView.cs
@@ -343,7 +343,9 @@ namespace Quaver.Shared.Screens.Selection
         private void OnActiveLeftPanelChanged(object sender, BindableValueChangedEventArgs<SelectContainerPanel> e)
         {
             LeaderboardContainer.ClearAnimations();
+            MapPreviewContainer.ClearAnimations();
             ModifierSelector.ClearAnimations();
+            ProfileContainer.ClearAnimations();
 
             const int animTime = 400;
             const Easing easing = Easing.OutQuint;

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/LeaderboardContainer.cs
@@ -408,12 +408,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
         /// </summary>
         public void StartLoading()
         {
+            ScoresContainer.StartLoading();
+
             foreach (var x in new List<Drawable>(Children))
             {
                 if (x is ILoadable loadable)
                     loadable.StartLoading();
-
-                ScoresContainer.StartLoading();
 
                 const int animTime = 20;
 
@@ -429,12 +429,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard
         /// </summary>
         public void StopLoading()
         {
+            ScoresContainer.StopLoading();
+
             foreach (var x in new List<Drawable>(Children))
             {
                 if (x is ILoadable loadable)
                     loadable.StopLoading();
-
-                ScoresContainer.StopLoading();
             }
         }
 


### PR DESCRIPTION
This aim to reduce / remove lagspikes when switching between map preview and other menus inside the map select screen.
Also tried to optimize leaderboard and option section, but can't really tell if this improves the performances