### PR TITLE
Quick fixes 1

### DIFF
--- a/Quaver.Shared/Database/Profiles/UserProfile.cs
+++ b/Quaver.Shared/Database/Profiles/UserProfile.cs
@@ -63,7 +63,7 @@ namespace Quaver.Shared.Database.Profiles
                             modeStats = stats.User.Keys7;
                             break;
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            continue;
                     }
 
                     var currentMode = Stats[mode];

--- a/Quaver.Shared/Database/Profiles/UserProfileStats.cs
+++ b/Quaver.Shared/Database/Profiles/UserProfileStats.cs
@@ -69,6 +69,8 @@ namespace Quaver.Shared.Database.Profiles
         {
             Profile = profile;
             Mode = mode;
+            Scores = new List<Score>();
+            JudgementCounts = GetEmptyJudgementCounts();
 
             FetchStats();
         }
@@ -143,15 +145,7 @@ namespace Quaver.Shared.Database.Profiles
         /// </summary>
         private void CalculateJudgementsMaxComboAndTotalScore()
         {
-            JudgementCounts = new Dictionary<Judgement, int>();
-
-            foreach (Judgement j in Enum.GetValues(typeof(Judgement)))
-            {
-                if (j == Judgement.Ghost)
-                    continue;
-
-                JudgementCounts.Add(j, 0);
-            }
+            JudgementCounts = GetEmptyJudgementCounts();
 
             TotalScore = 0;
             PauseCount = 0;
@@ -169,6 +163,24 @@ namespace Quaver.Shared.Database.Profiles
                 JudgementCounts[Judgement.Okay] += score.CountOkay;
                 JudgementCounts[Judgement.Miss] += score.CountMiss;
             }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        private static Dictionary<Judgement, int> GetEmptyJudgementCounts()
+        {
+            var judgements = new Dictionary<Judgement, int>();
+
+            foreach (Judgement j in Enum.GetValues(typeof(Judgement)))
+            {
+                if (j == Judgement.Ghost)
+                    continue;
+
+                judgements.Add(j, 0);
+            }
+
+            return judgements;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -296,12 +296,23 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
 
             // Update Positions
             UpdateSpritePositions(manager.CurrentVisualAudioOffset);
-            LongNoteBodySprite.Parent = playfield.Stage.HitObjectContainers[Info.HitObjectInfo.EditorLayer];
-            LongNoteEndSprite.Parent = playfield.Stage.HitObjectContainers[Info.HitObjectInfo.EditorLayer];
+            var hitObjectContainer = GetHitObjectContainer(playfield);
+            LongNoteBodySprite.Parent = hitObjectContainer;
+            LongNoteEndSprite.Parent = hitObjectContainer;
 
             // We set the parent of the HitObjectSprite **AFTER** we create the long note
             // so that the body of the long note isn't drawn over the object.
-            HitObjectSprite.Parent = playfield.Stage.HitObjectContainers[Info.HitObjectInfo.EditorLayer];
+            HitObjectSprite.Parent = hitObjectContainer;
+        }
+
+        private Container GetHitObjectContainer(GameplayPlayfieldKeys playfield)
+        {
+            var editorLayer = Info.HitObjectInfo.EditorLayer;
+
+            if (editorLayer < 0 || editorLayer >= playfield.Stage.HitObjectContainers.Length)
+                return playfield.Stage.HitObjectContainers[0];
+
+            return playfield.Stage.HitObjectContainers[editorLayer];
         }
 
         /// <summary>

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -544,8 +544,11 @@ namespace Quaver.Shared.Skinning
                 if (resource == null)
                     return new List<Texture2D> { UserInterface.BlankBox };
 
-                return AssetLoader.LoadSpritesheetFromTexture(AssetLoader.LoadTexture2D(
-                    GameBase.Game.Resources.Get($"{resource}@{rows}x{columns}.png")), rows, columns);
+                var buffer = GameBase.Game.Resources.Get($"{resource}@{rows}x{columns}.png");
+                if (buffer == null)
+                    return new List<Texture2D> { UserInterface.BlankBox };
+
+                return AssetLoader.LoadSpritesheetFromTexture(AssetLoader.LoadTexture2D(buffer), rows, columns);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fixes multiple issues from this runtime log https://github.com/Quaver/Quaver/issues/4653

User profile stats - exclude other key modes that do not work

Fixes crash (that does not always happen?) when EditorLayers is empty in qua, but the HitObjects still have one. I assume this happens due to default layer to not be available in the EditorLayers?

Fixes error spam for fallback spritesheet load fail.