### PR TITLE
Improve exiting the editor

### DIFF
--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -590,6 +590,11 @@ namespace Quaver.Shared.Screens.Edit
             BackupScheduler = null;
             if (EditorPluginUtils.EditScreen == this)
                 EditorPluginUtils.EditScreen = null;
+
+            // The editor can release a very large, long-lived managed graph. Request collection after the screen
+            // transition has finished, without blocking the game thread or retaining this screen in the callback.
+            ThreadScheduler.RunAfter(static () =>
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, false, false), 1000);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorPlayfield.cs
@@ -14,7 +14,6 @@ using Quaver.Shared.Config;
 using Quaver.Shared.Graphics;
 using Quaver.Shared.Graphics.Graphs;
 using Quaver.Shared.Helpers;
-using Quaver.Shared.Scheduling;
 using Quaver.Shared.Screens.Edit.Actions;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Flip;
 using Quaver.Shared.Screens.Edit.Actions.HitObjects.Move;
@@ -548,20 +547,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Spectrogram?.Destroy();
             SpectrogramLoadTask?.Dispose();
 
-            ThreadScheduler.Run(() =>
-            {
-                if (HitObjects.Count < 1000)
-                    HitObjects.ForEach(x => x.Destroy());
-
-                Timeline?.Destroy();
-                LineContainer?.Destroy();
-
-                HitObjects.Clear();
-                HitObjectMap.Clear();
-                LineContainer = null;
-                Timeline = null;
-            });
-
             Track.Seeked -= OnTrackSeeked;
             Track.RateChanged -= OnTrackRateChanged;
 
@@ -604,9 +589,20 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             ConfigManager.EditorSpectrogramInterleaveCount.ValueChanged -= OnSpectrogramInterleaveCountChanged;
             ConfigManager.EditorPlayfieldAlpha.ValueChanged -= OnPlayfieldAlphaChanged;
 
+            Timeline?.Destroy();
+            Timeline = null;
+            LineContainer?.Destroy();
+            LineContainer = null;
+
+            // Hit objects only reference managed drawables and shared skin textures. Dropping the collection roots
+            // avoids walking and disposing every object while still allowing the GC to reclaim the complete graph.
+            HitObjects = null;
+            HitObjectMap = null;
+            HitObjectPool = null;
+            LongNoteInDrag = null;
+
             base.Destroy();
             ActionManager = null;
-            HitObjectPool.Clear();
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/EditorPlayfieldLineContainer.cs
@@ -56,6 +56,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         private List<DrawableEditorLine> Lines { get; set; }
 
         /// <summary>
+        ///     Bookmark lines own globally registered buttons and subscribed text drawables, unlike ordinary timing
+        ///     and scroll lines, so only these lines require explicit destruction.
+        /// </summary>
+        private List<DrawableEditorLineBookmark> BookmarkLines { get; } = new List<DrawableEditorLineBookmark>();
+
+        /// <summary>
         ///     The lines that are visible and ready to be drawn to the screen
         /// </summary>
         private List<DrawableEditorLine> LinePool { get; set; }
@@ -180,7 +186,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         /// </summary>
         public override void Destroy()
         {
-            foreach (var line in Lines)
+            foreach (var line in BookmarkLines)
                 line.Destroy();
 
             PreviewLine?.Destroy();
@@ -191,6 +197,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             ActionManager.ScrollVelocityBatchAdded -= OnScrollVelocityBatchAdded;
             ActionManager.ScrollVelocityBatchRemoved -= OnScrollVelocityBatchRemoved;
             ActionManager.ScrollVelocityOffsetBatchChanged -= OnScrollVelocityBatchOffsetChanged;
+            ActionManager.ScrollSpeedFactorAdded -= OnScrollSpeedFactorAdded;
+            ActionManager.ScrollSpeedFactorRemoved -= OnScrollSpeedFactorRemoved;
+            ActionManager.ScrollSpeedFactorBatchAdded -= OnScrollSpeedFactorBatchAdded;
+            ActionManager.ScrollSpeedFactorBatchRemoved -= OnScrollSpeedFactorBatchRemoved;
+            ActionManager.ScrollSpeedFactorOffsetBatchChanged -= OnScrollSpeedFactorBatchOffsetChanged;
             ActionManager.TimingPointAdded -= OnTimingPointAdded;
             ActionManager.TimingPointRemoved -= OnTimingPointRemoved;
             ActionManager.TimingPointBatchAdded -= OnTimingPointBatchAdded;
@@ -238,7 +249,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             }
 
             foreach (var bookmark in Map.Bookmarks)
