### PR TITLE
Fix maps not starting when they have very long name

### DIFF
--- a/Quaver.Shared/Discord/DiscordRpc.cs
+++ b/Quaver.Shared/Discord/DiscordRpc.cs
@@ -103,8 +103,8 @@ namespace Quaver.Shared.Discord
         {
             return new DiscordRPC.RichPresence
             {
-                State = presence.State,
-                Details = presence.Details,
+                State = Truncate(presence.State, RichPresence.MaxStateLength),
+                Details = Truncate(presence.Details, RichPresence.MaxDetailsLength),
                 Timestamps = CreateTimestamps(presence),
                 Assets = CreateAssets(presence),
                 Party = CreateParty(presence),
@@ -134,10 +134,10 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Assets
             {
-                LargeImageKey = presence.LargeImageKey,
-                LargeImageText = presence.LargeImageText,
-                SmallImageKey = presence.SmallImageKey,
-                SmallImageText = presence.SmallImageText
+                LargeImageKey = Truncate(presence.LargeImageKey, 32),
+                LargeImageText = Truncate(presence.LargeImageText, 128),
+                SmallImageKey = Truncate(presence.SmallImageKey, 32),
+                SmallImageText = Truncate(presence.SmallImageText, 128)
             };
         }
 
@@ -148,7 +148,7 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Party
             {
-                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : presence.PartyId,
+                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : Truncate(presence.PartyId, 128),
                 Size = presence.PartySize,
                 Max = presence.PartyMax
             };
@@ -162,9 +162,17 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Secrets
             {
-                JoinSecret = presence.JoinSecret,
-                SpectateSecret = presence.SpectateSecret
+                JoinSecret = Truncate(presence.JoinSecret, 128),
+                SpectateSecret = Truncate(presence.SpectateSecret, 128)
             };
+        }
+
+        private static string Truncate(string value, int maxLength)
+        {
+            if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+                return value;
+
+            return $"{value[..(maxLength - 1)]}…";
         }
 
         private static DateTime FromUnixSeconds(long unixSeconds) =>

--- a/Quaver.Shared/Discord/DiscordRpc.cs
+++ b/Quaver.Shared/Discord/DiscordRpc.cs
@@ -103,8 +103,8 @@ namespace Quaver.Shared.Discord
         {
             return new DiscordRPC.RichPresence
             {
-                State = Truncate(presence.State, 120),
-                Details = Truncate(presence.Details, 120),
+                State = Truncate(presence.State, RichPresence.MaxStateLength - 4),
+                Details = Truncate(presence.Details, RichPresence.MaxDetailsLength - 4),
                 Timestamps = CreateTimestamps(presence),
                 Assets = CreateAssets(presence),
                 Party = CreateParty(presence),
@@ -134,10 +134,10 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Assets
             {
-                LargeImageKey = Truncate(presence.LargeImageKey, 25),
-                LargeImageText = Truncate(presence.LargeImageText, 120),
-                SmallImageKey = Truncate(presence.SmallImageKey, 25),
-                SmallImageText = Truncate(presence.SmallImageText, 120)
+                LargeImageKey = Truncate(presence.LargeImageKey, 32 - 4),
+                LargeImageText = Truncate(presence.LargeImageText, RichPresence.MaxDetailsLength - 4),
+                SmallImageKey = Truncate(presence.SmallImageKey, 32 - 4),
+                SmallImageText = Truncate(presence.SmallImageText, RichPresence.MaxDetailsLength - 4)
             };
         }
 
@@ -148,7 +148,7 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Party
             {
-                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : Truncate(presence.PartyId, 120),
+                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : Truncate(presence.PartyId, RichPresence.MaxDetailsLength - 4),
                 Size = presence.PartySize,
                 Max = presence.PartyMax
             };
@@ -162,8 +162,8 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Secrets
             {
-                JoinSecret = Truncate(presence.JoinSecret, 120),
-                SpectateSecret = Truncate(presence.SpectateSecret, 120)
+                JoinSecret = Truncate(presence.JoinSecret, RichPresence.MaxDetailsLength - 4),
+                SpectateSecret = Truncate(presence.SpectateSecret, RichPresence.MaxDetailsLength - 4)
             };
         }
 

--- a/Quaver.Shared/Discord/DiscordRpc.cs
+++ b/Quaver.Shared/Discord/DiscordRpc.cs
@@ -103,8 +103,8 @@ namespace Quaver.Shared.Discord
         {
             return new DiscordRPC.RichPresence
             {
-                State = Truncate(presence.State, RichPresence.MaxStateLength),
-                Details = Truncate(presence.Details, RichPresence.MaxDetailsLength),
+                State = Truncate(presence.State, 120),
+                Details = Truncate(presence.Details, 120),
                 Timestamps = CreateTimestamps(presence),
                 Assets = CreateAssets(presence),
                 Party = CreateParty(presence),
@@ -134,10 +134,10 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Assets
             {
-                LargeImageKey = Truncate(presence.LargeImageKey, 32),
-                LargeImageText = Truncate(presence.LargeImageText, 128),
-                SmallImageKey = Truncate(presence.SmallImageKey, 32),
-                SmallImageText = Truncate(presence.SmallImageText, 128)
+                LargeImageKey = Truncate(presence.LargeImageKey, 25),
+                LargeImageText = Truncate(presence.LargeImageText, 120),
+                SmallImageKey = Truncate(presence.SmallImageKey, 25),
+                SmallImageText = Truncate(presence.SmallImageText, 120)
             };
         }
 
@@ -148,7 +148,7 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Party
             {
-                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : Truncate(presence.PartyId, 128),
+                ID = string.IsNullOrEmpty(presence.PartyId) ? "quaver" : Truncate(presence.PartyId, 120),
                 Size = presence.PartySize,
                 Max = presence.PartyMax
             };
@@ -162,8 +162,8 @@ namespace Quaver.Shared.Discord
 
             return new DiscordRPC.Secrets
             {
-                JoinSecret = Truncate(presence.JoinSecret, 128),
-                SpectateSecret = Truncate(presence.SpectateSecret, 128)
+                JoinSecret = Truncate(presence.JoinSecret, 120),
+                SpectateSecret = Truncate(presence.SpectateSecret, 120)
             };
         }
 

