### PR TITLE
fix freezing while joining a multiplayer lobby

### DIFF
--- a/Quaver.Shared/Assets/Flags.cs
+++ b/Quaver.Shared/Assets/Flags.cs
@@ -109,6 +109,7 @@ namespace Quaver.Shared.Assets
                 {
                     var sourceRectangle = CreateSourceRectangle(mapping.Value);
                     ValidateSourceRectangle(mapping.Key, sheet, sourceRectangle);
+                    Textures[mapping.Key] = Crop(sheet, sourceRectangle);
                 }
 
                 Sheet = sheet;


### PR DESCRIPTION
Joining a lobby drew flags on a background thread, but flags can only be cut from the flag sheet on the main thread. Flags already seen elsewhere were cached and fine, but new ones weren't cached yet, so cutting them crashed and froze the join. Fix: cache all flags at game startup instead of on first use