### PR TITLE
[1.8.x] Skin.ini DisplayJudgementsInEachColumn can be set to any judgement

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/InputManagerKeys.cs
@@ -200,15 +200,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                 // Update Playfield
                 var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
 
-                // Get hit burst lane
-                var judgementHitBurstLane = Math.Clamp(lane, 0, playfield.Stage.JudgementHitBursts.Count - 1);
-
                 if (ReplayInputManager == null)
                 {
                     playfield.Stage.ComboDisplay.MakeVisible();
                     playfield.Stage.HitError.AddJudgement(Judgement.Miss, info.StartTime - time);
                     playfield.Stage.HitBubbles.AddJudgement(Judgement.Miss);
-                    playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
+                    playfield.Stage.PerformJudgementHitBurstAnimation(lane, Judgement.Miss);
                 }
 
                 // Update Object Pooling
@@ -270,15 +267,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             // Update Playfield
             var playfield = (GameplayPlayfieldKeys)Ruleset.Playfield;
 
-            // Get hit burst lane
-            var judgementHitBurstLane = Math.Clamp(lane, 0, playfield.Stage.JudgementHitBursts.Count - 1);
-
             if (ReplayInputManager == null)
             {
                 playfield.Stage.ComboDisplay.MakeVisible();
                 playfield.Stage.HitError.AddJudgement(judgement, info.StartTime - time);
                 playfield.Stage.HitBubbles.AddJudgement(judgement);
-                playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(judgement);
+                playfield.Stage.PerformJudgementHitBurstAnimation(lane, judgement);
             }
 
             // Update Object Pooling
@@ -305,7 +299,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                         view.UpdateScoreboardUsers();
                         view.UpdateScoreAndAccuracyDisplays();
                         playfield.Stage.HitBubbles.AddJudgement(Judgement.Miss);
-                        playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
+                        playfield.Stage.PerformJudgementHitBurstAnimation(lane, Judgement.Miss);
                     }
 
                     info.State = HitObjectState.Dead;
@@ -351,9 +345,6 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
 
             var view = (GameplayScreenView)Ruleset.Screen.View;
 
-            // Get hit burst lane
-            var judgementHitBurstLane = Math.Clamp(lane, 0, playfield.Stage.JudgementHitBursts.Count - 1);
-
             // If LN has been released during a window
             if (judgement != Judgement.Ghost)
             {
@@ -387,7 +378,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     playfield.Stage.ComboDisplay.MakeVisible();
                     playfield.Stage.HitError.AddJudgement(judgement, info.EndTime - time);
                     playfield.Stage.HitBubbles.AddJudgement(judgement);
-                    playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(judgement);
+                    playfield.Stage.PerformJudgementHitBurstAnimation(lane, judgement);
                 }
 
                 // play hitlighting animation on release
@@ -430,7 +421,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
             if (ReplayInputManager == null)
             {
                 playfield.Stage.HitBubbles.AddJudgement(Judgement.Miss);
-                playfield.Stage.JudgementHitBursts[judgementHitBurstLane].PerformJudgementAnimation(Judgement.Miss);
+                playfield.Stage.PerformJudgementHitBurstAnimation(lane, Judgement.Miss);
             }
 
             // Update Object Pool

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Input/ReplayInputManagerKeys.cs
@@ -217,9 +217,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Input
                     if (hitStat.Judgement != Judgement.Miss)
                         playfield.Stage.HitError.AddJudgement(hitStat.Judgement, hitStat.HitDifference);
 
-                    var lane = Math.Clamp(hitStat.HitObject.Lane - 1, 0, playfield.Stage.JudgementHitBursts.Count - 1);
                     playfield.Stage.HitBubbles.AddJudgement(hitStat.Judgement);
-                    playfield.Stage.JudgementHitBursts[lane].PerformJudgementAnimation(hitStat.Judgement);
+                    playfield.Stage.PerformJudgementHitBurstAnimation(hitStat.HitObject.Lane - 1, hitStat.Judgement);
 
                     CurrentVirtualReplayStat++;
                 }

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/HitObjectManagerKeys.cs
@@ -635,7 +635,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     {
                         playfield.Stage.ComboDisplay.MakeVisible();
                         playfield.Stage.HitBubbles.AddJudgement(Judgement.Miss);
-                        playfield.Stage.JudgementHitBursts[Math.Clamp(info.Lane - 1, 0, playfield.Stage.JudgementHitBursts.Count - 1)].PerformJudgementAnimation(Judgement.Miss);
+                        playfield.Stage.PerformJudgementHitBurstAnimation(info.Lane - 1, Judgement.Miss);
                     }
 
                     // If ManiaHitObject is an LN, kill it and count it as another miss because of the tail.
@@ -704,7 +704,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                     if (im?.ReplayInputManager == null)
                     {
                         stage.ComboDisplay.MakeVisible();
-                        stage.JudgementHitBursts[Math.Clamp(info.Lane - 1, 0, stage.JudgementHitBursts.Count - 1)].PerformJudgementAnimation(missedReleaseJudgement);
+                        stage.PerformJudgementHitBurstAnimation(info.Lane - 1, missedReleaseJudgement);
                     }
 
                     stage.HitLightingObjects[info.Lane - 1].StopHolding();

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -124,9 +124,17 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         public HitBubbles HitBubbles { get; private set; }
 
         /// <summary>
