### PR TITLE
fix Consistent crash when spectating

### DIFF
--- a/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
+++ b/Quaver.Shared/Graphics/Overlays/Hub/OnlineHub.cs
@@ -18,6 +18,7 @@ using Wobble;
 using Wobble.Graphics;
 using Wobble.Graphics.Animations;
 using Wobble.Graphics.Sprites;
+using Wobble.Graphics.UI.Buttons;
 using Wobble.Graphics.Sprites.Text;
 using Wobble.Managers;
 using Wobble.Window;
@@ -193,6 +194,18 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
 
         /// <summary>
         /// </summary>
+        /// <param name="drawable"></param>
+        private static void ResetInteractionState(Drawable drawable)
+        {
+            if (drawable is Button button)
+                button.ResetInteractionState();
+
+            foreach (var child in drawable.Children)
+                ResetInteractionState(child);
+        }
+
+        /// <summary>
+        /// </summary>
         /// <param name="type"></param>
         public void SelectSection(OnlineHubSectionType type) => SelectSection(Sections[type]);
 
@@ -211,7 +224,10 @@ namespace Quaver.Shared.Graphics.Overlays.Hub
             section.Container.Parent = this;
 
             if (oldSection != null)
+            {
+                ResetInteractionState(oldSection.Container);
                 oldSection.Container.Parent = null;
+            }
 
             ScheduleUpdate(() => HeaderText.Text = section.Name);
         }

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -787,7 +787,7 @@ namespace Quaver.Shared.Screens.Gameplay
 
             TimePauseKeyHeld = 0;
 
-            if (IsPaused)
+            if (IsPaused && SpectatorClient == null)
             {
                 Pause();
                 return;
@@ -890,7 +890,7 @@ namespace Quaver.Shared.Screens.Gameplay
             // If the pause key is not pressed...
             if (!IsPauseKeyHeld)
             {
-                if (Failed || IsPlayComplete || IsPaused)
+                if (Failed || IsPlayComplete || (IsPaused && SpectatorClient == null))
                     return;
 
                 // Remove the pause fade.


### PR DESCRIPTION
this fixes 3 issues and closes #4895

Spectator pause crash: IsPaused was overloaded to also mean "the host you're spectating is paused." Pressing Esc while spectating a paused host crashed the game trying to exit. Fixed by only treating IsPaused as a real pause when not spectating.

Stuck fade animation: Same root cause as the crash fix above. after fixing the crash i saw that tapping Esc and releasing early (instead of holding) left the pause fade stuck black instead of fading back out. i found out that the same IsPaused overload was also skipping that animation. Fixed the same way.

Online Hub freeze: Switching Hub sections detaches the old section instead of destroying it (so it can be reused later), which also stops it from updating. If a button was mid hover at that exact moment it stayed stuck forever and silently blocked all mouse input in the game. Fixed by clearing its hover state before detaching.

