### PR TITLE
replay notes correctly visible after instant button click

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -244,6 +244,11 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             var tint = Tint * (HitObjectManager.ShowHits ? HitObjectManagerKeys.SHOW_HITS_NOTE_ALPHA : 1);
             tint.A = 255;
 
+            // Cancel any leftover tint fade so it doesn't keep animating the Tint we're about to set below.
+            HitObjectSprite.ClearAnimations();
+            LongNoteBodySprite.ClearAnimations();
+            LongNoteEndSprite.ClearAnimations();
+
             // Update hitobject sprites
             HitObjectSprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode);
             HitObjectSprite.Visible = true;
@@ -567,9 +572,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             Tint = SkinManager.Skin.Keys[Ruleset.Mode].DeadNoteColor;
             var tint = Tint * (HitObjectManager.ShowHits ? HitObjectManagerKeys.SHOW_HITS_NOTE_ALPHA : 1);
             tint.A = 255;
+            HitObjectSprite.ClearAnimations();
             HitObjectSprite.Tint = tint;
             if (Info.IsLongNote)
             {
+                LongNoteBodySprite.ClearAnimations();
+                LongNoteEndSprite.ClearAnimations();
                 LongNoteBodySprite.Tint = tint;
                 LongNoteEndSprite.Tint = tint;
             }


### PR DESCRIPTION
closes #4847

Toggling "Show Hits" starts a fade animation on note sprites, including ones sitting unused in the reuse pool. If a pooled sprite gets reused for a new note before that fade finishes the fade keeps running and overwrites the new note's color with the old note's color making it look like the note disappeared.

If wanted we can also make the "Show Hits" toggle skip sprites sitting unused in the pool since they get the correct color anyway as soon as they're reused. That would cut down on wasted work, but it wouldn't fully replace this fix since a visible note can still die mid fade and get pooled while its animation is still running.