### PR TITLE
Small editor fixes

### DIFF
--- a/Quaver.Shared/Config/ConfigManager.cs
+++ b/Quaver.Shared/Config/ConfigManager.cs
@@ -450,6 +450,11 @@ namespace Quaver.Shared.Config
         internal static BindableInt EditorImGuiScalePercentage { get; private set; }
 
         /// <summary>
+        ///     Font size used by editor ImGui windows and texts.
+        /// </summary>
+        internal static BindableInt EditorImGuiFontSize { get; private set; }
+
+        /// <summary>
         ///     The scroll speed used in the editor.
         /// </summary>
         internal static BindableInt EditorScrollSpeedKeys { get; private set; }
@@ -1157,6 +1162,7 @@ namespace Quaver.Shared.Config
             DisplayFailedLocalScores = ReadValue(@"DisplayFailedLocalScores", true, data);
             EditorScrollSpeedKeys = ReadInt(@"EditorScrollSpeedKeys", 16, 5, 100, data);
             EditorImGuiScalePercentage = ReadInt(@"EditorImGuiScalePercentage", 100, 25, 300, data);
+            EditorImGuiFontSize = ReadInt(@"EditorImGuiFontSize", 16, 8, 32, data);
             EditorPlayfieldAlpha = ReadInt(@"EditorPlayfieldAlpha", 100, 0, 100, data);
             KeyEditorPausePlay = ReadValue(@"KeyEditorPausePlay", Keys.Space, data);
             KeyEditorDecreaseAudioRate = ReadValue(@"KeyEditorDecreaseAudioRate", Keys.OemMinus, data);

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -322,6 +322,8 @@ namespace Quaver.Shared.Screens.Edit
                 Alignment = Alignment.TopCenter
             };
 
+            Selector.ExcludedPlayfield = UnEditablePlayfield;
+
             // Reset the parent of the footer, so it draws over this playfield.
             Footer.Parent = Container;
         }
@@ -344,6 +346,9 @@ namespace Quaver.Shared.Screens.Edit
 
             // Makes it so that the playfield bookmark tooltips appear above reference difficulty
             Playfield.Parent = Container;
+
+            // Keep the selection rectangle above both playfields and their hit objects.
+            Selector.Parent = Container;
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/EditScreenView.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreenView.cs
@@ -322,8 +322,6 @@ namespace Quaver.Shared.Screens.Edit
                 Alignment = Alignment.TopCenter
             };
 
-            Selector.ExcludedPlayfield = UnEditablePlayfield;
-
             // Reset the parent of the footer, so it draws over this playfield.
             Footer.Parent = Container;
         }

--- a/Quaver.Shared/Screens/Edit/EditorImGuiOptions.cs
+++ b/Quaver.Shared/Screens/Edit/EditorImGuiOptions.cs
@@ -11,11 +11,11 @@ public static class EditorImGuiOptions
     /// <summary>
     /// </summary>
     /// <returns></returns>
