### PR TITLE
fix-4896: Mods change triggers Now Playing update

### DIFF
--- a/Quaver.Shared/Database/Maps/Map.cs
+++ b/Quaver.Shared/Database/Maps/Map.cs
@@ -425,14 +425,6 @@ namespace Quaver.Shared.Database.Maps
         public void ChangeSelected()
         {
             MapManager.Selected.Value = this;
-
-            Task.Run(async () =>
-            {
-                using (var writer = File.CreateText(ConfigManager.TempDirectory + "/Now Playing/map.txt"))
-                {
-                    await writer.WriteAsync($"{Artist} - {Title} [{DifficultyName}]");
-                }
-            });
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
+++ b/Quaver.Shared/Screens/Loading/MapLoadingScreen.cs
@@ -107,7 +107,7 @@ namespace Quaver.Shared.Screens.Loading
                 try
                 {
                     ParseAndLoadMap();
-                    QueueStreamerFilesWrite(MapManager.Selected.Value);
+                    QueueStreamerFilesWrite();
                     LoadGameplayScreen();
                 }
                 catch (Exception e)
@@ -182,14 +182,14 @@ namespace Quaver.Shared.Screens.Loading
         /// </summary>
         /// <param name="map"></param>
         /// <param name="delay"></param>
-        public static void QueueStreamerFilesWrite(Map map, int delay = 0)
-            => StreamerFilesWriteTask.Run(new StreamerFilesWriteRequest(map, ModManager.Mods), delay);
+        public static void QueueStreamerFilesWrite(int delay = 0)
+            => StreamerFilesWriteTask.Run(new StreamerFilesWriteRequest(MapManager.Selected.Value, ModManager.Mods), delay);
 
         /// <summary>
         ///    Queues files for livestreamers to be written.
         /// </summary>
         /// <param name="map"></param>
-        public static void WriteStreamerFiles(Map map) => QueueStreamerFilesWrite(map);
+        public static void WriteStreamerFiles(Map map) => QueueStreamerFilesWrite();
 
         /// <summary>
         ///    Writes files for livestreamers.

--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -166,7 +166,7 @@ namespace Quaver.Shared.Screens.Selection
             MapManager.Selected.ValueChanged += OnSelectedMapChangedForStreamerFiles;
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
 
-            MapLoadingScreen.QueueStreamerFilesWrite(MapManager.Selected.Value);
+            MapLoadingScreen.QueueStreamerFilesWrite();
 
             View = new SelectionScreenView(this);
             GlobalInputToken = new Token(this);
@@ -995,7 +995,7 @@ namespace Quaver.Shared.Screens.Selection
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void OnSelectedMapChangedForStreamerFiles(object sender, BindableValueChangedEventArgs<Map> e)
-            => MapLoadingScreen.QueueStreamerFilesWrite(e.Value, 250);
+            => MapLoadingScreen.QueueStreamerFilesWrite(250);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Components/SelectableModifier.cs
@@ -8,6 +8,7 @@ using Quaver.Shared.Helpers;
 using Quaver.Shared.Modifiers;
 using Quaver.Shared.Modifiers.Mods;
 using Quaver.Shared.Online;
+using Quaver.Shared.Screens.Loading;
 using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.Sprites;
@@ -154,7 +155,10 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Components
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnModsChanged(object sender, ModsChangedEventArgs e) => Icon.Image = GetTexture();
+        private void OnModsChanged(object sender, ModsChangedEventArgs e) {
+            Icon.Image = GetTexture();
+            MapLoadingScreen.QueueStreamerFilesWrite(250);
+        }
 
         private Texture2D GetTexture()
         {


### PR DESCRIPTION
# Fix #4896 
Mods change now triggers "Now Playing" update.

The function "QueueStreamerFilesWrite" now only update with currently selected map. I doesn't see a case where we would want to update "Now Playing" with anything other than what is currently playing.

I also removed a weird and redundant update of "Now Playing" inside "Map.cs". It didn't used the file lock that other update used and it was redundant with update inside "SelectionScreen.cs".