### PR TITLE
Fix song select ranked status refresh

### DIFF
--- a/Quaver.Shared/Online/OnlineManager.cs
+++ b/Quaver.Shared/Online/OnlineManager.cs
@@ -531,30 +531,6 @@ namespace Quaver.Shared.Online
 
                 var map = mapsets.First().Maps.Find(x => x.MapId == e.Id && x.Md5Checksum == e.Md5);
 
-                switch (e.Response.Code)
-                {
-                    case OnlineScoresResponseCode.NotSubmitted:
-                        map.RankedStatus = RankedStatus.NotSubmitted;
-                        break;
-                    case OnlineScoresResponseCode.NeedsUpdate:
-                        break;
-                    case OnlineScoresResponseCode.Unranked:
-                        map.RankedStatus = RankedStatus.Unranked;
-                        break;
-                    case OnlineScoresResponseCode.Ranked:
-                        map.RankedStatus = RankedStatus.Ranked;
-                        break;
-                    case OnlineScoresResponseCode.DanCourse:
-                        map.RankedStatus = RankedStatus.DanCourse;
-                        break;
-                    default:
-                        map.RankedStatus = RankedStatus.NotSubmitted;
-                        break;
-                }
-
-                if ((int)e.Response.Code == -1)
-                    map.RankedStatus = map.MapId == -1 ? RankedStatus.NotSubmitted : RankedStatus.Unranked;
-
                 // Update online grade
                 if (ConfigManager.LeaderboardSection.Value != LeaderboardType.Rate && e.Response.PersonalBest != null)
                 {

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
@@ -27,6 +27,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                     var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.All);
 
                     map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
@@ -26,8 +26,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                     var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.All);
 
-                    map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherAll.cs
@@ -24,9 +24,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                     if (!OnlineManager.Connected)
                         return new FetchedScoreStore(new List<Score>());
 
-                    var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.All);
+                    if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
+                        return new FetchedScoreStore(new List<Score>());
 
-                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
+                    var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.All);
 
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
@@ -25,7 +25,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                         return new FetchedScoreStore(new List<Score>());
 
                     var onlineScores = OnlineManager.Client?.GetClanScoreboard(map.Md5Checksum);
-                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                     
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
@@ -25,6 +25,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                         return new FetchedScoreStore(new List<Score>());
 
                     var onlineScores = OnlineManager.Client?.GetClanScoreboard(map.Md5Checksum);
+                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
                     
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherClan.cs
@@ -24,8 +24,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                     if (!OnlineManager.Connected)
                         return new FetchedScoreStore(new List<Score>());
 
+                    if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
+                        return new FetchedScoreStore(new List<Score>());
+
                     var onlineScores = OnlineManager.Client?.GetClanScoreboard(map.Md5Checksum);
-                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                     
                     var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
@@ -20,16 +20,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
 
-                if (!OnlineManager.IsDonator)
-                {
-                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
+                if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
                     return new FetchedScoreStore(new List<Score>());
-                }
+
+                if (!OnlineManager.IsDonator)
+                    return new FetchedScoreStore(new List<Score>());
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Country,
                     0, OnlineManager.Self.OnlineUser.CountryFlag.ToUpper());
-
-                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
@@ -22,15 +22,14 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 if (!OnlineManager.IsDonator)
                 {
-                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                     return new FetchedScoreStore(new List<Score>());
                 }
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Country,
                     0, OnlineManager.Self.OnlineUser.CountryFlag.ToUpper());
 
-                map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherCountry.cs
@@ -17,13 +17,20 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
         {
             try
             {
-                if (!OnlineManager.Connected || !OnlineManager.IsDonator)
+                if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
+
+                if (!OnlineManager.IsDonator)
+                {
+                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    return new FetchedScoreStore(new List<Score>());
+                }
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Country,
                     0, OnlineManager.Self.OnlineUser.CountryFlag.ToUpper());
 
                 map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
@@ -17,12 +17,19 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
         {
             try
             {
-                if (!OnlineManager.Connected || !OnlineManager.IsDonator)
+                if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
+
+                if (!OnlineManager.IsDonator)
+                {
+                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    return new FetchedScoreStore(new List<Score>());
+                }
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Friends);
 
                 map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
@@ -22,14 +22,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 if (!OnlineManager.IsDonator)
                 {
-                    ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                     return new FetchedScoreStore(new List<Score>());
                 }
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Friends);
 
-                map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherFriends.cs
@@ -20,15 +20,13 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
 
-                if (!OnlineManager.IsDonator)
-                {
-                    ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
+                if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
                     return new FetchedScoreStore(new List<Score>());
-                }
+
+                if (!OnlineManager.IsDonator)
+                    return new FetchedScoreStore(new List<Score>());
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Friends);
-
-                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
@@ -25,8 +25,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Global);
 
-                map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
@@ -26,6 +26,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Global);
 
                 map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherGlobal.cs
@@ -23,9 +23,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
 
-                var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Global);
+                if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
+                    return new FetchedScoreStore(new List<Score>());
 
-                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
+                var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Global);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
@@ -31,6 +31,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Mods, mods);
                 map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
