### PR TITLE
Add support for hex color in bookmark color picker

### DIFF
--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorColorPicker.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorColorPicker.cs
@@ -24,6 +24,7 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
         private NumericsVector3 color;
         private Color? pendingColor;
         private bool positionWindow = true;
+        private bool outsideClickReady;
 
         public bool IsOpen { get; private set; } = true;
 
@@ -71,8 +72,11 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
                 new NumericsVector2(300, 0),
                 new NumericsVector2(float.MaxValue, float.MaxValue));
 
-            if (ImGui.Begin(title + "###EditorColorPicker", ref open,
-                    ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings))
+            var contentsVisible = ImGui.Begin(title + "###EditorColorPicker", ref open,
+                ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoSavedSettings);
+            var windowHovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.AnyWindow);
+
+            if (contentsVisible)
             {
                 if (ImGui.ColorPicker3("##EditorColor", ref color, PickerFlags))
                     pendingColor = ToColor(color);
@@ -87,6 +91,18 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
             ImGui.End();
 
             if (!open)
+            {
+                closeRequested?.Invoke();
+                return;
+            }
+
+            if (!outsideClickReady)
+            {
+                outsideClickReady = !ImGui.IsMouseDown(ImGuiMouseButton.Left);
+                return;
+            }
+
+            if (ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !windowHovered)
                 closeRequested?.Invoke();
         }
 

--- a/Quaver.Shared/Screens/Edit/Dialogs/EditorColorPicker.cs
+++ b/Quaver.Shared/Screens/Edit/Dialogs/EditorColorPicker.cs
@@ -13,6 +13,7 @@ namespace Quaver.Shared.Screens.Edit.Dialogs
     {
         private const ImGuiColorEditFlags PickerFlags =
             ImGuiColorEditFlags.DisplayRGB |
+            ImGuiColorEditFlags.DisplayHex |
             ImGuiColorEditFlags.InputRGB |
             ImGuiColorEditFlags.Uint8;
 

--- a/Quaver.Shared/Screens/Edit/Plugins/Bookmarks/EditorBookmarkPanel.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/Bookmarks/EditorBookmarkPanel.cs
@@ -317,7 +317,7 @@ public class EditorBookmarkPanel : SpriteImGui, IEditorPlugin, IColoredImGuiTitl
                 ImGui.PopStyleColor();
 
             ImGui.TableNextColumn();
-            ImGui.TextWrapped(bookmark.Note ?? "");
+            ImGui.TextWrapped((bookmark.Note ?? "").Replace("%", "%%"));
 
             ImGui.TableNextColumn();
             var bookmarkColor = ColorHelper.ToXnaColor(bookmark.GetColor());


### PR DESCRIPTION
Require Wobble's [#226](https://github.com/Quaver/Wobble/pull/226) to fix an issue where inputs are not being registered at all in imgui input boxes