-        ///     The JudgementHitBurst Sprite.
+        ///     The per-column JudgementHitBurst sprites, used for the judgements configured in
+        ///     <see cref="SkinKeys.DisplayJudgementsInEachColumn"/>. Empty when that value is
+        ///     <see cref="JudgementsInEachColumn.False"/>.
         /// </summary>
         public List<JudgementHitBurst> JudgementHitBursts { get; private set; }
+
+        /// <summary>
+        ///     The normal, centered JudgementHitBurst sprite, shown when
+        ///     <see cref="SkinKeys.DisplayJudgementHitBursts"/> is true.
+        /// </summary>
+        public JudgementHitBurst NormalJudgementHitBurst { get; private set; }
 
         /// <summary>
         ///     When hitting an object, this is the sprite that will be shown at
@@ -602,10 +610,18 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             // Set size w/ scaling.
             var size = new Vector2(firstFrame.Width, firstFrame.Height) * Skin.JudgementHitBurstScale / firstFrame.Height;
 
-            var judgementBurstCount = skin.DisplayJudgementsInEachColumn ?
-                Screen.Map.GetKeyCount(Screen.Map.HasScratchKey) : 1;
+            NormalJudgementHitBurst = new JudgementHitBurst(Screen, frames, size, Skin.JudgementBurstPosY)
+            {
+                Parent = Playfield.ForegroundContainer,
+                Alignment = Alignment.MidCenter,
+                X = 0
+            };
+
+            if (skin.DisplayJudgementsInEachColumn == JudgementsInEachColumn.False)
+                return;
 
             var playfieldOffset = (Playfield.Width / 2) - (Playfield.LaneSize / 2);
+            var judgementBurstCount = Screen.Map.GetKeyCount(Screen.Map.HasScratchKey);
 
             for (var lane = 0; lane < judgementBurstCount; lane++)
             {
@@ -613,14 +629,37 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                 {
                     Parent = Playfield.ForegroundContainer,
                     Alignment = Alignment.MidCenter,
-                    X = skin.DisplayJudgementsInEachColumn ? Receptors[lane].X - playfieldOffset : 0
+                    X = Receptors[lane].X - playfieldOffset
                 };
 
-                if (skin.RotateJudgements && skin.DisplayJudgementsInEachColumn)
+                if (skin.RotateJudgements)
                     judgementHitBurst.Rotation = GameplayHitObjectKeys.GetObjectRotation(Screen.Map.Mode, lane);
 
                 JudgementHitBursts.Add(judgementHitBurst);
             }
