### PR TITLE
[1.8.x] fix-3986: Request on inaccessible leaderboards update Ranked Status to Unranked

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -506,6 +506,12 @@ namespace Quaver.Shared.Online
         /// <param name="e"></param>
         private static void OnRetrievedOnlineScores(object sender, RetrievedOnlineScoresEventArgs e)
         {
+            if (e.Response.Status < 200 || e.Response.Status >= 300)
+            {
+                Logger.Important($"Could not retrieve scores and ranked status for: {e.Id} | {e.Md5}, status code: {e.Response.Status}", LogType.Network);
+                return;
+            }
+
             Logger.Important($"Retrieved scores and ranked status for: {e.Id} | {e.Md5}", LogType.Network);
 
             try


### PR DESCRIPTION
When going inside the 'All' leaderboard a request is sent to update status of the map.
If your not a donator the result of the request contains a ranked status field that is always "unranked" even in case where it is incorrect.

What should happens I think is that an authenticated user that do not has correct role to access data should be met with a 403 (FORBIDDEN) status code and if so no update should be done on client.

I cannot access Quaver.Server.Client code so I cannot be sure of the status code currently used in those responses, but if it's not in [200;300[ range it should not be updated anyway.