-                Lines.Add(new DrawableEditorLineBookmark(Playfield, bookmark));
+            {
+                var line = new DrawableEditorLineBookmark(Playfield, bookmark);
+                BookmarkLines.Add(line);
+                Lines.Add(line);
+            }
             
             PreviewLine = new DrawableEditorLinePreview(Playfield, Map.SongPreviewTime);
 
@@ -541,21 +556,30 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
         
         private void OnBookmarkAdded(object sender, EditorActionBookmarkAddedEventArgs e)
         {
-            Lines.InsertSorted(new DrawableEditorLineBookmark(Playfield, e.Bookmark));
+            var line = new DrawableEditorLineBookmark(Playfield, e.Bookmark);
+            BookmarkLines.Add(line);
+            Lines.InsertSorted(line);
             InitializeLinePool();
         }
         
         private void OnBookmarkBatchAdded(object sender, EditorActionBookmarkBatchAddedEventArgs e)
         {
-            Lines.InsertSorted(e.Bookmarks.Select(bookmark => new DrawableEditorLineBookmark(Playfield, bookmark)));
+            var lines = e.Bookmarks.Select(bookmark => new DrawableEditorLineBookmark(Playfield, bookmark)).ToList();
+            BookmarkLines.AddRange(lines);
+            Lines.InsertSorted(lines);
             InitializeLinePool();
         }
         
         private void OnBookmarkRemoved(object sender, EditorActionBookmarkRemovedEventArgs e)
         {
             var line = Lines.Find(x => x is DrawableEditorLineBookmark line && line.Bookmark == e.Bookmark);
+
+            if (line == null)
+                return;
+
             line.Destroy();
             Lines.Remove(line);
+            BookmarkLines.Remove((DrawableEditorLineBookmark)line);
             InitializeLinePool();
         }
         
@@ -566,7 +590,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
                 var found = x is DrawableEditorLineBookmark line && e.Bookmarks.Contains(line.Bookmark);
 
                 if (found)
+                {
                     x.Destroy();
+                    BookmarkLines.Remove((DrawableEditorLineBookmark)x);
+                }
 
                 return found;
             });

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -134,8 +134,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
         /// </summary>
         public override void Destroy()
         {
-            foreach (var item in CachedLines)
-                item.Value.ForEach(x => x.Destroy());
+            Lines = null;
+            LinePool = null;
+            CachedLines.Clear();
 
             // ReSharper disable twice DelegateSubtraction
             BeatSnap.ValueChanged -= OnBeatSnapChanged;
@@ -144,6 +145,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
             Track.RateChanged -= OnTrackRateChanged;
             ScaleScrollSpeedWithAudioRate.ValueChanged -= OnScaleScrollSpeedWithRateChanged;
             ActionManager.TimingPointAdded -= OnTimingPointAdded;
+            ActionManager.TimingPointRemoved -= OnTimingPointRemoved;
             ActionManager.TimingPointBatchAdded -= OnTimingPointBatchAdded;
             ActionManager.TimingPointBatchRemoved -= OnTimingPointBatchRemoved;
             ActionManager.TimingPointOffsetChanged -= OnTimingPointOffsetChanged;
@@ -461,10 +463,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
        /// </summary>
        private void ReInitialize()
        {
-           foreach (var lines in CachedLines)
-               lines.Value.ForEach(x => x.Destroy());
-
-           Lines.Clear();
+           Lines = null;
+           LinePool = null;
            CachedLines.Clear();
 
            InitializeLines();

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimelineTick.cs
@@ -59,7 +59,9 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
 
             Y = -2;
 
-            Measure = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.InterBold), measureCount.ToString(), 24, false)
+            // Uncached labels measure themselves when drawn, so they do not need a per-label font change subscription.
+            Measure = new SpriteTextPlus(FontManager.GetWobbleFont(Fonts.InterBold), measureCount.ToString(), 24,
+                false, false)
             {
                 Parent = this,
                 Alignment = Alignment.MidLeft,

--- a/Quaver.Shared/Screens/QuaverScreenManager.cs
+++ b/Quaver.Shared/Screens/QuaverScreenManager.cs
@@ -108,7 +108,6 @@ namespace Quaver.Shared.Screens
                 OnlineManager.Client?.UpdateClientStatus(status);
 
             OtherGameMapDatabaseCache.RunThread();
-            GC.Collect();
 
             if (switchImmediately)
                 Transitioner.FadeOut();


### PR DESCRIPTION
This PR also removed the GC Collect from when the screen switches, due to the fact that it was running too quickly for it to catch that we have destroyed the previous screen.
I'm yet to properly test if this effects anything, but I don't think it should be.