### PR TITLE
Add an option to filter maps by clan ranked status

### DIFF
--- a/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
+++ b/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
@@ -222,7 +222,7 @@ namespace Quaver.Shared.Online.API.MapsetSearch
                 request.AddQueryParameter("sort_order", ReverseSort ^ invertSort ? "desc" : "asc");
                 request.AddQueryParameter("sort_by", SortBy switch
                 {
-                    DownloadSortBy.DateLastUpdated => "date_last_updated",
+                    DownloadSortBy.DateLastUpdated => Status == DownloadFilterRankedStatus.ClanRanked ? "date_clan_ranked" : "date_last_updated",
                     DownloadSortBy.DateSubmitted => "date_submitted",
                     DownloadSortBy.Length => "length",
                     DownloadSortBy.DifficultyRating => "difficulty_rating",
@@ -271,6 +271,12 @@ namespace Quaver.Shared.Online.API.MapsetSearch
         /// </summary>
         private void SetStatusQueryParams(RestRequest request)
         {
+            if (Status == DownloadFilterRankedStatus.ClanRanked)
+            {
+                request.AddQueryParameter("is_clan_ranked", "true");
+                return;
+            }
+
             // Ranked Status Query Param
             if (Status == DownloadFilterRankedStatus.All)
             {

--- a/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
+++ b/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
@@ -222,7 +222,7 @@ namespace Quaver.Shared.Online.API.MapsetSearch
                 request.AddQueryParameter("sort_order", ReverseSort ^ invertSort ? "desc" : "asc");
                 request.AddQueryParameter("sort_by", SortBy switch
                 {
-                    DownloadSortBy.DateLastUpdated => Status == DownloadFilterRankedStatus.ClanRanked ? "date_clan_ranked" : "date_last_updated",
+                    DownloadSortBy.DateLastUpdated => (Status == DownloadFilterRankedStatus.ClanRanked ? "date_clan_ranked" : "date_last_updated"),
                     DownloadSortBy.DateSubmitted => "date_submitted",
                     DownloadSortBy.Length => "length",
                     DownloadSortBy.DifficultyRating => "difficulty_rating",

--- a/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
+++ b/Quaver.Shared/Online/API/MapsetSearch/APIRequestMapsetSearch.cs
@@ -222,7 +222,7 @@ namespace Quaver.Shared.Online.API.MapsetSearch
                 request.AddQueryParameter("sort_order", ReverseSort ^ invertSort ? "desc" : "asc");
                 request.AddQueryParameter("sort_by", SortBy switch
                 {
-                    DownloadSortBy.DateLastUpdated => (Status == DownloadFilterRankedStatus.ClanRanked ? "date_clan_ranked" : "date_last_updated"),
+                    DownloadSortBy.DateLastUpdated => Status == DownloadFilterRankedStatus.ClanRanked ? "date_clan_ranked" : "date_last_updated",
                     DownloadSortBy.DateSubmitted => "date_submitted",
                     DownloadSortBy.Length => "length",
                     DownloadSortBy.DifficultyRating => "difficulty_rating",

--- a/Quaver.Shared/QuaverGame.cs
+++ b/Quaver.Shared/QuaverGame.cs
@@ -596,8 +596,7 @@ namespace Quaver.Shared
         /// <summary>
         ///     Shows the FPS counter based on the current config variable.
         /// </summary>
-        private void ShowFpsCounter(FpsCounter counter) =>
-            counter.Visible = ConfigManager.FpsCounter.Value && CurrentScreen?.Type != QuaverScreenType.Gameplay;
+        private static void ShowFpsCounter(FpsCounter counter) => counter.Visible = ConfigManager.FpsCounter.Value;
 
         /// <summary>
         ///     Uses a custom fps config
@@ -1006,8 +1005,6 @@ namespace Quaver.Shared
         {
             if (Fps == null)
                 return;
-
-            ShowFpsCounter(Fps);
 
             Fps.Y = -MenuBorder.HEIGHT - 10;
 

--- a/Quaver.Shared/Screens/Downloading/UI/Search/DownloadStatusDropdown.cs
+++ b/Quaver.Shared/Screens/Downloading/UI/Search/DownloadStatusDropdown.cs
@@ -34,6 +34,7 @@ namespace Quaver.Shared.Screens.Downloading.UI.Search
             "All",
             "Unranked",
             "Ranked",
+            "Clan Ranked",
         };
 
         /// <summary>
@@ -47,5 +48,6 @@ namespace Quaver.Shared.Screens.Downloading.UI.Search
         All,
         Unranked,
         Ranked,
+        ClanRanked,
     }
 }


### PR DESCRIPTION
Requires changes from api_v2 ([#160](https://github.com/Quaver/api-v2/pull/160)) to fix sorting issues when looking for clan ranked maps