-    public static ImGuiOptions GetOptions(int size)
+    public static ImGuiOptions GetOptions()
     {
         var notoSansCjkPath = $@"{WobbleGame.WorkingDirectory}/Fonts/noto-sans-cjk.ttc";
         return new ImGuiOptions([
-            new ImGuiFont($@"{WobbleGame.WorkingDirectory}/Fonts/inter.ttf", size,
+            new ImGuiFont($@"{WobbleGame.WorkingDirectory}/Fonts/inter.ttf", ConfigManager.EditorImGuiFontSize.Value,
             [
                 new ImGuiFontFallback(notoSansCjkPath,
                     QuaverLocalization.GetNotoCjkFaceIndex(ConfigManager.Language.Value),

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorKeybindPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorKeybindPanel.cs
@@ -385,6 +385,7 @@ public class EditorKeybindPanel : SpriteImGui, IEditorPlugin
     /// <returns></returns>
     public static ImGuiOptions GetOptions() => new ImGuiOptions(new List<ImGuiFont>
     {
-        new ImGuiFont($@"{WobbleGame.WorkingDirectory}/Fonts/lato-black.ttf", 16),
+        new ImGuiFont($@"{WobbleGame.WorkingDirectory}/Fonts/lato-black.ttf",
+            ConfigManager.EditorImGuiFontSize.Value),
     }, false);
 }

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollSpeedFactorPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollSpeedFactorPanel.cs
@@ -108,7 +108,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorScrollSpeedFactorPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(16), screen.ImGuiScale)
+        public EditorScrollSpeedFactorPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorScrollVelocityPanel.cs
@@ -110,7 +110,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorScrollVelocityPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(16), screen.ImGuiScale)
+        public EditorScrollVelocityPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingGroupPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingGroupPanel.cs
@@ -84,7 +84,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorTimingGroupPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(16), screen.ImGuiScale)
+        public EditorTimingGroupPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Timing/EditorTimingPointPanel.cs
@@ -83,7 +83,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins.Timing
         /// <summary>
         /// </summary>
         /// <param name="screen"></param>
-        public EditorTimingPointPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(16), screen.ImGuiScale)
+        public EditorTimingPointPanel(EditScreen screen) : base(false, EditorImGuiOptions.GetOptions(), screen.ImGuiScale)
         {
             Screen = screen;
             Initialize();

--- a/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Menu/EditorFileMenuBar.cs
@@ -66,7 +66,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Menu
         private static bool DestroyContext { get; } = true;
 #endif
 
-        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, EditorImGuiOptions.GetOptions(18), screen.ImGuiScale) => Screen = screen;
+        public EditorFileMenuBar(EditScreen screen) : base(DestroyContext, EditorImGuiOptions.GetOptions(), screen.ImGuiScale) => Screen = screen;
 
 
         /// <inheritdoc />

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
@@ -31,6 +31,11 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
         private EditorPlayfield Playfield { get; }
 
         /// <summary>
+        ///     A read-only playfield that must not start selections for the working map.
+        /// </summary>
+        public EditorPlayfield ExcludedPlayfield { private get; set; }
+
+        /// <summary>
         /// </summary>
         private EditorFooter Footer { get; }
 
@@ -123,6 +128,10 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
             if (!Button.IsGloballyClickable)
                 return;
 
+            if (ExcludedPlayfield is { IsDisposed: false } &&
+                GraphicsHelper.RectangleContains(ExcludedPlayfield.ScreenRectangle, MouseManager.CurrentState.Position))
+                return;
+
             if (Playfield.GetHoveredHitObject() != null)
                 return;
 
@@ -199,24 +208,34 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
             if (IsSelecting && StartingPoint -  new Vector2(MouseManager.CurrentState.X, MouseManager.CurrentState.Y) != Vector2.Zero)
             {
                 var timeDragEnd = Playfield.GetTimeFromY(MouseManager.CurrentState.Y) / Playfield.TrackSpeed;
+                var selectionLeft = Math.Min(StartingPoint.X, MouseManager.CurrentState.X);
+                var selectionRight = Math.Max(StartingPoint.X, MouseManager.CurrentState.X);
+                var playfieldLeft = Playfield.ScreenRectangle.X;
+                var playfieldRight = playfieldLeft + Playfield.ScreenRectangle.Width;
 
-                var startLane = Playfield.GetLaneFromX(StartingPoint.X);
-                var endLane = Playfield.GetLaneFromX(MouseManager.CurrentState.X);
-
-                var foundObjects = WorkingMap.HitObjects.FindAll(x =>
+                // GetLaneFromX clamps out-of-bounds coordinates to the first/last lane. Only perform lane
+                // selection when the rectangle actually overlaps the editable playfield, otherwise a selection
+                // beside a reference difficulty would incorrectly select the outermost editor lane.
+                if (selectionRight > playfieldLeft && selectionLeft < playfieldRight)
                 {
-                    var yInbetween = TimeDragStart > timeDragEnd ?
-                        IsBetween(x.StartTime, timeDragEnd, TimeDragStart)
-                        : IsBetween(x.StartTime, TimeDragStart, timeDragEnd);
+                    var startLane = Playfield.GetLaneFromX(Math.Max(selectionLeft, playfieldLeft));
+                    var endLane = Playfield.GetLaneFromX(Math.Min(selectionRight, playfieldRight));
 
-                    return yInbetween && (startLane < endLane ? IsBetween(x.Lane, startLane, endLane) :
-                               IsBetween(x.Lane, endLane, startLane));
-                });
+                    var foundObjects = WorkingMap.HitObjects.FindAll(x =>
+                    {
+                        var yInbetween = TimeDragStart > timeDragEnd ?
+                            IsBetween(x.StartTime, timeDragEnd, TimeDragStart)
+                            : IsBetween(x.StartTime, TimeDragStart, timeDragEnd);
 
-                foreach (var ho in foundObjects)
-                {
-                    if (!SelectedHitObjects.Value.Contains(ho))
-                        SelectedHitObjects.Add(ho);
+                        return yInbetween && (startLane < endLane ? IsBetween(x.Lane, startLane, endLane) :
+                                   IsBetween(x.Lane, endLane, startLane));
+                    });
+
+                    foreach (var ho in foundObjects)
+                    {
+                        if (!SelectedHitObjects.Value.Contains(ho))
+                            SelectedHitObjects.Add(ho);
+                    }
                 }
             }
 

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Selection/EditorRectangleSelector.cs
@@ -31,11 +31,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
         private EditorPlayfield Playfield { get; }
 
         /// <summary>
-        ///     A read-only playfield that must not start selections for the working map.
-        /// </summary>
-        public EditorPlayfield ExcludedPlayfield { private get; set; }
-
-        /// <summary>
         /// </summary>
         private EditorFooter Footer { get; }
 
@@ -128,10 +123,6 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
             if (!Button.IsGloballyClickable)
                 return;
 
-            if (ExcludedPlayfield is { IsDisposed: false } &&
-                GraphicsHelper.RectangleContains(ExcludedPlayfield.ScreenRectangle, MouseManager.CurrentState.Position))
-                return;
-
             if (Playfield.GetHoveredHitObject() != null)
                 return;
 
@@ -214,8 +205,8 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Selection
                 var playfieldRight = playfieldLeft + Playfield.ScreenRectangle.Width;
 
                 // GetLaneFromX clamps out-of-bounds coordinates to the first/last lane. Only perform lane
-                // selection when the rectangle actually overlaps the editable playfield, otherwise a selection
-                // beside a reference difficulty would incorrectly select the outermost editor lane.
+                // selection when the rectangle actually overlaps the editable playfield, otherwise an
+                // out-of-bounds selection would incorrectly select the outermost lane.
                 if (selectionRight > playfieldLeft && selectionLeft < playfieldRight)
                 {
                     var startLane = Playfield.GetLaneFromX(Math.Max(selectionLeft, playfieldLeft));

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Timeline/EditorPlayfieldTimeline.cs
@@ -324,30 +324,35 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Timeline
                     VisibleMeasureLines.Add(line);
             }
 
-            // Dense sections are the merged time spans between adjacent measure numbers whose rendered bounds
-            // overlap. Outside these spans, timeline line rendering remains unchanged.
+            // Dense sections are runs of at least three measure numbers whose rendered bounds overlap. A single
+            // close pair can occur around a short timing-point section and should not hide either timing line.
+            var denseRunStartIndex = -1;
+
             for (var i = 1; i < VisibleMeasureLines.Count; i++)
             {
                 var previous = VisibleMeasureLines[i - 1];
                 var current = VisibleMeasureLines[i];
 
-                if (!current.MeasureOverlaps(previous))
-                    continue;
-
-                var startTime = Math.Min(previous.StartTime, current.StartTime);
-                var endTime = Math.Max(previous.StartTime, current.StartTime);
-
-                if (DenseMeasureRanges.Count == 0 ||
-                    startTime > DenseMeasureRanges[DenseMeasureRanges.Count - 1].EndTime)
+                if (current.MeasureOverlaps(previous))
                 {
-                    DenseMeasureRanges.Add((startTime, endTime));
+                    if (denseRunStartIndex == -1)
+                        denseRunStartIndex = i - 1;
+
                     continue;
                 }
 
-                var lastRange = DenseMeasureRanges[DenseMeasureRanges.Count - 1];
-                DenseMeasureRanges[DenseMeasureRanges.Count - 1] =
-                    (lastRange.StartTime, Math.Max(lastRange.EndTime, endTime));
+                if (denseRunStartIndex != -1 && i - denseRunStartIndex >= 3)
+                {
+                    DenseMeasureRanges.Add((VisibleMeasureLines[denseRunStartIndex].StartTime,
+                        previous.StartTime));
+                }
+
+                denseRunStartIndex = -1;
             }
+
+            if (denseRunStartIndex != -1 && VisibleMeasureLines.Count - denseRunStartIndex >= 3)
+                DenseMeasureRanges.Add((VisibleMeasureLines[denseRunStartIndex].StartTime,
+                    VisibleMeasureLines[VisibleMeasureLines.Count - 1].StartTime));
 
             // Keep as many evenly spaced measure numbers as will fit instead of reducing a dense run to only its
             // endpoints. This preserves useful numerical gaps throughout the visible timeline.

--- a/Quaver.Shared/Screens/Options/OptionsMenu.cs
+++ b/Quaver.Shared/Screens/Options/OptionsMenu.cs
@@ -457,6 +457,8 @@ namespace Quaver.Shared.Screens.Options
             }
 
             options.Add(new OptionsSlider(containerRect, "Editor ImGui Scale", ConfigManager.EditorImGuiScalePercentage));
+            options.Add(new OptionsSlider(containerRect, "Editor ImGui Font Size", ConfigManager.EditorImGuiFontSize,
+                value => $"{value}px"));
 
             return options;
         }

