### PR TITLE
[1.8.x] the top of the qr bar and map preview did not allign with the header on some resolution

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -125,6 +125,7 @@ namespace Quaver.Shared.Screens.Edit
             }
 
             CreateBackground();
+            MenuBar = new EditorFileMenuBar(EditScreen);
             CreatePlayfield();
             CreateFooter();
             CreateSelector();
@@ -137,8 +138,6 @@ namespace Quaver.Shared.Screens.Edit
 
             if (EditScreen.DisplayGameplayPreview.Value)
                 CreateGameplayPreview();
-
-            MenuBar = new EditorFileMenuBar(EditScreen);
 
             EditScreen.DisplayGameplayPreview.ValueChanged += OnDisplayGameplayPreviewChanged;
             EditScreen.UneditableMap.ValueChanged += OnUneditableMapChanged;
@@ -431,12 +430,13 @@ namespace Quaver.Shared.Screens.Edit
             if (MapPreview != null)
                 return;
 
+            var menuBarVirtualY = (int)(EditorFileMenuBar.CurrentHeight / WindowManager.ScreenScale.Y);
             MapPreview = new EditorMapPreview(EditScreen.ActionManager, new Bindable<bool>(false), EditScreen.ActiveLeftPanel,
-                (int)WindowManager.Height - MenuBorder.HEIGHT - 34, EditScreen.Track, EditScreen.WorkingMap)
+                (int)(WindowManager.Height - menuBarVirtualY - EditorFooter.HEIGHT), EditScreen.Track, EditScreen.WorkingMap)
             {
                 Parent = Container,
                 Alignment = Alignment.TopCenter,
-                Y = 34,
+                Y = menuBarVirtualY,
             };
 
             var keyCount = ModeHelper.ToKeyCount(EditScreen.WorkingMap.Mode);

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -59,13 +59,19 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         /// </summary>
         public bool IsActive { get; private set; }
 
+        public static float CurrentHeight { get; private set; }
+
 #if VISUAL_TESTS
         private static bool DestroyContext { get; } = false;
 #else
         private static bool DestroyContext { get; } = true;
 #endif
 
-        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions(), screen.ImGuiScale) => Screen = screen;
+        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, GetOptions(), screen.ImGuiScale)
+        {
+            Screen = screen;
+            CurrentHeight = 14 + 20 * screen.ImGuiScale;
+        }
 
 
         /// <inheritdoc />
@@ -83,6 +89,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
                 return;
 
             Height = ImGui.GetWindowSize().Y;
+            CurrentHeight = Height;
 
             CreateFileSection();
             CreateEditSection();

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -34,6 +34,7 @@ using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffset;
 using Quaver.Shared.Screens.Edit.Actions.Timing.ChangeOffsetBatch;
 using Quaver.Shared.Screens.Edit.Actions.Timing.RemoveBatch;
 using Quaver.Shared.Screens.Edit.UI.Footer;
+using Quaver.Shared.Screens.Edit.UI.Menu;
 using Quaver.Shared.Screens.Edit.UI.Playfield.Lines;
 using Quaver.Shared.Screens.Edit.UI.Playfield.Seek;
 using Quaver.Shared.Screens.Edit.UI.Playfield.Spectrogram;
@@ -802,13 +803,14 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             if (IsUneditable)
                 return;
 
+            var menuBarVirtualY = (int)(EditorFileMenuBar.CurrentHeight / WindowManager.ScreenScale.Y);
             SeekBar = new EditorDifficultySeekBar(ActionManager, Map, ModIdentifier.None,
-                new ScalableVector2(56, WindowManager.Height - EditorFooter.HEIGHT - 38), 200, 3, Track,
+                new ScalableVector2(56, WindowManager.Height - EditorFooter.HEIGHT - menuBarVirtualY), 200, 3, Track,
                 true, 0.85f)
             {
                 Parent = this,
                 Tint = ColorHelper.HexToColor("#181818"),
-                Y = 34
+                Y = menuBarVirtualY
             };
 
             SeekBar.X -= SeekBar.Width + 60;


### PR DESCRIPTION
this pr closes #3907. Some things which this pr nor issue include are not fixed (these were already found issues so you can ignore this if you'd like): 

1. the top of the map preview is within the header
2. the top of the bar where you place your notes is within the header
3. the bottom of the qr bar is in the footer which makes it impossible to click on 00:00.000
4. the bottom of the map preview leaves a very small gap between it and the footer