+        }
+
+        /// <summary>
+        ///     Performs the judgement hit burst animation for a given lane, dispatching to either
+        ///     the per-column hit burst (if the judgement is configured to show in
+        ///     <see cref="SkinKeys.DisplayJudgementsInEachColumn"/>) or the normal (centered) hit
+        ///     burst (if <see cref="SkinKeys.DisplayJudgementHitBursts"/> is true) never both.
+        /// </summary>
+        /// <param name="lane">Zero-indexed lane the judgement occurred in.</param>
+        /// <param name="judgement">The judgement to animate.</param>
+        public void PerformJudgementHitBurstAnimation(int lane, Judgement judgement)
+        {
+            var judgementFlag = (JudgementsInEachColumn)(1 << (int)judgement);
+
+            if (JudgementHitBursts.Count != 0 && Skin.DisplayJudgementsInEachColumn.HasFlag(judgementFlag))
+            {
+                var index = Math.Clamp(lane, 0, JudgementHitBursts.Count - 1);
+                JudgementHitBursts[index].PerformJudgementAnimation(judgement);
+                return;
+            }
+
+            if (Skin.DisplayJudgementHitBursts)
+                NormalJudgementHitBurst.PerformJudgementAnimation(judgement);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Gameplay/UI/JudgementsInEachColumn.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/JudgementsInEachColumn.cs
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * Copyright (c) Swan & The Quaver Team <support@quavergame.com>.
+*/
+
+using System;
+
+namespace Quaver.Shared.Screens.Gameplay.UI
+{
+    /// <summary>
+    ///     Which judgements get their own hit burst displayed in their column
+    ///     instead of the normal hit burst.
+    /// </summary>
+    [Flags]
+    public enum JudgementsInEachColumn
+    {
+        False = 0,
+        Marv = 1 << 0,
+        Perf = 1 << 1,
+        Great = 1 << 2,
+        Good = 1 << 3,
+        Okay = 1 << 4,
+        Miss = 1 << 5,
+        Default = False,
+        NoMarv = Perf | Great | Good | Okay | Miss,
+        All = Marv | NoMarv
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Preview/SelectMapPreviewContainer.cs
@@ -279,9 +279,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         if (playfield.Stage.HitBubbles.Y < 0)
                             playfield.Stage.HitBubbles.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBursts[0].OriginalPosY < 0)
+                        if (playfield.Stage.NormalJudgementHitBurst.OriginalPosY < 0)
+                        {
+                            playfield.Stage.NormalJudgementHitBurst.OriginalPosY *= previewMultiplier;
                             for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                                 playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
+                        }
 
                         if (playfield.Stage.ComboDisplay.OriginalPosY < 0)
                             playfield.Stage.ComboDisplay.OriginalPosY *= previewMultiplier;
@@ -291,6 +294,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                     case ScrollDirection.Up:
                         playfield.Container.Alignment = Alignment.TopLeft;
                         playfield.Stage.HitError.Y -= filterPanelHeight + MenuBorder.HEIGHT;
+                        playfield.Stage.NormalJudgementHitBurst.OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
                         for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                             playfield.Stage.JudgementHitBursts[i].OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
                         playfield.Stage.ComboDisplay.OriginalPosY -= filterPanelHeight + MenuBorder.HEIGHT;
@@ -298,9 +302,12 @@ namespace Quaver.Shared.Screens.Selection.UI.Preview
                         if (playfield.Stage.HitError.Y < 0)
                             playfield.Stage.HitError.Y *= previewMultiplier;
 
-                        if (playfield.Stage.JudgementHitBursts[0].OriginalPosY < 0)
+                        if (playfield.Stage.NormalJudgementHitBurst.OriginalPosY < 0)
+                        {
+                            playfield.Stage.NormalJudgementHitBurst.OriginalPosY *= previewMultiplier;
                             for (var i = 0; i < playfield.Stage.JudgementHitBursts.Count; i++)
                                 playfield.Stage.JudgementHitBursts[i].OriginalPosY *= previewMultiplier;
+                        }
 
                         if (playfield.Stage.ComboDisplay.OriginalPosY < 0)
                             playfield.Stage.ComboDisplay.OriginalPosY *= previewMultiplier;

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -212,7 +212,9 @@ namespace Quaver.Shared.Skinning
         [FixedScale]
         internal float JudgementBurstPosY { get; private set; }
 
-        internal bool DisplayJudgementsInEachColumn { get; private set; }
+        internal JudgementsInEachColumn DisplayJudgementsInEachColumn { get; private set; } = JudgementsInEachColumn.False;
+
+        internal bool DisplayJudgementHitBursts { get; private set; } = true;
 
         internal bool RotateJudgements { get; private set; }
 
@@ -653,7 +655,8 @@ namespace Quaver.Shared.Skinning
             ComboPosX = ConfigHelper.ReadInt32((int)ComboPosX, ini["ComboPosX"]);
             ComboPosY = ConfigHelper.ReadInt32((int)ComboPosY, ini["ComboPosY"]);
             JudgementBurstPosY = ConfigHelper.ReadInt32((int)JudgementBurstPosY, ini["JudgementBurstPosY"]);
-            DisplayJudgementsInEachColumn = ConfigHelper.ReadBool(DisplayJudgementsInEachColumn, ini["DisplayJudgementsInEachColumn"]);
+            DisplayJudgementsInEachColumn = ReadJudgementsInEachColumn(DisplayJudgementsInEachColumn, ini["DisplayJudgementsInEachColumn"]);
+            DisplayJudgementHitBursts = ConfigHelper.ReadBool(DisplayJudgementHitBursts, ini["DisplayJudgementHitBursts"]);
             RotateJudgements = ConfigHelper.ReadBool(RotateJudgements, ini["RotateJudgements"]);
             HealthBarType = ConfigHelper.ReadEnum(HealthBarType, ini["HealthBarType"]);
             HealthBarKeysAlignment = ConfigHelper.ReadEnum(HealthBarKeysAlignment, ini["HealthBarKeysAlignment"]);
@@ -837,6 +840,16 @@ namespace Quaver.Shared.Skinning
 
             return paddedTextures;
         }
+
+        /// <summary>
+        ///     Reads the value for <see cref="DisplayJudgementsInEachColumn"/>, keeping "True" as a
+        ///     backwards-compatible alias for <see cref="JudgementsInEachColumn.All"/>, since it used
+        ///     to be a boolean skin.ini key.
+        /// </summary>
+        private static JudgementsInEachColumn ReadJudgementsInEachColumn(JudgementsInEachColumn defaultVal, string newVal) =>
+            string.Equals(newVal, "true", StringComparison.OrdinalIgnoreCase)
+                ? JudgementsInEachColumn.All
+                : ConfigHelper.ReadEnum(defaultVal, newVal);
 
         /// <summary>
         ///     Loads the HitObjects w/ note snapping


### PR DESCRIPTION
this pr closes #4713. Within the skin.ini it is now possible to set DisplayJudgementsInEachColumn to `Marv, Perf, Great, Good, Okay, Miss, NoMarv, All (also accepted as True), Default (also accepted as False) or any combination of them joined by commas (,)`. When a DisplayJudgementsInEachColumn is set for a judgement it won't also show up as part of the hitburst. you can also set DisplayJudgementHitBursts to either `True` or `False` to turn it on or off which removes the need to put empty pictures as judgements