--- a/Quaver.Shared/Scripting/LuaImGui.cs
+++ b/Quaver.Shared/Scripting/LuaImGui.cs
@@ -227,7 +227,7 @@ namespace Quaver.Shared.Scripting
         /// <param name="isResource"></param>
         /// <param name="name"></param>
         public LuaImGui(string filePath, bool isResource = false, string name = null)
-            : base(false, EditorImGuiOptions.GetOptions(18), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
+            : base(false, EditorImGuiOptions.GetOptions(), ConfigManager.EditorImGuiScalePercentage.Value / 100f)
         {
             FilePath = filePath;
             IsResource = isResource;

--- a/Quaver.Shared/Scripting/LuaPluginState.cs
+++ b/Quaver.Shared/Scripting/LuaPluginState.cs
@@ -49,6 +49,11 @@ namespace Quaver.Shared.Scripting
         public int FontSize => ConfigManager.EditorImGuiFontSize.Value;
 
         /// <summary>
+        ///     Gets the current Quaver client version.
+        /// </summary>
+        public string GameVersion => ((QuaverGame)GameBase.Game).Version;
+
+        /// <summary>
         ///     Any state that the user wants to store for their plugin
         /// </summary>
         public Dictionary<string, DynValue> Values { get; [MoonSharpHidden] init; } = new(StringComparer.Ordinal);

--- a/Quaver.Shared/Scripting/LuaPluginState.cs
+++ b/Quaver.Shared/Scripting/LuaPluginState.cs
@@ -44,6 +44,11 @@ namespace Quaver.Shared.Scripting
         public float Scale => EditorPluginUtils.EditScreen.ImGuiScale;
 
         /// <summary>
+        ///     Gets the font size used by ImGui.
+        /// </summary>
+        public int FontSize => ConfigManager.EditorImGuiFontSize.Value;
+
+        /// <summary>
         ///     Any state that the user wants to store for their plugin
         /// </summary>
         public Dictionary<string, DynValue> Values { get; [MoonSharpHidden] init; } = new(StringComparer.Ordinal);


### PR DESCRIPTION
1. Fixes select tool when referencing another map
2. Fixes select tool selecting the 4th column when select going to the empty space on right
3. Fixed dense bpm not drawing timing lines when they are not dense
4. Adds new font size slider in Options + exposes it for plugins to use
5. Exposes `GameVersion` to plugins as well