@@ -30,9 +30,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 mods = ModManager.Mods - (long) mods;
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Mods, mods);
-                map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
+                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                 var scores = new List<Score>();
 
                 if (onlineScores?.Scores == null)

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherMods.cs
@@ -22,6 +22,9 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
 
+                if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
+                    return new FetchedScoreStore(new List<Score>());
+
                 var mods = ModHelper.GetModsFromRate(ModHelper.GetRateFromMods(ModManager.Mods));
 
                 if (mods == ModIdentifier.None)
@@ -31,7 +34,6 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Mods, mods);
 
-                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
                 var scores = new List<Score>();
 
                 if (onlineScores?.Scores == null)

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
@@ -13,15 +13,15 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
         ///     Refreshes the selected map's online status from /v2/map/:id.
         /// </summary>
         /// <param name="map"></param>
-        public static void UpdateMapStatus(Map map)
+        public static bool UpdateMapStatus(Map map)
         {
             if (map == null || map.MapId <= 0 || OnlineManager.Client == null)
-                return;
+                return false;
 
             var response = OnlineManager.Client.RetrieveMapInfo(map.MapId);
 
             if (response?.Map == null)
-                return;
+                return false;
 
             var rankedStatus = response.Map.RankedStatus;
             var needsOnlineUpdate = NeedsOnlineUpdate(map, response.Map.Md5);
@@ -29,17 +29,19 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
             var rankedStatusChanged = map.RankedStatus != rankedStatus;
             var needsOnlineUpdateChanged = map.NeedsOnlineUpdate != needsOnlineUpdate;
 
-            if (!rankedStatusChanged && !needsOnlineUpdateChanged)
-                return;
+            if (rankedStatusChanged || needsOnlineUpdateChanged)
+            {
+                map.RankedStatus = rankedStatus;
+                map.NeedsOnlineUpdate = needsOnlineUpdate;
 
-            map.RankedStatus = rankedStatus;
-            map.NeedsOnlineUpdate = needsOnlineUpdate;
+                if (rankedStatusChanged)
+                    MapDatabaseCache.UpdateMap(map);
 
-            if (rankedStatusChanged)
-                MapDatabaseCache.UpdateMap(map);
+                Logger.Debug($"Updated online map status for map {map.MapId}: ranked={rankedStatus}, needsUpdate={needsOnlineUpdate}", LogType.Runtime);
+                RankedStatusUpdated?.Invoke(null, EventArgs.Empty);
+            }
 
-            Logger.Debug($"Updated online map status for map {map.MapId}: ranked={rankedStatus}, needsUpdate={needsOnlineUpdate}", LogType.Runtime);
-            RankedStatusUpdated?.Invoke(null, EventArgs.Empty);
+            return needsOnlineUpdate;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
@@ -1,0 +1,37 @@
+using System;
+using Quaver.Shared.Database.Maps;
+using Quaver.Shared.Online;
+using Wobble.Logging;
+
+namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
+{
+    internal static class ScoreFetcherOnlineMapStatus
+    {
+        public static event EventHandler RankedStatusUpdated;
+
+        /// <summary>
+        ///     Refreshes the selected map's online ranked status from /v2/map/:id.
+        /// </summary>
+        /// <param name="map"></param>
+        public static void UpdateRankedStatus(Map map)
+        {
+            if (map == null || map.MapId <= 0 || OnlineManager.Client == null)
+                return;
+
+            var response = OnlineManager.Client.RetrieveMapInfo(map.MapId);
+
+            if (response?.Map == null)
+                return;
+
+            var rankedStatus = response.Map.RankedStatus;
+
+            if (map.RankedStatus == rankedStatus)
+                return;
+
+            map.RankedStatus = rankedStatus;
+            MapDatabaseCache.UpdateMap(map);
+            Logger.Debug($"Updated online ranked status for map {map.MapId} to {rankedStatus}", LogType.Runtime);
+            RankedStatusUpdated?.Invoke(null, EventArgs.Empty);
+        }
+    }
+}

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherOnlineMapStatus.cs
@@ -10,10 +10,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
         public static event EventHandler RankedStatusUpdated;
 
         /// <summary>
-        ///     Refreshes the selected map's online ranked status from /v2/map/:id.
+        ///     Refreshes the selected map's online status from /v2/map/:id.
         /// </summary>
         /// <param name="map"></param>
-        public static void UpdateRankedStatus(Map map)
+        public static void UpdateMapStatus(Map map)
         {
             if (map == null || map.MapId <= 0 || OnlineManager.Client == null)
                 return;
@@ -24,14 +24,38 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 return;
 
             var rankedStatus = response.Map.RankedStatus;
+            var needsOnlineUpdate = NeedsOnlineUpdate(map, response.Map.Md5);
 
-            if (map.RankedStatus == rankedStatus)
+            var rankedStatusChanged = map.RankedStatus != rankedStatus;
+            var needsOnlineUpdateChanged = map.NeedsOnlineUpdate != needsOnlineUpdate;
+
+            if (!rankedStatusChanged && !needsOnlineUpdateChanged)
                 return;
 
             map.RankedStatus = rankedStatus;
-            MapDatabaseCache.UpdateMap(map);
-            Logger.Debug($"Updated online ranked status for map {map.MapId} to {rankedStatus}", LogType.Runtime);
+            map.NeedsOnlineUpdate = needsOnlineUpdate;
+
+            if (rankedStatusChanged)
+                MapDatabaseCache.UpdateMap(map);
+
+            Logger.Debug($"Updated online map status for map {map.MapId}: ranked={rankedStatus}, needsUpdate={needsOnlineUpdate}", LogType.Runtime);
             RankedStatusUpdated?.Invoke(null, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="onlineMd5"></param>
+        /// <returns></returns>
+        private static bool NeedsOnlineUpdate(Map map, string onlineMd5)
+        {
+            if (string.IsNullOrEmpty(onlineMd5))
+                return false;
+
+            if (string.Equals(map.Md5Checksum, onlineMd5, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            return true;
         }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
@@ -27,8 +27,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                     mods = 0;
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Rate, mods);
-                map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
-                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
+                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
@@ -21,13 +21,15 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
                 if (!OnlineManager.Connected)
                     return new FetchedScoreStore(new List<Score>());
 
+                if (ScoreFetcherOnlineMapStatus.UpdateMapStatus(map))
+                    return new FetchedScoreStore(new List<Score>());
+
                 var mods = ModHelper.GetModsFromRate(ModHelper.GetRateFromMods(ModManager.Mods));
 
                 if (mods == ModIdentifier.None)
                     mods = 0;
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Rate, mods);
-                ScoreFetcherOnlineMapStatus.UpdateMapStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Leaderboard/Rankings/ScoreFetcherRate.cs
@@ -28,6 +28,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings
 
                 var onlineScores = OnlineManager.Client?.RetrieveScoreboard(map.MapId, map.Md5Checksum, OnlineScoreboard.Rate, mods);
                 map.NeedsOnlineUpdate = onlineScores?.Code == OnlineScoresResponseCode.NeedsUpdate;
+                ScoreFetcherOnlineMapStatus.UpdateRankedStatus(map);
 
                 var scores = new List<Score>();
 

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapset.cs
@@ -12,6 +12,7 @@ using Quaver.Shared.Graphics.Containers;
 using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings;
 using Wobble.Assets;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -73,6 +74,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 OnlineManager.Client.OnRetrievedOnlineScores += OnRetrievedOnlineScores;
 
             MapsetInfoRetriever.MapsetInfoRetrieved += OnMapsetInfoRetrieved;
+            ScoreFetcherOnlineMapStatus.RankedStatusUpdated += OnOnlineRankedStatusUpdated;
 
             ModManager.ModsChanged += OnModsChanged;
 
@@ -91,6 +93,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                 OnlineManager.Client.OnRetrievedOnlineScores -= OnRetrievedOnlineScores;
 
             MapsetInfoRetriever.MapsetInfoRetrieved -= OnMapsetInfoRetrieved;
+            ScoreFetcherOnlineMapStatus.RankedStatusUpdated -= OnOnlineRankedStatusUpdated;
 
             ModManager.ModsChanged -= OnModsChanged;
 
@@ -159,6 +162,8 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
         }
 
         private void OnMapsetInfoRetrieved(object sender, EventArgs args) => UpdateContent(Item, Index);
+
+        private void OnOnlineRankedStatusUpdated(object sender, EventArgs args) => UpdateContent(Item, Index);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylist.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Playlists/DrawablePlaylist.cs
@@ -1,6 +1,8 @@
+using System;
 using Quaver.Shared.Database.Playlists;
 using Quaver.Shared.Graphics.Containers;
 using Quaver.Shared.Modifiers;
+using Quaver.Shared.Screens.Selection.UI.Leaderboard.Rankings;
 using Quaver.Shared.Screens.Selection.UI.Mapsets;
 using Wobble.Bindables;
 using Wobble.Graphics;
@@ -47,6 +49,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
 
             PlaylistManager.Selected.ValueChanged += OnPlaylistChanged;
             PlaylistManager.PlaylistMapsManaged += OnPLaylistMapsManaged;
+            ScoreFetcherOnlineMapStatus.RankedStatusUpdated += OnOnlineRankedStatusUpdated;
             ModManager.ModsChanged += OnModsChanged;
         }
 
@@ -80,6 +83,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
             PlaylistManager.Selected.ValueChanged -= OnPlaylistChanged;
             ModManager.ModsChanged -= OnModsChanged;
             PlaylistManager.PlaylistMapsManaged -= OnPLaylistMapsManaged;
+            ScoreFetcherOnlineMapStatus.RankedStatusUpdated -= OnOnlineRankedStatusUpdated;
 
             base.Destroy();
         }
@@ -121,5 +125,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Playlists
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnModsChanged(object sender, ModsChangedEventArgs e) => UpdateContent(Item, Index);
+
+        private void OnOnlineRankedStatusUpdated(object sender, EventArgs e) => UpdateContent(Item, Index);
     }
 }


### PR DESCRIPTION
We now check for ranked statuses by looking at the map/:id route after fetching online scores for that map, because Scoreboard endpoint no longer exposes Code (aka ranked status)
