### PR TITLE
Chat messages overlapping: Round 2

### DIFF
--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -377,19 +377,19 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         }
 
         /// <summary>
-        ///     Checks whether a message has already been added. Chat messages are often re-created as
-        ///     separate objects between local echo, server echo, and history fetches, so reference equality
-        ///     is not enough to prevent duplicate drawables.
+        ///     Checks whether a message has already been added. Messages can be re-created as separate
+        ///     objects when coming from history or queue paths, so compare stable message fields too.
         /// </summary>
         /// <param name="messages"></param>
         /// <param name="message"></param>
         /// <returns></returns>
         private static bool ContainsMessage(List<ChatMessage> messages, ChatMessage message)
         {
-            return messages.Any(x => x.SenderId == message.SenderId
+            return messages.Any(x => ReferenceEquals(x, message)
+                                     || x.SenderId == message.SenderId
                                      && x.Channel == message.Channel
                                      && x.Message == message.Message
-                                     && Math.Abs(x.Time - message.Time) < 1000);
+                                     && x.Time == message.Time);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -159,8 +159,9 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 ForceScrollToBottom = false;
             }
 
-            base.Update(gameTime);
             UpdateVisibleMessageDrawables();
+
+            base.Update(gameTime);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -64,6 +64,11 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         private const int MaxMessagesFlushedPerUpdate = 8;
 
         /// <summary>
+        ///     Extra pixels above and below the viewport to keep message drawables active while scrolling.
+        /// </summary>
+        private const int VisibleMessageBuffer = 300;
+
+        /// <summary>
         ///     The total height of all messages
         /// </summary>
         private float TotalMessageHeight { get; set; }
@@ -155,6 +160,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
             }
 
             base.Update(gameTime);
+            UpdateVisibleMessageDrawables();
         }
 
         /// <summary>
@@ -309,9 +315,6 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
 
                 var drawable = AddObject(AvailableItems.Count - 1);
 
-                if (Pool.Count < PoolSize)
-                    AddContainedDrawable(drawable);
-
                 if (ShouldScrollToBottom(message))
                     NeedsScrollToBottom = true;
 
@@ -338,6 +341,29 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 TotalMessageHeight = y;
                 NeedsReflow = false;
                 UpdateContentContainerSize();
