### PR TITLE
Hide FPS Counter when playing

### DIFF
--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -596,7 +596,8 @@ namespace Quaver.Shared
         /// <summary>
         ///     Shows the FPS counter based on the current config variable.
         /// </summary>
-        private static void ShowFpsCounter(FpsCounter counter) => counter.Visible = ConfigManager.FpsCounter.Value;
+        private void ShowFpsCounter(FpsCounter counter) =>
+            counter.Visible = ConfigManager.FpsCounter.Value && CurrentScreen?.Type != QuaverScreenType.Gameplay;
 
         /// <summary>
         ///     Uses a custom fps config
@@ -1005,6 +1006,8 @@ namespace Quaver.Shared
         {
             if (Fps == null)
                 return;
+
+            ShowFpsCounter(Fps);
 
             Fps.Y = -MenuBorder.HEIGHT - 10;
 


### PR DESCRIPTION
This is mostly for testing right now.
I feel like disabling the fps counter somehow makes the game feel a lot smoother/responsive.
So for this test I only hide it once we are playing a map, other wise we still show it.
If this makes people feel real difference, I think we should keep it or alternatively add another option to force always show it, in case someone really needs it.