### PR TITLE
Qol improvements in draws

### DIFF
--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -258,7 +258,6 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
                 new ScalableVector2(Width, height))
             {
                 Parent = this,
-                SetChildrenVisibility = true,
                 Visible = false,
                 Y = DividerLine.Y + DividerLine.Height,
                 Scrollbar =
@@ -350,12 +349,19 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         private void SetItemVisibility(bool visible)
         {
             ItemContainer.Visible = visible;
+            ItemContainer.ContentContainer.Visible = visible;
+            ItemContainer.Scrollbar.Visible = visible && MaxHeight != 0 && Height * Options.Count > OpenHeight;
 
             if (Items == null)
                 return;
 
             Items.ForEach(x => x.Visible = visible);
         }
+
+        /// <summary>
+        ///     Restores the dropdown item list visibility after an external owner toggles the drawable tree.
+        /// </summary>
+        public void ApplyItemVisibilityState() => SetItemVisibility(Opened);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/Dropdown.cs
@@ -73,6 +73,11 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         public bool Opened { get; private set; }
 
         /// <summary>
+        ///     If the dropdown item list is waiting for its close animation to finish before hiding.
+        /// </summary>
+        private bool HidingItemsAfterClose { get; set; }
+
+        /// <summary>
         ///     The line that divides the top element from the items
         /// </summary>
         public Sprite DividerLine { get; private set; }
@@ -158,6 +163,21 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         /// <inheritdoc />
         /// <summary>
         /// </summary>
+        /// <param name="gameTime"></param>
+        public override void Update(GameTime gameTime)
+        {
+            if (HidingItemsAfterClose && ItemContainer.Height <= 0)
+            {
+                HidingItemsAfterClose = false;
+                SetItemVisibility(false);
+            }
+
+            base.Update(gameTime);
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
         public override void Destroy()
         {
             ItemSelected = null;
@@ -238,6 +258,8 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
                 new ScalableVector2(Width, height))
             {
                 Parent = this,
+                SetChildrenVisibility = true,
+                Visible = false,
                 Y = DividerLine.Y + DividerLine.Height,
                 Scrollbar =
                 {
@@ -265,6 +287,8 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
                 Items.Add(item);
                 ItemContainer.AddContainedDrawable(item);
             }
+
+            SetItemVisibility(false);
         }
 
         /// <summary>
@@ -273,6 +297,8 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         public void Open(int time = 500)
         {
             Opened = true;
+            HidingItemsAfterClose = false;
+            SetItemVisibility(true);
 
             Image = UserInterface.DropdownOpen;
             HoverSprite.Image = UserInterface.DropdownOpen;
@@ -298,6 +324,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         public void Close(int time = 500)
         {
             Opened = false;
+            HidingItemsAfterClose = time > 0;
 
             Image = UserInterface.DropdownClosed;
             HoverSprite.Image = UserInterface.DropdownClosed;
@@ -312,6 +339,22 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
             ItemContainer.ChangeHeightTo(0, Easing.OutQuint, time);
 
             Items.ForEach(x => x.IsClickable = false);
+
+            if (!HidingItemsAfterClose)
+                SetItemVisibility(false);
+        }
+
+        /// <summary>
+        ///     Toggles visibility of the closed dropdown item list and its child text.
+        /// </summary>
+        private void SetItemVisibility(bool visible)
+        {
+            ItemContainer.Visible = visible;
+
+            if (Items == null)
+                return;
+
+            Items.ForEach(x => x.Visible = visible);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Form/Dropdowns/DropdownItem.cs
+++ b/Quaver.Shared/Graphics/Form/Dropdowns/DropdownItem.cs
@@ -46,6 +46,7 @@ namespace Quaver.Shared.Graphics.Form.Dropdowns
         {
             Dropdown = dropdown;
             Index = index;
+            SetChildrenVisibility = true;
 
             Size = Dropdown.Size;
             Tint = ColorHelper.HexToColor("#181818");

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Channels/Scrolling/DrawableChatChannel.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Channels/Scrolling/DrawableChatChannel.cs
@@ -99,14 +99,11 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Channels.Scrolling
             Item = item;
             Index = index;
 
-            AddScheduledUpdate(() =>
-            {
-                Name.Text = Item.GetDisplayedName();
-                Name.Tint = GetTextColor();
+            Name.Text = Item.GetDisplayedName();
+            Name.Tint = GetTextColor();
 
-                MentionedIcon.X = Name.X + Name.Width + 8;
-                MentionedIcon.Visible = Item.IsMentioned;
-            });
+            MentionedIcon.X = Name.X + Name.Width + 8;
+            MentionedIcon.Visible = Item.IsMentioned;
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/ChatMessageContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/ChatMessageContainer.cs
@@ -139,6 +139,9 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages
             };
 
             MessageScrollContainers.Add(chan, container);
+
+            if (OnlineChat.Instance != null)
+                container.SetEventProcessingSuspended(OnlineChat.Instance.IsEventProcessingSuspended);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/Scrolling/ChatMessageScrollContainer.cs
@@ -93,6 +93,21 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         /// </summary>
         public RightClickOptions ActiveRightClickOptions { get; private set; }
 
+        /// <summary>
+        ///     If this container is subscribed to online chat message events.
+        /// </summary>
+        private bool IsSubscribedToChatEvents { get; set; }
+
+        /// <summary>
+        ///     If chat message event processing is currently suspended.
+        /// </summary>
+        private bool IsEventProcessingSuspended { get; set; }
+
+        /// <summary>
+        ///     If message history should be refreshed when chat processing resumes.
+        /// </summary>
+        private bool ShouldRefreshHistoryOnResume { get; set; }
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>
@@ -127,7 +142,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
                 OnlineManager.Client.OnConnectionStatusChanged += OnConnectionStatusChanged;
 
                 if (OnlineManager.Connected)
-                    OnlineManager.Client.OnChatMessageReceived += OnChatMessageReceived;
+                    SubscribeToEvents();
             }
         }
 
@@ -168,8 +183,39 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         /// </summary>
         public override void Destroy()
         {
+            if (OnlineManager.Client != null)
+                OnlineManager.Client.OnConnectionStatusChanged -= OnConnectionStatusChanged;
+
             UnsubscribeFromEvents();
             base.Destroy();
+        }
+
+        /// <summary>
+        ///     Suspends or resumes chat message event processing for this channel.
+        /// </summary>
+        /// <param name="suspended"></param>
+        public void SetEventProcessingSuspended(bool suspended)
+        {
+            if (IsEventProcessingSuspended == suspended)
+                return;
+
+            IsEventProcessingSuspended = suspended;
+
+            if (suspended)
+            {
+                ShouldRefreshHistoryOnResume = true;
+                UnsubscribeFromEvents();
+            }
+            else if (OnlineManager.Connected)
+            {
+                if (ShouldRefreshHistoryOnResume)
+                {
+                    HasRequestedMessageHistory = false;
+                    ShouldRefreshHistoryOnResume = false;
+                }
+
+                SubscribeToEvents();
+            }
         }
 
         /// <inheritdoc />
@@ -525,15 +571,22 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages.Scrolling
         /// </summary>
         private void SubscribeToEvents()
         {
+            if (IsSubscribedToChatEvents || IsEventProcessingSuspended || OnlineManager.Client == null)
+                return;
+
             OnlineManager.Client.OnChatMessageReceived += OnChatMessageReceived;
+            IsSubscribedToChatEvents = true;
         }
 
         /// <summary>
         /// </summary>
         private void UnsubscribeFromEvents()
         {
-            if (OnlineManager.Client != null)
-                OnlineManager.Client.OnChatMessageReceived -= OnChatMessageReceived;
+            if (!IsSubscribedToChatEvents || OnlineManager.Client == null)
+                return;
+
+            OnlineManager.Client.OnChatMessageReceived -= OnChatMessageReceived;
+            IsSubscribedToChatEvents = false;
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
@@ -18,6 +18,7 @@ using Quaver.Shared.Graphics.Overlays.Chatting.Messages;
 using Quaver.Shared.Graphics.Overlays.Hub;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Screens;
 using Wobble;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -69,6 +70,11 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         ///     If the closed visibility state has been applied after the close animation.
         /// </summary>
         private bool IsClosedVisibilityApplied { get; set; }
+
+        /// <summary>
+        ///     If chat event processing is suspended while gameplay is active.
+        /// </summary>
+        public bool IsEventProcessingSuspended { get; private set; }
 
         /// <summary>
         /// </summary>
@@ -164,6 +170,23 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         {
             SetChatVisibility(false);
             IsClosedVisibilityApplied = true;
+        }
+
+        /// <summary>
+        ///     Suspends chat event processing while gameplay is active to avoid background UI work during play.
+        /// </summary>
+        public void UpdateEventProcessingSuspension()
+        {
+            var game = GameBase.Game as QuaverGame;
+            var shouldSuspend = game?.CurrentScreen?.Type == QuaverScreenType.Gameplay;
+
+            if (IsEventProcessingSuspended == shouldSuspend)
+                return;
+
+            IsEventProcessingSuspended = shouldSuspend;
+
+            foreach (var container in MessageContainer.MessageScrollContainers.Values.ToList())
+                container.SetEventProcessingSuspended(shouldSuspend);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
@@ -66,6 +66,11 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         public bool IsOpen { get; private set; }
 
         /// <summary>
+        ///     If the closed visibility state has been applied after the close animation.
+        /// </summary>
+        private bool IsClosedVisibilityApplied { get; set; }
+
+        /// <summary>
         /// </summary>
         public static OnlineChat Instance
         {
@@ -95,6 +100,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
             DestroyIfParentIsNull = false;
 
             OnlineManager.Status.ValueChanged += OnConnectionStatusChanged;
+            ApplyClosedVisibility();
         }
 
         /// <inheritdoc />
@@ -105,6 +111,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         {
             HandleResizing();
             HandleActiveJoinChatChannelDialogClosing();
+            HandleClosedVisibility();
 
             base.Update(gameTime);
         }
@@ -114,6 +121,8 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         /// </summary>
         public void Open()
         {
+            IsClosedVisibilityApplied = false;
+            SetChatVisibility(true);
             SetClickable(this, true);
             SetRetainedContainersClickable(true);
 
@@ -132,8 +141,29 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
             ClearAnimations();
             MoveToY((int)Height + 10, Easing.OutQuint, 500);
             IsOpen = false;
+            IsClosedVisibilityApplied = false;
             SetClickable(this, false);
             SetRetainedContainersClickable(false);
+        }
+
+        /// <summary>
+        ///     Keeps retained chat drawables from drawing after the close animation has completed.
+        /// </summary>
+        private void HandleClosedVisibility()
+        {
+            if (IsOpen || Animations.Count != 0 || IsClosedVisibilityApplied)
+                return;
+
+            ApplyClosedVisibility();
+        }
+
+        /// <summary>
+        ///     Immediately applies the closed visibility state to the retained chat drawable trees.
+        /// </summary>
+        public void ApplyClosedVisibility()
+        {
+            SetChatVisibility(false);
+            IsClosedVisibilityApplied = true;
         }
 
         /// <summary>
@@ -187,6 +217,45 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
         {
             foreach (var container in MessageContainer.MessageScrollContainers.Values.ToList())
                 SetClickable(container, clickable);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="visible"></param>
+        private void SetChatVisibility(bool visible)
+        {
+            SetDrawableTreeVisible(this, visible);
+
+            SetDrawableTreeVisible(ChannelList.ChannelContainer, visible);
+
+            if (ChannelList.ChannelContainer.Pool != null)
+            {
+                foreach (var drawable in ChannelList.ChannelContainer.Pool.ToList())
+                    SetDrawableTreeVisible(drawable, visible);
+            }
+
+            foreach (var container in MessageContainer.MessageScrollContainers.Values.ToList())
+            {
+                SetDrawableTreeVisible(container, visible);
+
+                if (container.Pool == null)
+                    continue;
+
+                foreach (var drawable in container.Pool.ToList())
+                    SetDrawableTreeVisible(drawable, visible);
+            }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="drawable"></param>
+        /// <param name="visible"></param>
+        private static void SetDrawableTreeVisible(Drawable drawable, bool visible)
+        {
+            drawable.Visible = visible;
+
+            foreach (var child in drawable.Children)
+                SetDrawableTreeVisible(child, visible);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
@@ -289,6 +289,9 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
 
             foreach (var child in drawable.Children)
                 SetDrawableTreeVisible(child, visible);
+
+            if (drawable is Dropdown dropdown)
+                dropdown.ApplyItemVisibilityState();
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/OnlineChat.cs
@@ -254,7 +254,12 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
             if (ChannelList.ChannelContainer.Pool != null)
             {
                 foreach (var drawable in ChannelList.ChannelContainer.Pool.ToList())
+                {
                     SetDrawableTreeVisible(drawable, visible);
+
+                    if (visible)
+                        drawable.UpdateContent(drawable.Item, drawable.Index);
+                }
             }
 
             foreach (var container in MessageContainer.MessageScrollContainers.Values.ToList())
@@ -265,7 +270,12 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting
                     continue;
 
                 foreach (var drawable in container.Pool.ToList())
+                {
                     SetDrawableTreeVisible(drawable, visible);
+
+                    if (visible)
+                        drawable.UpdateContent(drawable.Item, drawable.Index);
+                }
             }
         }
 

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Quaver.Server.Client.Handlers;
 using Quaver.Server.Client.Structures;
 using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Graphics.Menu.Border;
 using Quaver.Shared.Graphics.Overlays.Hub.Downloads;
 using Quaver.Shared.Graphics.Overlays.Hub.Notifications;
@@ -158,7 +159,15 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
             drawable.Visible = visible;
 
             foreach (var child in drawable.Children)
+            {
+                if (drawable is Dropdown dropdown && child == dropdown.ItemContainer)
+                {
+                    SetDrawableTreeVisible(child, visible && dropdown.Opened);
+                    continue;
+                }
+
                 SetDrawableTreeVisible(child, visible);
+            }
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
@@ -29,6 +29,11 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
         public bool IsOpen { get; private set; }
 
         /// <summary>
+        ///     If the closed visibility state has been applied after the close animation.
+        /// </summary>
+        private bool IsClosedVisibilityApplied { get; set; }
+
+        /// <summary>
         /// </summary>
         private Sprite Background { get; set; }
 
@@ -70,6 +75,7 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
             CreateHeaderText();
             CreateIconContainer();
             CreateSections();
+            ApplyClosedVisibility();
         }
 
         /// <inheritdoc />
@@ -83,6 +89,8 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
             foreach (var section in Sections)
                 section.Value.Update(gameTime);
 
+            HandleClosedVisibility();
+
             base.Update(gameTime);
         }
 
@@ -92,6 +100,8 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
         public void Open()
         {
             IsOpen = true;
+            IsClosedVisibilityApplied = false;
+            SetHubVisibility(true);
 
             ClearAnimations();
             MoveToX(0, Easing.OutQuint, 500);
@@ -103,9 +113,52 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
         public void Close()
         {
             IsOpen = false;
+            IsClosedVisibilityApplied = false;
 
             ClearAnimations();
             MoveToX(Width + 10, Easing.OutQuint, 500);
+        }
+
+        /// <summary>
+        /// </summary>
+        private void HandleClosedVisibility()
+        {
+            if (IsOpen || Animations.Count != 0 || IsClosedVisibilityApplied)
+                return;
+
+            ApplyClosedVisibility();
+        }
+
+        /// <summary>
+        ///     Immediately applies the closed visibility state to the retained hub drawable trees.
+        /// </summary>
+        public void ApplyClosedVisibility()
+        {
+            SetHubVisibility(false);
+            IsClosedVisibilityApplied = true;
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="visible"></param>
+        private void SetHubVisibility(bool visible)
+        {
+            SetDrawableTreeVisible(this, visible);
+
+            foreach (var section in Sections.Values.ToList())
+                section.ApplyVisibility(visible);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="drawable"></param>
+        /// <param name="visible"></param>
+        private static void SetDrawableTreeVisible(Drawable drawable, bool visible)
+        {
+            drawable.Visible = visible;
+
+            foreach (var child in drawable.Children)
+                SetDrawableTreeVisible(child, visible);
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
@@ -159,15 +159,10 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
             drawable.Visible = visible;
 
             foreach (var child in drawable.Children)
-            {
-                if (drawable is Dropdown dropdown && child == dropdown.ItemContainer)
-                {
-                    SetDrawableTreeVisible(child, visible && dropdown.Opened);
-                    continue;
-                }
-
                 SetDrawableTreeVisible(child, visible);
-            }
+
+            if (drawable is Dropdown dropdown)
+                dropdown.ApplyItemVisibilityState();
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubDialog.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubDialog.cs
@@ -95,6 +95,9 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
         /// </summary>
         public override void Destroy()
         {
+            Hub.ApplyClosedVisibility();
+            Chat.ApplyClosedVisibility();
+
             Hub.Parent = null;
             Chat.Parent = null;
 

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubSection.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubSection.cs
@@ -68,6 +68,27 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
 
         /// <summary>
         /// </summary>
+        /// <param name="visible"></param>
+        public virtual void ApplyVisibility(bool visible)
+        {
+            SetDrawableTreeVisible(Container, visible);
+            SetDrawableTreeVisible(Icon, visible);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="drawable"></param>
+        /// <param name="visible"></param>
+        protected static void SetDrawableTreeVisible(Drawable drawable, bool visible)
+        {
+            drawable.Visible = visible;
+
+            foreach (var child in drawable.Children)
+                SetDrawableTreeVisible(child, visible);
+        }
+
+        /// <summary>
+        /// </summary>
         private void CreateContainer()
         {
             Container = new Sprite()

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubSection.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHubSection.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended;
 using Quaver.Shared.Assets;
+using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Screens.Menu.UI.Jukebox;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
@@ -85,6 +86,9 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
 
             foreach (var child in drawable.Children)
                 SetDrawableTreeVisible(child, visible);
+
+            if (drawable is Dropdown dropdown)
+                dropdown.ApplyItemVisibilityState();
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/OnlineHubSectionOnlineUsers.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/OnlineHubSectionOnlineUsers.cs
@@ -70,6 +70,16 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers
             base.Update(gameTime);
         }
 
+        /// <inheritdoc />
+        /// <summary>
+        /// </summary>
+        /// <param name="visible"></param>
+        public override void ApplyVisibility(bool visible)
+        {
+            base.ApplyVisibility(visible);
+            UserContainer.ApplyVisibility(visible);
+        }
+
         /// <summary>
         /// </summary>
         private void CreateFilterPanel()

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/OnlineUserContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/OnlineUserContainer.cs
@@ -10,6 +10,7 @@ using Quaver.Server.Client.Enums;
 using Quaver.Shared.Assets;
 using Quaver.Shared.Config;
 using Quaver.Shared.Graphics.Containers;
+using Quaver.Shared.Graphics.Form.Dropdowns;
 using Quaver.Shared.Graphics.Form.Dropdowns.RightClick;
 using Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Filter;
 using Quaver.Shared.Helpers;
@@ -175,6 +176,9 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Scrolling
 
             foreach (var child in drawable.Children)
                 SetDrawableTreeVisible(child, visible);
+
+            if (drawable is Dropdown dropdown)
+                dropdown.ApplyItemVisibilityState();
         }
 
         /// <summary>

--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/OnlineUserContainer.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineUsers/Scrolling/OnlineUserContainer.cs
@@ -153,6 +153,32 @@ namespace Quaver.Shared.Graphics.Overlays.Hub.OnlineUsers.Scrolling
 
         /// <summary>
         /// </summary>
+        /// <param name="visible"></param>
+        public void ApplyVisibility(bool visible)
+        {
+            SetDrawableTreeVisible(this, visible);
+
+            if (Pool == null)
+                return;
+
+            foreach (var drawable in Pool.ToList())
+                SetDrawableTreeVisible(drawable, visible);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="drawable"></param>
+        /// <param name="visible"></param>
+        private static void SetDrawableTreeVisible(Drawable drawable, bool visible)
+        {
+            drawable.Visible = visible;
+
+            foreach (var child in drawable.Children)
+                SetDrawableTreeVisible(child, visible);
+        }
+
+        /// <summary>
+        /// </summary>
         /// <param name="user"></param>
         private void AddUser(User user)
         {

--- a/Quaver.Shared/Graphics/Tooltip.cs
+++ b/Quaver.Shared/Graphics/Tooltip.cs
@@ -20,6 +20,7 @@ namespace Quaver.Shared.Graphics
 
             DestroyIfParentIsNull = false;
             SetChildrenAlpha = true;
+            SetChildrenVisibility = true;
 
             Text = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "", 20, cacheText)
             {
@@ -28,6 +29,7 @@ namespace Quaver.Shared.Graphics
             };
 
             ChangeText(text);
+            Hide();
         }
 
         public void ChangeText(string text)
@@ -36,6 +38,14 @@ namespace Quaver.Shared.Graphics
 
             const int padding = 16;
             Size = new ScalableVector2(Text.Width + padding, Text.Height + padding);
+        }
+
+        public void Show() => Visible = true;
+
+        public void Hide()
+        {
+            Visible = false;
+            Parent = null;
         }
     }
 }

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -369,6 +369,7 @@ namespace Quaver.Shared
 
             BackgroundHelper.Update(gameTime);
             DialogManager.Update(gameTime);
+            OnlineChat?.UpdateEventProcessingSuspension();
 
             HandleGlobalInput(gameTime);
             HandleOnlineHubInput();

--- a/Quaver.Shared/Screens/Gameplay/UI/EpilepsyWarning.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/EpilepsyWarning.cs
@@ -16,11 +16,14 @@ namespace Quaver.Shared.Screens.Gameplay.UI;
 public class EpilepsyWarning : Sprite
 {
     private const int WarningHeight = 180;
+    private const float HiddenAlphaThreshold = 0.001f;
 
     private const string WarningBody =
         "This map contains rapid movements, flashing lights, or visual patterns.\n It may trigger seizures for people with photosensitive epilepsy. Viewer discretion is advised.";
 
     private GameplayScreen Screen { get; }
+
+    private bool ShouldShow { get; }
 
     /// <summary>
     ///     The scale used for fade animations.
@@ -33,13 +36,17 @@ public class EpilepsyWarning : Sprite
         Image = UserInterface.BlankBox;
         Tint = new Color(0, 0, 0, 0.5f);
         SetChildrenAlpha = true;
+        SetChildrenVisibility = true;
         Alpha = 0;
-        Visible = ShouldDisplayWarning();
+        ShouldShow = ShouldDisplayWarning();
+        Visible = false;
 
         CreateBackground();
         CreateIcon();
         CreateTitle();
         CreateBody();
+
+        Visible = false;
     }
 
     private void CreateBackground() => new Sprite
@@ -109,11 +116,16 @@ public class EpilepsyWarning : Sprite
     {
         base.Update(gameTime);
 
+        if (!ShouldShow)
+            return;
+
         var dt = gameTime.ElapsedGameTime.TotalMilliseconds;
 
         // Fade in on map start
         if (Screen.Timing.Time < -500)
         {
+            Visible = true;
+
             var alpha = MathHelper.Lerp(Alpha, 1, (float)Math.Min(dt / AnimationScale, 1));
 
             Alpha = alpha;
@@ -123,6 +135,9 @@ public class EpilepsyWarning : Sprite
             var alpha = MathHelper.Lerp(Alpha, 0, (float)Math.Min(dt / AnimationScale, 1));
 
             Alpha = alpha;
+
+            if (alpha <= HiddenAlphaThreshold)
+                Visible = false;
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -6,8 +6,8 @@
 */
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
+using MonoGame.Extended;
 using Quaver.API.Enums;
 using Quaver.API.Helpers;
 using Quaver.Shared.Assets;
@@ -15,6 +15,8 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Database.Maps;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Skinning;
+using Wobble;
+using Wobble.Assets;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
 using MathHelper = Microsoft.Xna.Framework.MathHelper;
@@ -36,7 +38,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// <summary>
         ///     The list of lines that are currently in the hit error.
         /// </summary>
-        public List<Sprite> LineObjectPool { get; }
+        private HitErrorLine[] LinePool { get; }
 
         /// <summary>
         ///     The current index we're in within the object pool.
@@ -71,18 +73,18 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 Parent = this
             };
 
-            // Create the object pool and initialize all of the sprites.
-            LineObjectPool = new List<Sprite>();
-            for (var i = 0; i < PoolSize; i++)
+            // Create the object pool and initialize all of the lines.
+            LinePool = new HitErrorLine[PoolSize];
+
+            _ = new HitErrorLineBatch(LinePool)
             {
-                LineObjectPool.Add(new Sprite()
-                {
-                    Parent = this,
-                    Size = new ScalableVector2(4, 0, 0, 1),
-                    Alignment = Alignment.MidCenter,
-                    Alpha = 0
-                });
-            }
+                Parent = this,
+                Size = new ScalableVector2(0, 0, 1, 1),
+                Alignment = Alignment.MidCenter
+            };
+
+            for (var i = 0; i < PoolSize; i++)
+                LinePool[i].Alpha = 0;
 
             // Create the hit chevron.
             var chevronSize = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorChevronSize;
@@ -108,12 +110,12 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             var dt = gameTime.ElapsedGameTime.TotalMilliseconds;
 
             // Gradually fade out the line.
-            foreach (var line in LineObjectPool)
-                line.Alpha = MathHelper.Lerp(line.Alpha, 0, (float)Math.Min(dt / ConfigManager.HitErrorFadeTime.Value, 1));
+            for (var i = 0; i < LinePool.Length; i++)
+                LinePool[i].Alpha = MathHelper.Lerp(LinePool[i].Alpha, 0, (float)Math.Min(dt / ConfigManager.HitErrorFadeTime.Value, 1));
 
             // Tween the chevron to the last hit
             if (CurrentLinePoolIndex != -1)
-                LastHitCheveron.X = MathHelper.Lerp(LastHitCheveron.X, LineObjectPool[CurrentLinePoolIndex].X, (float)Math.Min(dt / 360, 1));
+                LastHitCheveron.X = MathHelper.Lerp(LastHitCheveron.X, LinePool[CurrentLinePoolIndex].X, (float)Math.Min(dt / 360, 1));
 
             base.Update(gameTime);
         }
@@ -128,10 +130,10 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             if (CurrentLinePoolIndex >= PoolSize)
                 CurrentLinePoolIndex = 0;
 
-            LineObjectPool[CurrentLinePoolIndex].Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].JudgeColors[j];
+            LinePool[CurrentLinePoolIndex].Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].JudgeColors[j];
 
-            LineObjectPool[CurrentLinePoolIndex].X = -(float)hitTime / ModHelper.GetRateFromMods(ModManager.Mods) * SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorWidthScale;
-            LineObjectPool[CurrentLinePoolIndex].Alpha = Alpha;
+            LinePool[CurrentLinePoolIndex].X = -(float)hitTime / ModHelper.GetRateFromMods(ModManager.Mods) * SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorWidthScale;
+            LinePool[CurrentLinePoolIndex].Alpha = Alpha;
 
             if (!ConfigManager.ColorHitErrorByTiming.Value)
             {
@@ -148,6 +150,56 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             else
             {
                 LastHitCheveron.Tint = SkinManager.Skin.Keys[MapManager.Selected.Value.Mode].HitErrorNeutralColor;
+            }
+        }
+
+        private struct HitErrorLine
+        {
+            public float X;
+
+            public float Alpha;
+
+            public Color Tint;
+        }
+
+        private class HitErrorLineBatch : Sprite
+        {
+            private const float LineWidth = 4;
+
+            private readonly HitErrorLine[] lines;
+
+            public HitErrorLineBatch(HitErrorLine[] lines)
+            {
+                this.lines = lines;
+                Image = WobbleAssets.WhiteBox;
+            }
+
+            public override void DrawToSpriteBatch()
+            {
+                if (!Visible)
+                    return;
+
+                var scaledLineWidth = LineWidth * Math.Abs(AbsoluteScale.X);
+                var lineHeight = RenderRectangle.Height;
+                var centerX = RenderRectangle.X + RenderRectangle.Width / 2f;
+                var y = RenderRectangle.Y;
+
+                for (var i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i];
+
+                    if (line.Alpha <= 0.001f)
+                        continue;
+
+                    var rect = new RectangleF(
+                        centerX + line.X * AbsoluteScale.X - scaledLineWidth / 2f,
+                        y,
+                        scaledLineWidth,
+                        lineHeight);
+
+                    GameBase.Game.SpriteBatch.Draw(Image, rect, null, line.Tint * line.Alpha, SpriteOverallRotation,
+                        Origin, SpriteEffect, 0f);
+                }
             }
         }
     }