+            }
+        }
+
+        /// <summary>
+        ///     Keeps only visible or near-visible messages parented to the content container.
+        ///     Detached messages keep their layout data, but they do not update or draw while offscreen.
+        /// </summary>
+        private void UpdateVisibleMessageDrawables()
+        {
+            lock (Pool)
+            {
+                var visibleTop = -ContentContainer.Y - VisibleMessageBuffer;
+                var visibleBottom = -ContentContainer.Y + Height + VisibleMessageBuffer;
+
+                foreach (var drawable in Pool)
+                {
+                    var isVisible = drawable.Y + drawable.Height >= visibleTop && drawable.Y <= visibleBottom;
+
+                    if (isVisible && drawable.Parent != ContentContainer)
+                        AddContainedDrawable(drawable);
+                    else if (!isVisible && drawable.Parent == ContentContainer)
+                        RemoveContainedDrawable(drawable);
+                }
             }
         }
 

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -282,7 +282,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         {
             lock (MessageQueue)
             {
-                if (!HasRequestedMessageHistory || MessageQueue.Count == 0 || RequestHistoryTask.IsRunning)
+                if (!HasRequestedMessageHistory || MessageQueue.Count == 0 || RequestHistoryTask.IsRunning || HasPendingHistoryMessages())
                     return;
 
                 var count = Math.Min(MessageQueue.Count, MaxMessagesFlushedPerUpdate);
@@ -294,6 +294,15 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
 
                 Logger.Important($"Flushed {count} messages from the `{Channel.Name}` message queue. {MessageQueue.Count} messages remaining", LogType.Runtime);
             }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private bool HasPendingHistoryMessages()
+        {
+            lock (MessageHistoryQueue)
+                return MessageHistoryQueue.Count != 0;
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -59,9 +59,29 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         private List<ChatMessage> MessageQueue { get; } = new List<ChatMessage>();
 
         /// <summary>
+        ///     The maximum amount of messages to create in a single update.
+        /// </summary>
+        private const int MaxMessagesFlushedPerUpdate = 8;
+
+        /// <summary>
         ///     The total height of all messages
         /// </summary>
         private float TotalMessageHeight { get; set; }
+
+        /// <summary>
+        ///     If message drawables need to have their positions recalculated.
+        /// </summary>
+        private bool NeedsReflow { get; set; }
+
+        /// <summary>
+        ///     If the container should scroll to the bottom after the next reflow.
+        /// </summary>
+        private bool NeedsScrollToBottom { get; set; }
+
+        /// <summary>
+        ///     If the next bottom scroll should ignore the user's current scroll position.
+        /// </summary>
+        private bool ForceScrollToBottom { get; set; }
 
         /// <summary>
         ///     The currently active right click options for the screen
@@ -122,6 +142,17 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
             RequestMessageHistoryIfNecessary();
             FlushMessageHistoryQueue();
             FlushMessageQueue();
+
+            if (NeedsReflow)
+            {
+                ReflowMessageDrawables();
+
+                if (NeedsScrollToBottom)
+                    ScrollToBottomIfNecessary(ForceScrollToBottom);
+
+                NeedsScrollToBottom = false;
+                ForceScrollToBottom = false;
+            }
 
             base.Update(gameTime);
         }
@@ -218,14 +249,24 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 if (!HasRequestedMessageHistory || MessageHistoryQueue.Count == 0)
                     return;
 
-                foreach (var message in MessageHistoryQueue)
-                    AddMessage(message);
+                var count = Math.Min(MessageHistoryQueue.Count, MaxMessagesFlushedPerUpdate);
 
-                Logger.Important($"Flushed {MessageHistoryQueue.Count} messages from the `{Channel.Name}` message history queue.", LogType.Runtime);
-                MessageHistoryQueue.Clear();
+                for (var i = 0; i < count; i++)
+                    AddMessage(MessageHistoryQueue[i]);
+
+                MessageHistoryQueue.RemoveRange(0, count);
+
+                Logger.Important($"Flushed {count} messages from the `{Channel.Name}` message history queue. {MessageHistoryQueue.Count} messages remaining.", LogType.Runtime);
             }
 
-            ScrollToBottomIfNecessary(true);
+            lock (MessageHistoryQueue)
+            {
+                if (MessageHistoryQueue.Count == 0)
+                {
+                    NeedsScrollToBottom = true;
+                    ForceScrollToBottom = true;
+                }
+            }
         }
 
         /// <summary>
@@ -238,10 +279,14 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 if (!HasRequestedMessageHistory || MessageQueue.Count == 0 || RequestHistoryTask.IsRunning)
                     return;
 
-                AddMessage(MessageQueue[0]);
-                MessageQueue.RemoveAt(0);
+                var count = Math.Min(MessageQueue.Count, MaxMessagesFlushedPerUpdate);
 
-                Logger.Important($"Flushed the latest message from the `{Channel.Name}` message queue. {MessageQueue.Count} messages remaining", LogType.Runtime);
+                for (var i = 0; i < count; i++)
+                    AddMessage(MessageQueue[i]);
+
+                MessageQueue.RemoveRange(0, count);
+
+                Logger.Important($"Flushed {count} messages from the `{Channel.Name}` message queue. {MessageQueue.Count} messages remaining", LogType.Runtime);
             }
         }
 
