### PR TITLE
Restore quick bookmark edits by clicking on the bookmark in the editor

### DIFF
--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmark.cs
@@ -45,7 +45,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines
             Tooltip.Border.DrawIfOffScreen = true;
             Tooltip.Visible = !string.IsNullOrEmpty(Bookmark.Note);
 
-            ImageButton = new DrawableEditorLineBookmarkButton(Playfield, Bookmark)
+            ImageButton = new DrawableEditorLineBookmarkButton(Playfield, Bookmark, Tooltip.Text)
             {
                 Parent = this,
                 Size = new ScalableVector2(0, 0, 1, 1),

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmarkButton.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/Lines/DrawableEditorLineBookmarkButton.cs
@@ -3,8 +3,10 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Quaver.API.Maps.Structures;
 using Quaver.Shared.Assets;
+using Quaver.Shared.Screens.Edit.Dialogs;
 using Wobble.Graphics;
 using Wobble.Graphics.UI.Buttons;
+using Wobble.Graphics.UI.Dialogs;
 
 namespace Quaver.Shared.Screens.Edit.UI.Playfield.Lines;
 
@@ -14,16 +16,32 @@ public class DrawableEditorLineBookmarkButton : ImageButton
 
     public BookmarkInfo Bookmark { get; }
 
-    public DrawableEditorLineBookmarkButton(EditorPlayfield playfield, BookmarkInfo bookmark) : base(UserInterface
-        .BlankBox)
+    private Drawable BookmarkText { get; }
+
+    public DrawableEditorLineBookmarkButton(EditorPlayfield playfield, BookmarkInfo bookmark, Drawable bookmarkText)
+        : base(UserInterface.BlankBox)
     {
         Playfield = playfield;
         Bookmark = bookmark;
+        BookmarkText = bookmarkText;
         Alpha = 0;
+        Clicked += OnClicked;
         RightClicked += OnRightClicked;
     }
 
-    protected override bool IsMouseInClickArea() => ScreenRectangle.Contains(Playfield.GetRelativeMousePosition());
+    protected override bool IsMouseInClickArea()
+    {
+        var mousePosition = Playfield.GetRelativeMousePosition();
+        return ScreenRectangle.Contains(mousePosition) ||
+               BookmarkText.Visible && BookmarkText.ScreenRectangle.Contains(mousePosition);
+    }
 
-    private void OnRightClicked(object sender, EventArgs e) => Playfield.ActionManager.RemoveBookmark(Bookmark);
+    private void OnClicked(object sender, EventArgs e) =>
+        DialogManager.Show(new EditorBookmarkDialog(Playfield.ActionManager, Playfield.Track, Bookmark));
+
+    private void OnRightClicked(object sender, EventArgs e)
+    {
+        if (ScreenRectangle.Contains(Playfield.GetRelativeMousePosition()))
+            Playfield.ActionManager.RemoveBookmark(Bookmark);
+    }
 }


### PR DESCRIPTION
Fix #4866 (also, added quick color edit to the modal)