--- a/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/HitErrorBar.cs
@@ -176,9 +176,10 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             public override void DrawToSpriteBatch()
             {
-                if (!Visible)
+                if (!Visible || Alpha <= 0.001f)
                     return;
 
+                var batchAlpha = Alpha;
                 var scaledLineWidth = LineWidth * Math.Abs(AbsoluteScale.X);
                 var lineHeight = RenderRectangle.Height;
                 var centerX = RenderRectangle.X + RenderRectangle.Width / 2f;
@@ -197,7 +198,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                         scaledLineWidth,
                         lineHeight);
 
-                    GameBase.Game.SpriteBatch.Draw(Image, rect, null, line.Tint * line.Alpha, SpriteOverallRotation,
+                    GameBase.Game.SpriteBatch.Draw(Image, rect, null, line.Tint * (line.Alpha * batchAlpha), SpriteOverallRotation,
                         Origin, SpriteEffect, 0f);
                 }
             }

--- a/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
@@ -101,6 +101,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         public PauseScreen(GameplayScreen screen)
         {
             Screen = screen;
+            SetChildrenVisibility = true;
+            Visible = false;
 
             // Background
             Background = new Sprite()
@@ -294,6 +296,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             if (Screen.Failed || Screen.SpectatorClient != null)
                 Visible = false;
 
+            if (!Screen.IsPaused && Background.Alpha <= 0 && Buttons.TrueForAll(x => x.Alpha <= 0))
+                Visible = false;
+
             Continue.IsClickable = Screen.IsPaused && Visible && !Screen.InReplayMode;
             Retry.IsClickable = Screen.IsPaused && Visible && !Screen.InReplayMode;
             Quit.IsClickable = Screen.IsPaused && Visible && !Screen.InReplayMode;
@@ -318,6 +323,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             if (Screen.SpectatorClient != null)
                 return;
 
+            Visible = true;
             Background.ClearAnimations();
             Background.Animations.Add(new Animation(AnimationProperty.Alpha, Easing.Linear, Background.Alpha, 1, ANIMATION_TIME));
             Container.ClearAnimations();

--- a/Quaver.Shared/Screens/Gameplay/UI/Scoreboard/ScoreboardUser.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Scoreboard/ScoreboardUser.cs
@@ -151,6 +151,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             RatingProcessor = (RatingProcessorKeys)score?.RatingProcessor ?? processor ?? new RatingProcessorKeys(MapManager.Selected.Value.DifficultyFromMods(mods));
             Type = type;
             Size = new ScalableVector2(299, 58);
+            var hasLiveScoreText = Type == ScoreboardUserType.Self || Judgements?.Count > 0;
 
             // Set position initially to offscreen
             X = -Width - 10;
@@ -194,7 +195,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
                 Image = avatar,
             };
 