@@ -254,23 +299,62 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
             lock (AvailableItems)
             lock (Pool)
             {
-                if (!Channel.Messages.Contains(message))
+                if (ContainsMessage(AvailableItems, message))
+                    return;
+
+                if (!ContainsMessage(Channel.Messages, message))
                     Channel.Messages.Add(message);
 
-                if (!AvailableItems.Contains(message))
-                    AvailableItems.Add(message);
+                AvailableItems.Add(message);
 
                 var drawable = AddObject(AvailableItems.Count - 1);
 
                 if (Pool.Count < PoolSize)
                     AddContainedDrawable(drawable);
 
-                drawable.Y = TotalMessageHeight;
-                TotalMessageHeight += drawable.Height;
+                if (ShouldScrollToBottom(message))
+                    NeedsScrollToBottom = true;
 
-                UpdateContentContainerSize();
-                ScrollToBottomIfNecessary();
+                NeedsReflow = true;
             }
+        }
+
+        /// <summary>
+        ///     Positions each message after the previous message's actual rendered height.
+        ///     This keeps multiline or late-resized messages from overlapping rows below them.
+        /// </summary>
+        private void ReflowMessageDrawables()
+        {
+            lock (Pool)
+            {
+                var y = 0f;
+
+                foreach (var drawable in Pool)
+                {
+                    drawable.Y = y;
+                    y += drawable.Height;
+                }
+
+                TotalMessageHeight = y;
+                NeedsReflow = false;
+                UpdateContentContainerSize();
+            }
+        }
+
+        /// <summary>
+        ///     Checks whether a message has already been added. Chat messages are often re-created as
+        ///     separate objects between local echo, server echo, and history fetches, so reference equality
+        ///     is not enough to prevent duplicate drawables.
+        /// </summary>
+        /// <param name="messages"></param>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        private static bool ContainsMessage(List<ChatMessage> messages, ChatMessage message)
+        {
+            return messages.Any(x => x.SenderId == message.SenderId
+                                     && x.Channel == message.Channel
+                                     && x.Message == message.Message
+                                     && Math.Abs(x.Time - message.Time) < 1000);
         }
 
         /// <summary>
@@ -281,11 +365,24 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         /// </summary>
         private void ScrollToBottomIfNecessary(bool force = false)
         {
-            if (TotalMessageHeight - Height - Math.Abs(ContentContainer.Y) >= 600 && !AvailableItems.Last().IsFromSelf && !force)
+            if (AvailableItems.Count == 0)
+                return;
+
+            if (!ShouldScrollToBottom(AvailableItems.Last(), force))
                 return;
 
             ClearAnimations();
             ScrollTo(-TotalMessageHeight, 600);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="latestMessage"></param>
+        /// <param name="force"></param>
+        /// <returns></returns>
+        private bool ShouldScrollToBottom(ChatMessage latestMessage, bool force = false)
+        {
+            return force || TotalMessageHeight - Height - Math.Abs(ContentContainer.Y) < 600 || latestMessage.IsFromSelf;
         }
 
         /// <summary>
@@ -359,6 +456,9 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 Pool.ForEach(x => x.Destroy());
                 Pool.Clear();
                 TotalMessageHeight = 0;
+                NeedsReflow = false;
+                NeedsScrollToBottom = false;
+                ForceScrollToBottom = false;
                 UpdateContentContainerSize();
             });
 
@@ -423,7 +523,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
             e.Message.Sender = OnlineManager.OnlineUsers[e.Message.SenderId];
 
             // Don't display messages from self.
-            if (e.Message.Sender == OnlineManager.Self)
+            if (OnlineManager.Self != null && e.Message.SenderId == OnlineManager.Self.OnlineUser.Id)
                 return;
 
             Channel.QueueMessage(e.Message);


### PR DESCRIPTION
Since my first fix didn't do the trick, i'm comming up with a new list of things that could cause the issue, that this PR aim to solve;
- Duplicate message -> The game now checks if a message already exists before sending it again (it's not just the message, it'll also check the time the message has been sent at)
- Message rendering -> I tried to change the message component behaviour so that they can't render on top of each other. This logic was already implemented before using the "TotalMessageHeight" variable, but i now recalculate the total height every time there is a new message sent. This is not perfect, but could potentially fix the issue

I also added a few optimizations to the way the chat messages are loaded when the message box is being initialized so that it won't tank fps on chat with a big history