### PR TITLE
fix-4626: Keep "Date Added" after refresh

### DIFF
--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -114,7 +114,7 @@ namespace Quaver.Shared.Database.Maps
             {
                 var filePath = BackslashToForward($"{ConfigManager.SongDirectory.Value}/{map.Directory}/{map.Path}");
                 // Check if the file actually exists.
-                if (fileHashSet.Contains(BackslashToForward(filePath)))
+                if (fileHashSet.Contains(filePath))
                 {
                     // Check if the file was updated. In this case, we check if the last write times are different
                     // BEFORE checking Md5 checksum of the file since it's faster to check if we even need to

--- a/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
+++ b/Quaver.Shared/Database/Maps/MapDatabaseCache.cs
@@ -108,12 +108,11 @@ namespace Quaver.Shared.Database.Maps
         {
             var maps = FetchAll();
 
-            var fileHashSet = files.ToHashSet();
+            var fileHashSet = files.ToHashSet().Select(BackslashToForward);
 
             foreach (var map in maps)
             {
                 var filePath = BackslashToForward($"{ConfigManager.SongDirectory.Value}/{map.Directory}/{map.Path}");
-
                 // Check if the file actually exists.
                 if (fileHashSet.Contains(BackslashToForward(filePath)))
                 {
@@ -358,6 +357,7 @@ namespace Quaver.Shared.Database.Maps
                     map.Id = MapsToUpdate[i].Id;
                     map.Directory = MapsToUpdate[i].Directory;
                     map.Mapset = MapsToUpdate[i].Mapset;
+                    map.DateAdded = MapsToUpdate[i].DateAdded;
 
                     if (map.Id == 0)
                     {


### PR DESCRIPTION
# Fix #4626
There was a problem inside a path compare that happens during refresh.
I also keep "Date Added" during forced update.