### PR TITLE
[1.7.x] Quit during epilepsy warning with automod doesn't pause music anymore

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -813,6 +813,9 @@ namespace Quaver.Shared.Screens.Gameplay
                     if (SpectatorClient != null)
                         OnlineManager.Client?.StopSpectating();
 
+                    if (!HasStarted)
+                        AudioEngine.Track?.Dispose();
+
                     Exit(() => new SelectionScreen());
 
                     return;


### PR DESCRIPTION
This pr will resolve and close issue #4702. Quitting via Autoplay before the track started playing left it orphaned in a non-disposed, never-played state that song select's track-restart check doesn't detect. Disposing it in that case lets song select pick it back up normally.