### PR TITLE
Fix Long Notes selection being missplaced after transforming into a normal note

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -171,9 +171,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         public void UpdateLongNoteSizeAndAlpha()
         {
-            if (!Info.IsLongNote)
-                return;
-
             Body.Height = GetLongNoteHeight();
             Body.Y = -Body.Height + Height / 2f;
             Tail.Y = -Body.Height;


### PR DESCRIPTION
To reproduce (thanks to Larpzoid):
step 1: add long note (set it to any length)
step 2: drag ln tail to remove ln
step 3: select said note
step 4: contemplate what happens when life doesn't give you lemon