### PR TITLE
[1.7.x] Fix pause menu and main menu navigation offset

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
@@ -237,9 +237,23 @@ namespace Quaver.Shared.Screens.Gameplay.UI
 
                 if (button == Selected)
                 {
+                    if (dontPlayAudio)
+                    {
+                        button.X = GetActivePosX(button) + HOVER_X_OFFSET;
+                        button.Tint = Color.White;
+                        continue;
+                    }
+
                     button.FadeToColor(Color.White, Easing.OutQuint, ANIMATION_TIME);
                     button.MoveToX(GetActivePosX(button) + HOVER_X_OFFSET, Easing.OutQuint, ANIMATION_TIME);
 
+                    continue;
+                }
+
+                if (dontPlayAudio)
+                {
+                    button.X = GetActivePosX(button);
+                    button.Tint = TintColor;
                     continue;
                 }
 

--- a/Quaver.Shared/Screens/Main/UI/Nagivation/NavigationButton.cs
+++ b/Quaver.Shared/Screens/Main/UI/Nagivation/NavigationButton.cs
@@ -88,7 +88,7 @@ namespace Quaver.Shared.Screens.Main.UI.Nagivation
 
         public void Select(bool instantWidth = false)
         {
-            ClearAnimations();
+            ClearWidthAnimations();
 
             var width = OriginalSize.X.Value + 20;
 
@@ -106,10 +106,29 @@ namespace Quaver.Shared.Screens.Main.UI.Nagivation
 
         public void Deselect()
         {
-            ClearAnimations();
+            ClearWidthAnimations();
             ChangeWidthTo((int) OriginalSize.X.Value, Easing.OutQuint, 450);
             Image = DeselectedButton;
             IsSelected = false;
+        }
+
+        /// <summary>
+        ///     Clears only the width-related animations, leaving other in-progress animations
+        ///     (such as the entrance slide-in MoveToX from <see cref="NavigationButtonContainer.AlignButtons"/>)
+        ///     untouched. Calling ClearAnimations() here would wipe that slide-in mid-flight if the
+        ///     user navigates with the arrow keys right as the main menu is entered, leaving the
+        ///     button stuck off-screen.
+        /// </summary>
+        private void ClearWidthAnimations()
+        {
+            lock (Animations)
+            {
+                for (var i = Animations.Count - 1; i >= 0; i--)
+                {
+                    if (Animations[i].Properties == AnimationProperty.Width)
+                        Animations.RemoveAt(i);
+                }
+            }
         }
 
         private void CreateHoverEffect() => HoverEffect = new Sprite()


### PR DESCRIPTION
## Fix pause menu and main menu navigation offset

### Fixed

#### #4103 pause bug

When tap to pause is enabled and the pause key is hit the instant a map finishes loading the pause menu's Continue/Retry/Quit buttons could appear stuck on the left edge of the screen instead of centered. This happened because the buttons' initial position was set via a 400ms slide-in animation rather than being placed directly so if the pause menu was activated before that animation had time to run it became visible mid-animation.

Button positions are now set immediately on initialization instead of relying on an animation to reach their resting position.

#### Fix main menu navigation buttons getting stuck off-screen when spamming arrow keys

Navigating the main menu's side navigation buttons with the arrow keys immediately after entering the main menu (e.g. coming back from the song select screen) could leave a button stuck off-screen to the left. Selecting/deselecting a button cleared all of its animations, including the entrance slide-in animation so if that slide-in hadn't finished yet it was wiped out mid-flight and the button never reached its correct position.

Selecting/deselecting a button now only clears its width animation leaving the entrance slide-in animation untouched.

### Testing (Done on windows 11)

- Verified pausing instantly via tap to pause right as a map loads no longer leaves the pause menu buttons offset to the left.
- Verified pause menu still behaves correctly when paused normally (after map has fully loaded).
- Verified spamming up/down arrow keys immediately upon returning to the main menu no longer leaves navigation buttons stuck off-screen.
- Verified main menu navigation buttons still animate in/out correctly under normal use.

### Closes

- #4103