--- a/Quaver.Shared/Helpers/RichPresenceHelper.cs
+++ b/Quaver.Shared/Helpers/RichPresenceHelper.cs
@@ -25,13 +25,13 @@ namespace Quaver.Shared.Helpers
             }
 
             SteamManager.SetRichPresence("State", Truncate(state, Constants.k_cchMaxRichPresenceValueLength));
-            DiscordHelper.Presence.State = Truncate(state, DiscordRpc.RichPresence.MaxStateLength);
+            DiscordHelper.Presence.State = Truncate(state, 120);
 
             // This would be potentially problematic as the source specifies 'bytes', and .NET using UTF-16 could have
             // made things complicated. Fortunately however, through direct testing it appears that they consider
             // UTF-16 codepoints to be 1 byte long, even if the underlying memory layout would suggest otherwise.
             SteamManager.SetRichPresence("Details", Truncate(details, Constants.k_cchMaxRichPresenceValueLength));
-            DiscordHelper.Presence.Details = Truncate(details, DiscordRpc.RichPresence.MaxDetailsLength);
+            DiscordHelper.Presence.Details = Truncate(details, 120);
 
             DiscordHelper.UpdatePresence();
         }

--- a/Quaver.Shared/Helpers/RichPresenceHelper.cs
+++ b/Quaver.Shared/Helpers/RichPresenceHelper.cs
@@ -1,9 +1,5 @@
 using Quaver.Shared.Discord;
 using Quaver.Shared.Online;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
 using Steamworks;
 
 namespace Quaver.Shared.Helpers
@@ -20,19 +16,16 @@ namespace Quaver.Shared.Helpers
         /// <param name="details">Details of the game. Strings too long gets automatically truncated.</param>
         public static void UpdateRichPresence(string state, string details)
         {
-            static string Truncate(string s, int length) => s.Length >= length ? $"{s[..(length - 1)]}…" : s;
+            static string Truncate(string s, int length)
+            {
+                if (string.IsNullOrEmpty(s) || s.Length <= length)
+                    return s;
 
-            // It is assumed that state is already sufficiently small enough to fit in both the rich presences.
-            // The largest case is multiplayer lobby names, which is 50 characters long. Combine that with the
-            // interpolation, and it ends up at most 61 characters long.
-            Debug.Assert(
-                state.Length <= DiscordRpc.RichPresence.MaxStateLength &&
-                state.Length <= Constants.k_cchMaxRichPresenceKeyLength,
-                $"State is too long for rich presence: {state.Length} chars"
-            );
+                return $"{s[..(length - 1)]}…";
+            }
 
-            SteamManager.SetRichPresence("State", state);
-            DiscordHelper.Presence.State = state;
+            SteamManager.SetRichPresence("State", Truncate(state, Constants.k_cchMaxRichPresenceValueLength));
+            DiscordHelper.Presence.State = Truncate(state, DiscordRpc.RichPresence.MaxStateLength);
 
             // This would be potentially problematic as the source specifies 'bytes', and .NET using UTF-16 could have
             // made things complicated. Fortunately however, through direct testing it appears that they consider

--- a/Quaver.Shared/Helpers/RichPresenceHelper.cs
+++ b/Quaver.Shared/Helpers/RichPresenceHelper.cs
@@ -25,13 +25,13 @@ namespace Quaver.Shared.Helpers
             }
 
             SteamManager.SetRichPresence("State", Truncate(state, Constants.k_cchMaxRichPresenceValueLength));
-            DiscordHelper.Presence.State = Truncate(state, 120);
+            DiscordHelper.Presence.State = Truncate(state, DiscordRpc.RichPresence.MaxStateLength - 4);
 
             // This would be potentially problematic as the source specifies 'bytes', and .NET using UTF-16 could have
             // made things complicated. Fortunately however, through direct testing it appears that they consider
             // UTF-16 codepoints to be 1 byte long, even if the underlying memory layout would suggest otherwise.
             SteamManager.SetRichPresence("Details", Truncate(details, Constants.k_cchMaxRichPresenceValueLength));
-            DiscordHelper.Presence.Details = Truncate(details, 120);
+            DiscordHelper.Presence.Details = Truncate(details, DiscordRpc.RichPresence.MaxDetailsLength - 4);
 
             DiscordHelper.UpdatePresence();
         }


### PR DESCRIPTION
new Discord RPC lib reintroduced an issue where untruncated map with crazy long name would break. So, we now truncate it again, as well as difficulty name