-            RankText = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "?.", 20, false)
+            RankText = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "?.", 20)
             {
                 Parent = this,
                 Alignment = Alignment.MidLeft,
@@ -230,7 +231,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             ScheduleAvatarMaskBlend(Avatar.Image);
 
             // Create username text.
-            Username = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), GetUsernameFormatted(), 21)
+            Username = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), GetUsernameFormatted(), 21, Type != ScoreboardUserType.Self)
             {
                 Parent = this,
                 Alignment = Alignment.TopLeft,
@@ -240,7 +241,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             };
 
             // Create score text.
-            Score = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0.00 / 0.00%", 19, false)
+            Score = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0.00 / 0.00%", 19, !hasLiveScoreText)
             {
                 Parent = this,
                 Alignment = Alignment.BotLeft,
@@ -250,7 +251,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             };
 
             // Create score text.
-            Combo = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), $"{Processor.Combo:N0}x", 18, false)
+            Combo = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), $"{Processor.Combo:N0}x", 18, !hasLiveScoreText)
             {
                 Parent = this,
                 Alignment = Alignment.MidRight,

--- a/Quaver.Shared/Screens/Gameplay/UI/Scoreboard/ScoreboardUser.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/Scoreboard/ScoreboardUser.cs
@@ -152,6 +152,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             Type = type;
             Size = new ScalableVector2(299, 58);
             var hasLiveScoreText = Type == ScoreboardUserType.Self || Judgements?.Count > 0;
+            var cacheStaticText = !screen.IsMultiplayerGame;
 
             // Set position initially to offscreen
             X = -Width - 10;
@@ -231,7 +232,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             ScheduleAvatarMaskBlend(Avatar.Image);
 
             // Create username text.
-            Username = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), GetUsernameFormatted(), 21, Type != ScoreboardUserType.Self)
+            Username = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), GetUsernameFormatted(), 21, cacheStaticText && Type != ScoreboardUserType.Self)
             {
                 Parent = this,
                 Alignment = Alignment.TopLeft,
@@ -241,7 +242,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             };
 
             // Create score text.
