### PR TITLE
Fix Pause mod not being removed after leaving a map (v2)

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -454,6 +454,10 @@ namespace Quaver.Shared.Screens.Gameplay
             NextSoundEffectIndex = 0;
             UpdateNextSoundEffectIndex();
 
+            // Remove paused modifier if enabled.
+            if (ModManager.IsActivated(ModIdentifier.Paused))
+                ModManager.RemoveMod(ModIdentifier.Paused);
+
             // Handle autoplay replays.
             if (ModManager.IsActivated(ModIdentifier.Autoplay))
                 LoadedReplay = ReplayHelper.GeneratePerfectReplay(map, MapHash);

--- a/Quaver.Shared/Screens/Results/ResultsScreen.cs
+++ b/Quaver.Shared/Screens/Results/ResultsScreen.cs
@@ -167,6 +167,10 @@ namespace Quaver.Shared.Screens.Results
 
             SetDiscordRichPresence();
             View = new ResultsScreenView(this);
+
+            // Remove paused modifier if enabled.
+            if (ModManager.IsActivated(ModIdentifier.Paused))
+                ModManager.RemoveMod(ModIdentifier.Paused);
         }
 
         /// <summary>


### PR DESCRIPTION
There was actually some edge cases for which we needed that check in the gameplay screen. Just to be extra safe, i also added it in the result screen