### PR TITLE
[1.8.x] Disables hit bubbles in the editor map preview

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Preview/EditorMapPreview.cs
@@ -50,6 +50,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Preview
         /// </summary>
         private EditorActionManager ActionManager { get; }
 
+        protected override bool ShowHitBubbles { get; } = false;
+
         /// <inheritdoc />
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -94,6 +94,11 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
         protected bool HasSeekBar { get; set; } = true;
 
         /// <summary>
+        ///     If true, hit bubbles will be displayed in the preview's playfield
+        /// </summary>
+        protected virtual bool ShowHitBubbles { get; } = true;
+
+        /// <summary>
         ///     The amount of delay before the task will run
         /// </summary>
         protected int DelayTime { get; set; } = 350;
@@ -245,6 +250,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                 var playfield = (GameplayPlayfieldKeys)LoadedGameplayScreen.Ruleset.Playfield;
 
                 playfield.Stage.HealthBar.Visible = false;
+                playfield.Stage.HitBubbles.Visible = ShowHitBubbles;
 
                 Wheel.ClearAnimations();
                 Wheel.FadeTo(0, Easing.Linear, 250);


### PR DESCRIPTION
this pr closes #4382. you can also change `protected virtual bool ShowHitBubbles { get; } = true;` into false if you want to apply it to the preview in the song select also. then you also won't need the overwrite anymore