-            Score = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0.00 / 0.00%", 19, !hasLiveScoreText)
+            Score = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), "0.00 / 0.00%", 19, cacheStaticText && !hasLiveScoreText)
             {
                 Parent = this,
                 Alignment = Alignment.BotLeft,
@@ -251,7 +252,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI.Scoreboard
             };
 
             // Create score text.
-            Combo = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), $"{Processor.Combo:N0}x", 18, !hasLiveScoreText)
+            Combo = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack), $"{Processor.Combo:N0}x", 18, cacheStaticText && !hasLiveScoreText)
             {
                 Parent = this,
                 Alignment = Alignment.MidRight,

--- a/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SongInformation.cs
@@ -25,6 +25,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 {
     public class SongInformation : Sprite
     {
+        private const float HiddenAlphaThreshold = 0.001f;
+
         /// <summary>
         /// Reference to the actual gameplay screen.
         /// </summary>
@@ -80,7 +82,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
             Size = new ScalableVector2(750, 150);
             Tint = Colors.MainAccentInactive;
+            SetChildrenVisibility = true;
             Alpha = 0;
+            Visible = false;
 
             // Create watching text outside of replay mode because other text relies on it.
             Watching = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.LatoBlack),
@@ -144,6 +148,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 Y = Rating.Y + TextYSpacing + TextYSpacing * 0.7f,
                 Alpha = 0
             };
+
+            Visible = false;
         }
 
         /// <inheritdoc />
@@ -158,6 +164,8 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             // Fade in on map start
             if (Screen.Timing.Time < -500)
             {
+                Visible = true;
+
                 var alpha = MathHelper.Lerp(Title.Alpha, 1, (float)Math.Min(dt / AnimationScale, 1));
 
                 Title.Alpha = alpha;
@@ -178,6 +186,9 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 Creator.Alpha = alpha;
                 Rating.Alpha = alpha;
                 Mods.Alpha = alpha;
+
+                if (alpha <= HiddenAlphaThreshold)
+                    Visible = false;
             }
 
             base.Update(gameTime);

--- a/Quaver.Shared/Screens/QuaverScreen.cs
+++ b/Quaver.Shared/Screens/QuaverScreen.cs
@@ -180,15 +180,11 @@ namespace Quaver.Shared.Screens
         /// <param name="tooltip"></param>
         public void ActivateTooltip(Tooltip tooltip)
         {
-            if (ActiveTooltip != null)
-            {
-                ActiveTooltip.Visible = false;
-                ActiveTooltip.Parent = null;
-            }
+            ActiveTooltip?.Hide();
 
             ActiveTooltip = tooltip;
             ActiveTooltip.Parent = View.Container;
-            ActiveTooltip.Visible = true;
+            ActiveTooltip.Show();
 
             var x = MathHelper.Clamp(MouseManager.CurrentState.X - ActiveTooltip.Width, 0,
                 WindowManager.Width - ActiveTooltip.Width);
@@ -210,8 +206,8 @@ namespace Quaver.Shared.Screens
             if (ActiveTooltip == null)
                 return;
 
-            ActiveTooltip.Visible = false;
-            ActiveTooltip.Parent = null;
+            ActiveTooltip.Hide();
+            ActiveTooltip = null;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
@@ -89,7 +89,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Components
                 if (Selector == null)
                     return;
 
-                Tooltip.Parent = null;
+                Selector.DeactivateTooltip();
             };
 
             Clicked += (sender, args) =>

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/ModifierSelector.cs
@@ -165,8 +165,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
         /// <param name="tooltip"></param>
         public void ActivateTooltip(Tooltip tooltip)
         {
-            if (ActiveTooltip != null)
-                ActiveTooltip.Parent = null;
+            ActiveTooltip?.Hide();
 
             ActiveTooltip = tooltip;
 
@@ -174,10 +173,20 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers
                 return;
 
             ActiveTooltip.Parent = this;
+            ActiveTooltip.Show();
 
             ActiveTooltip.Alpha = 0;
             ActiveTooltip.ClearAnimations();
             ActiveTooltip.FadeTo(1, Easing.Linear, 150);
+        }
+
+        public void DeactivateTooltip()
+        {
+            if (ActiveTooltip == null)
+                return;
+
+            ActiveTooltip.Hide();
+            ActiveTooltip = null;
         }
 
         /// <summary>


### PR DESCRIPTION
This is quite the big pull request so i will list all the big changes from it, everything else is matter of properly hiding drawing of sprites/text.
- chat overlay, not properly removes all the chat msgs from being drawn
- all dropdowns no longer render anything, until opened
- we stop the chat msgs processing while playing, and it will resume after finishing playing
- reduced the hit error bar to draw less sprites
- we properly hide the pause screen, where in some cases it was drawn and even accessible via keyboard
- scoreboard text is also now cached when playing

+ debugger and fps fix https://github.com/Quaver/Wobble/pull/179

This PR pretty much focuses on fixing gameplay + due to chat overlay also other areas of the game benefit from it.