### PR TITLE
Use texture regions as much as possible in skin

### DIFF
--- a/Quaver.Shared/Graphics/NumberDisplay.cs
+++ b/Quaver.Shared/Graphics/NumberDisplay.cs
@@ -225,7 +225,7 @@ namespace Quaver.Shared.Graphics
                     });
 
                     // Set size
-                    Digits[i].Size = new ScalableVector2(Digits[i].Image.Width * ImageScale.X, Digits[i].Image.Height * ImageScale.Y);
+                    Digits[i].Size = new ScalableVector2(Digits[i].ImageWidth * ImageScale.X, Digits[i].ImageHeight * ImageScale.Y);
                     recomputeWidth = true;
                     recomputeHeight = true;
                 }
@@ -235,7 +235,7 @@ namespace Quaver.Shared.Graphics
                     var previousSize = Digits[i].Size;
 
                     Digits[i].Image = CharacterToTexture(Value[i]);
-                    Digits[i].Size = new ScalableVector2(Digits[i].Image.Width * ImageScale.X, Digits[i].Image.Height * ImageScale.Y);
+                    Digits[i].Size = new ScalableVector2(Digits[i].ImageWidth * ImageScale.X, Digits[i].ImageHeight * ImageScale.Y);
 
                     if (Digits[i].Size.X.Value != previousSize.X.Value)
                         recomputeWidth = true;

--- a/Quaver.Shared/Graphics/Overlays/Chatting/Messages/ChannelTopicHeader.cs
+++ b/Quaver.Shared/Graphics/Overlays/Chatting/Messages/ChannelTopicHeader.cs
@@ -105,7 +105,7 @@ namespace Quaver.Shared.Graphics.Overlays.Chatting.Messages
             };
 
             const float scale = 0.75f;
-            CloseButton.Size = new ScalableVector2(CloseButton.Image.Width * scale, CloseButton.Image.Height * scale);
+            CloseButton.Size = new ScalableVector2(CloseButton.ImageWidth * scale, CloseButton.ImageHeight * scale);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModHeader.cs
+++ b/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModHeader.cs
@@ -28,7 +28,7 @@ namespace Quaver.Shared.Screens.Edit.UI.AutoMods
             Panel = panel;
 
             Image = UserInterface.AutoModPanelHeader;
-            Size = new ScalableVector2(Panel.Width, Image.Height);
+            Size = new ScalableVector2(Panel.Width, ImageHeight);
 
             CreateGearIcon();
             CreateText();

--- a/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModIssue.cs
+++ b/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModIssue.cs
@@ -69,7 +69,7 @@ namespace Quaver.Shared.Screens.Edit.UI.AutoMods
 
             Icon.Image = GetIconImage();
             Icon.Tint = Item.Level == AutoModIssueLevel.Ranking ? Colors.MainBlue : Color.White;
-            Icon.Size = new ScalableVector2(Icon.Image.Width, Icon.Image.Height);
+            Icon.Size = new ScalableVector2(Icon.ImageWidth, Icon.ImageHeight);
         }
 
         private void CreateButton()

--- a/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanel.cs
+++ b/Quaver.Shared/Screens/Edit/UI/AutoMods/EditorAutoModPanel.cs
@@ -54,7 +54,7 @@ namespace Quaver.Shared.Screens.Edit.UI.AutoMods
             AutoMod = new Bindable<AutoModMapset>(new AutoModMapset(Mapset));
             AutoMod.Value.Run();
 
-            Size = new ScalableVector2(Image.Width, Image.Height);
+            Size = new ScalableVector2(ImageWidth, ImageHeight);
 
             CreateHeader();
             CreateDetails();

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObject.cs
@@ -98,7 +98,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             SelectedHitObjects = selectedHitObjects;
             DefaultLayer = defaultLayer;
 
-            Image = GetHitObjectTexture();
+            Region = GetHitObjectTexture();
             SetPosition();
             Tint = GetNoteTint();
         }
@@ -118,7 +118,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         public virtual void SetSize()
         {
             Width = Playfield.ColumnSize - Playfield.BorderLeft.Width * 2;
-            Height = (Playfield.ColumnSize - Playfield.BorderLeft.Width * 2) * Image.Height / Image.Width;
+            Height = (Playfield.ColumnSize - Playfield.BorderLeft.Width * 2) * ImageHeight / ImageWidth;
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <summary>
         ///    Returns the texture for the hitobject
         /// </summary>
-        public Texture2D GetHitObjectTexture()
+        public TextureRegion GetHitObjectTexture()
         {
             var index = SkinMode.ColorObjectsBySnapDistance && Map.TimingPoints.Count > 0 ? HitObjectManager.GetBeatSnap(Info, Info.GetTimingPoint(Map.TimingPoints)) : 0;
             var lane = Info.Lane - 1;

--- a/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Edit/UI/Playfield/EditorHitObjectKeys.cs
@@ -33,12 +33,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <summary>
         ///     The texture for the long note's body
         /// </summary>
-        public Texture2D TextureBody { get; private set; }
+        public TextureRegion TextureBody { get; private set; }
 
         /// <summary>
         ///     The texture for the long note's end.
         /// </summary>
-        public Texture2D TextureTail { get; private set; }
+        public TextureRegion TextureTail { get; private set; }
 
         /// <summary>
         ///     Displays when the object is selected
@@ -134,7 +134,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Body = new Sprite
             {
                 Parent = this,
-                Image = TextureBody,
+                Region = TextureBody,
                 Size = new ScalableVector2(Width, GetLongNoteHeight()),
             };
 
@@ -143,7 +143,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
             Tail = new Sprite
             {
                 Parent = this,
-                Image = TextureTail,
+                Region = TextureTail,
                 Size = new ScalableVector2(Width, GetTailHeight()),
                 Y = -Body.Height,
             };
@@ -218,7 +218,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <summary>
         /// </summary>
         /// <returns></returns>
-        private Texture2D GetBodyTexture()
+        private TextureRegion GetBodyTexture()
         {
             var lane = Info.Lane - 1;
             return Info.Type switch
@@ -236,7 +236,7 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// <summary>
         /// </summary>
         /// <returns></returns>
-        private Texture2D GetTailTexture()
+        private TextureRegion GetTailTexture()
         {
             var lane = Info.Lane - 1;
             return Info.Type switch
@@ -290,12 +290,12 @@ namespace Quaver.Shared.Screens.Edit.UI.Playfield
         /// </summary>
         public void UpdateTextures()
         {
-            Image = GetHitObjectTexture();
+            Region = GetHitObjectTexture();
             TextureBody = GetBodyTexture();
             TextureTail = GetTailTexture();
 
-            Body.Image = TextureBody;
-            Tail.Image = TextureTail;
+            Body.Region = TextureBody;
+            Tail.Region = TextureTail;
 
             if (SkinMode.RotateHitObjectsByColumn && (Coloring.Value == HitObjectColoring.None || SkinMode.RotateEditorObjectsByColumn))
                 SpriteRotation = GameplayHitObjectKeys.GetObjectRotation(Map.Mode, Info.Lane - 1);

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/HitObjects/GameplayHitObjectKeys.cs
@@ -198,8 +198,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             };
 
             // Set long note end properties.
-            LongNoteEndSprite.Image = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldEnds[lane];
-            LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.Image.Height / LongNoteEndSprite.Image.Width;
+            LongNoteEndSprite.Region = SkinManager.Skin.Keys[ruleset.Mode].NoteHoldEnds[lane];
+            LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.ImageHeight / LongNoteEndSprite.ImageWidth;
             LongNoteEndOffset = LongNoteEndSprite.Height / 2f;
 
             // Hits go above the hit object.
@@ -250,14 +250,14 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
             LongNoteEndSprite.ClearAnimations();
 
             // Update hitobject sprites
-            HitObjectSprite.Image = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode);
+            HitObjectSprite.Region = GetHitObjectTexture(info.Lane, manager.Ruleset.Mode);
             HitObjectSprite.Visible = true;
             HitObjectSprite.Tint = tint;
             StopLongNoteAnimation();
 
             // Update hit body's size to match image ratio
             HitObjectSprite.Size = new ScalableVector2(laneSize,
-                defaultLaneSize * HitObjectSprite.Image.Height / HitObjectSprite.Image.Width);
+                defaultLaneSize * HitObjectSprite.ImageHeight / HitObjectSprite.ImageWidth);
             LongNoteBodySprite.Width = laneSize;
             LongNoteEndSprite.Width = laneSize;
             LongNoteBodyOffset = HitObjectSprite.Height / 2;
@@ -278,12 +278,12 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
                 var bodies = GetHoldBodyTexture(info.Lane, manager.Ruleset.Mode);
                 LongNoteBodySprite.ReplaceFrames(bodies);
 
-                LongNoteEndSprite.Image = GetHoldEndTexture(info.Lane, manager.Ruleset.Mode);
+                LongNoteEndSprite.Region = GetHoldEndTexture(info.Lane, manager.Ruleset.Mode);
                 LongNoteEndSprite.Visible = SkinManager.Skin.Keys[Ruleset.Mode].DrawLongNoteEnd;
                 LongNoteBodySprite.Visible = true;
 
                 // Set long note end properties.
-                LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.Image.Height / LongNoteEndSprite.Image.Width;
+                LongNoteEndSprite.Height = laneSize * LongNoteEndSprite.ImageHeight / LongNoteEndSprite.ImageWidth;
                 LongNoteEndOffset = LongNoteEndSprite.Height / 2f;
 
                 InitializeLongNoteSize();
@@ -503,7 +503,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     If not, we default it to the first beat snap in the list.
         /// </summary>
         /// <returns></returns>
-        private Texture2D GetHitObjectTexture(int lane, GameMode mode)
+        private TextureRegion GetHitObjectTexture(int lane, GameMode mode)
         {
             lane = lane - 1;
             var skin = SkinManager.Skin.Keys[mode];
@@ -531,7 +531,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     the note is a long note or note.
         /// </summary>
         /// <returns></returns>
-        private List<Texture2D> GetHoldBodyTexture(int lane, GameMode mode)
+        private List<TextureRegion> GetHoldBodyTexture(int lane, GameMode mode)
         {
             lane = lane - 1;
             var skin = SkinManager.Skin.Keys[mode];
@@ -550,7 +550,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.HitObjects
         ///     the note is a long note or note.
         /// </summary>
         /// <returns></returns>
-        private Texture2D GetHoldEndTexture(int lane, GameMode mode)
+        private TextureRegion GetHoldEndTexture(int lane, GameMode mode)
         {
             lane = lane - 1;
             var skin = SkinManager.Skin.Keys[mode];

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/GameplayPlayfieldKeysStage.cs
@@ -413,7 +413,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
                     Size = new ScalableVector2(laneSize * scale, (Playfield.LaneSize * Skin.NoteReceptorsUp[i].Height / Skin.NoteReceptorsUp[i].Width) * scale),
                     Position = new ScalableVector2(posX, Playfield.ReceptorPositionY[i]),
                     Alignment = Alignment.TopLeft,
-                    Image = Skin.NoteReceptorsUp[i],
+                    Region = Skin.NoteReceptorsUp[i],
                     SpriteEffect = !Playfield.ScrollDirections[i].Equals(ScrollDirection.Down) && Skin.FlipNoteImagesOnUpscroll ? SpriteEffects.FlipVertically : SpriteEffects.None,
                     Rotation = Skin.RotateReceptorsByColumn ? Skin.ReceptorRotations[i] / 180f * MathF.PI : 0
                 });
@@ -641,8 +641,8 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
 
                 var scale = Skin.HitLightingScale / 100;
 
-                hl.Image = Skin.HitLighting.First();
-                hl.Size = new ScalableVector2(hl.Image.Width * scale, hl.Image.Height * scale);
+                hl.Region = Skin.HitLighting.First();
+                hl.Size = new ScalableVector2(hl.ImageWidth * scale, hl.ImageHeight * scale);
 
                 var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, hl.RelativeRectangle,
                     Receptors[i].ScreenRectangle);
@@ -737,7 +737,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
         /// </summary>
         public void SetReceptorAndLightingActivity(int index, bool pressed)
         {
-            Receptors[index].Image = pressed ? Skin.NoteReceptorsDown[index] : Skin.NoteReceptorsUp[index];
+            Receptors[index].Region = pressed ? Skin.NoteReceptorsDown[index] : Skin.NoteReceptorsUp[index];
             ColumnLightingObjects[index].Active = pressed;
         }
 

--- a/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
+++ b/Quaver.Shared/Screens/Gameplay/Rulesets/Keys/Playfield/HitLighting.cs
@@ -94,7 +94,7 @@ namespace Quaver.Shared.Screens.Gameplay.Rulesets.Keys.Playfield
             var previewScale = Playfield.LaneSize / (skin.ColumnSize * WindowManager.BaseToVirtualRatio);
             var scale = (skinScale / 100f) * previewScale;
 
-            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+            Size = new ScalableVector2(ImageWidth * scale, ImageHeight * scale);
 
             var relativeRect = new RectangleF(0, 0, RelativeRectangle.Width, RelativeRectangle.Height);
             var pos = GraphicsHelper.AlignRect(Alignment.MidCenter, relativeRect, Playfield.Stage.Receptors[ColumnIndex].ScreenRectangle);

--- a/Quaver.Shared/Screens/Gameplay/UI/ComboAlert.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/ComboAlert.cs
@@ -58,7 +58,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
             if (SkinManager.Skin.ComboAlerts.Count != 0)
             {
                 AlertSprite.Image = SkinManager.Skin.ComboAlerts.First();
-                AlertSprite.Size = new ScalableVector2(AlertSprite.Image.Width, AlertSprite.Image.Height);
+                AlertSprite.Size = new ScalableVector2(AlertSprite.ImageWidth, AlertSprite.ImageHeight);
                 AlertSprite.X = AlertSprite.Width;
             }
         }
@@ -85,7 +85,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                         TextureIndex = 0;
 
                     AlertSprite.Image = SkinManager.Skin.ComboAlerts[TextureIndex];
-                    AlertSprite.Size = new ScalableVector2(AlertSprite.Image.Width, AlertSprite.Image.Height);
+                    AlertSprite.Size = new ScalableVector2(AlertSprite.ImageWidth, AlertSprite.ImageHeight);
                     AlertSprite.X = AlertSprite.Width + 10;
 
                     AlertSprite

--- a/Quaver.Shared/Screens/Gameplay/UI/GradeDisplay.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/GradeDisplay.cs
@@ -80,7 +80,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// </summary>
         public void UpdateWidth()
         {
-            Width = Height * ((float)Image.Width / Image.Height);
+            Width = Height * ((float)ImageWidth / ImageHeight);
         }
     }
 }

--- a/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/JudgementHitBurst.cs
@@ -69,7 +69,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// <param name="frames"></param>
         /// <param name="size"></param>
         /// <param name="posY"></param>
-        public JudgementHitBurst(GameplayScreen screen, List<Texture2D> frames, Vector2 size, float posY) : base(frames)
+        public JudgementHitBurst(GameplayScreen screen, List<TextureRegion> frames, Vector2 size, float posY) : base(frames)
         {
             Screen = screen;
             OriginalPosY = posY;

--- a/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/PauseScreen.cs
@@ -133,7 +133,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 UsePreviousSpriteBatchOptions = true
             };
             Buttons.Add(Continue);
-            Continue.Size = new ScalableVector2(Continue.Image.Width, Continue.Image.Height);
+            Continue.Size = new ScalableVector2(Continue.ImageWidth, Continue.ImageHeight);
             Continue.Hovered += (o, e) => HoverButton(0);
 
             // Retry Button
@@ -147,7 +147,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 UsePreviousSpriteBatchOptions = true
             };
             Buttons.Add(Retry);
-            Retry.Size = new ScalableVector2(Retry.Image.Width, Retry.Image.Height);
+            Retry.Size = new ScalableVector2(Retry.ImageWidth, Retry.ImageHeight);
             Retry.Hovered += (o, e) => HoverButton(1);
 
             // Quit Button
@@ -161,7 +161,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
                 UsePreviousSpriteBatchOptions = true
             };
             Buttons.Add(Quit);
-            Quit.Size = new ScalableVector2(Quit.Image.Width, Quit.Image.Height);
+            Quit.Size = new ScalableVector2(Quit.ImageWidth, Quit.ImageHeight);
             Quit.Hovered += (o, e) => HoverButton(2);
 
             // Select continue button on initialization

--- a/Quaver.Shared/Screens/Gameplay/UI/SkipDisplay.cs
+++ b/Quaver.Shared/Screens/Gameplay/UI/SkipDisplay.cs
@@ -29,7 +29,7 @@ namespace Quaver.Shared.Screens.Gameplay.UI
         /// </summary>
         /// <param name="screen"></param>
         /// <param name="frames"></param>
-        internal SkipDisplay(GameplayScreen screen, List<Texture2D> frames) : base(frames)
+        internal SkipDisplay(GameplayScreen screen, List<TextureRegion> frames) : base(frames)
         {
             Screen = screen;
             Size = new ScalableVector2(230, 56);

--- a/Quaver.Shared/Screens/Multi/UI/Status/Name/MultiplayerChangeGameNameButton.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Status/Name/MultiplayerChangeGameNameButton.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Status.Name
 
             const float scale = 0.85f;
 
-            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+            Size = new ScalableVector2(ImageWidth * scale, ImageHeight * scale);
 
             Clicked += (sender, args) => DialogManager.Show(new ChangeGameNameDialog(Game.Value));
         }

--- a/Quaver.Shared/Screens/Multi/UI/Status/Password/MultiplayerEditPasswordButton.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Status/Password/MultiplayerEditPasswordButton.cs
@@ -23,7 +23,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Status.Password
 
             const float scale = 0.85f;
 
-            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+            Size = new ScalableVector2(ImageWidth * scale, ImageHeight * scale);
 
             Clicked += (sender, args) => DialogManager.Show(new ChangeGamePasswordDialog(Game.Value));
         }

--- a/Quaver.Shared/Screens/Multi/UI/Status/Selection/MultiplayerSelectMapButton.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Status/Selection/MultiplayerSelectMapButton.cs
@@ -24,7 +24,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Status.Selection
 
             const float scale = 0.85f;
 
-            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+            Size = new ScalableVector2(ImageWidth * scale, ImageHeight * scale);
 
             Clicked += (sender, args) =>
             {

--- a/Quaver.Shared/Screens/Multi/UI/Status/Sharing/ShareMultiplayerMapsetButton.cs
+++ b/Quaver.Shared/Screens/Multi/UI/Status/Sharing/ShareMultiplayerMapsetButton.cs
@@ -26,7 +26,7 @@ namespace Quaver.Shared.Screens.Multi.UI.Status.Sharing
 
             var scale = 0.85f;
 
-            Size = new ScalableVector2(Image.Width * scale, Image.Height * scale);
+            Size = new ScalableVector2(ImageWidth * scale, ImageHeight * scale);
 
             Clicked += (sender, args) => ShareMapset();
         }

--- a/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderContentContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Header/Contents/ResultsScreenHeaderContentContainer.cs
@@ -188,7 +188,7 @@ namespace Quaver.Shared.Screens.Results.UI.Header.Contents
 
             const int width = 110;
             
-            GradeSprite.Size = new ScalableVector2(width, (float) GradeSprite.Image.Height / GradeSprite.Image.Width * width);
+            GradeSprite.Size = new ScalableVector2(width, (float) GradeSprite.ImageHeight / GradeSprite.ImageWidth * width);
             GradeSprite.Y = -TabSelector.Height - 22;
         }
 

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Table/ResultsMultiplayerTable.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Multiplayer/Table/ResultsMultiplayerTable.cs
@@ -99,11 +99,11 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Multiplayer.Table
                 case MultiplayerGameRuleset.Free_For_All:
                 case MultiplayerGameRuleset.Battle_Royale:
                     Image = SkinManager.Skin?.Results?.ResultsMultiplayerFFAPanel ?? UserInterface.ResultsMultiplayerFFAPanel;
-                    Height = Image.Height + 4;
+                    Height = ImageHeight + 4;
                     break;
                 case MultiplayerGameRuleset.Team:
                     Image = SkinManager.Skin?.Results?.ResultsMultiplayerTeamPanel ?? UserInterface.ResultsMultiplayerTeamPanel;
-                    Height = Image.Height;
+                    Height = ImageHeight;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/ResultsOverviewGraphContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Graphs/ResultsOverviewGraphContainer.cs
@@ -124,7 +124,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Graphs
             ScoreSubmissionStats = scoreSubmissionStats;
 
             Image = SkinManager.Skin?.Results?.ResultsGraphContainerPanel ?? UserInterface.ResultsGraphContainerPanel;
-            Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, Image.Height);
+            Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, ImageHeight);
 
             Statistics = Processor.Value.Stats != null ? Processor.Value.GetHitStatistics() : new HitStatistics();
 

--- a/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Heading/ResultsOverviewScoreContainer.cs
+++ b/Quaver.Shared/Screens/Results/UI/Tabs/Overview/Heading/ResultsOverviewScoreContainer.cs
@@ -37,7 +37,7 @@ namespace Quaver.Shared.Screens.Results.UI.Tabs.Overview.Heading
             Processor = processor;
 
             Image = SkinManager.Skin?.Results?.ResultsScoreContainerPanel ?? UserInterface.ResultsScoreContainerPanel;
-            Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, Image.Height);
+            Size = new ScalableVector2(ResultsScreenView.CONTENT_WIDTH - ResultsTabContainer.PADDING_X, ImageHeight);
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/DrawableMapContainer.cs
@@ -123,7 +123,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
 
                 OnlineGrade.Visible = true;
                 OnlineGrade.Image = SkinManager.Skin.Grades[map.OnlineGrade];
-                OnlineGrade.Size = new ScalableVector2(width, (float) OnlineGrade.Image.Height / OnlineGrade.Image.Width * width);
+                OnlineGrade.Size = new ScalableVector2(width, (float) OnlineGrade.ImageHeight / OnlineGrade.ImageWidth * width);
 
                 Name.X = OnlineGrade.X + OnlineGrade.Width + 16;
                 ByText.X = Name.X;

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/DrawableMapsetContainer.cs
@@ -194,7 +194,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 
                     OnlineGrade.Visible = true;
                     OnlineGrade.Image = SkinManager.Skin.Grades[map.OnlineGrade];
-                    OnlineGrade.Size = new ScalableVector2(width, OnlineGrade.Image.Height / OnlineGrade.Image.Width * width);
+                    OnlineGrade.Size = new ScalableVector2(width, OnlineGrade.ImageHeight / OnlineGrade.ImageWidth * width);
 
                     Title.X = OnlineGrade.X + OnlineGrade.Width + 16;
                     Title.TruncateWithEllipsis(400 - (int)OnlineGrade.Width - 16);

--- a/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowSlider.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Modifiers/Dialogs/Windows/JudgementWindowSlider.cs
@@ -110,7 +110,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Modifiers.Dialogs.Windows
             {
                 Parent = this,
                 Alignment = Alignment.MidLeft,
-                Image = img,
+                Region = img,
                 Size = new ScalableVector2(110, 0),
             };
 

--- a/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentPlayerModifiers.cs
+++ b/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentPlayerModifiers.cs
@@ -64,7 +64,7 @@ namespace Quaver.Shared.Screens.Tournament.Overlay.Components
                         break;
                 }
 
-                icon.Size = new ScalableVector2(icon.Image.Width * scale, icon.Image.Height * scale);
+                icon.Size = new ScalableVector2(icon.ImageWidth * scale, icon.ImageHeight * scale);
                 totalSpacing += Settings.SpacingLayout.Value == Layout.Vertical ? icon.Height : icon.Width;
 
                 if (i != Icons.Count - 1)

--- a/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentPlayerWinnerDisplay.cs
+++ b/Quaver.Shared/Screens/Tournament/Overlay/Components/TournamentPlayerWinnerDisplay.cs
@@ -49,7 +49,7 @@ namespace Quaver.Shared.Screens.Tournament.Overlay.Components
                 var settings = (TournamentPlayerWinnerDisplaySettings) Settings;
                 var scale = settings.Scale.Value / 100f;
 
-                Icon.Size = new ScalableVector2(Icon.Image.Width * scale, Icon.Image.Height * scale);
+                Icon.Size = new ScalableVector2(Icon.ImageWidth * scale, Icon.ImageHeight * scale);
             }
         }
 

--- a/Quaver.Shared/Screens/V2/Main/MainMenuScreenView.cs
+++ b/Quaver.Shared/Screens/V2/Main/MainMenuScreenView.cs
@@ -158,7 +158,7 @@ namespace Quaver.Shared.Screens.V2.Main
                         TextureManager.Load(
                             "Quaver.Resources/Textures/UI/Screens/Main/Logos/logo-accent.png"),
                         accentColor);
-                Logo.Size = new ScalableVector2(Logo.Image.Width, Logo.Image.Height);
+                Logo.Size = new ScalableVector2(Logo.ImageWidth, Logo.ImageHeight);
             }
             else
             {
@@ -173,7 +173,7 @@ namespace Quaver.Shared.Screens.V2.Main
             }
 
             Logo.Parent = Content;
-            LogoOptions = new FlexItemOptions { Basis = Logo.Image.Height, Shrink = 1 };
+            LogoOptions = new FlexItemOptions { Basis = Logo.ImageHeight, Shrink = 1 };
             Content.SetItemOptions(Logo, LogoOptions);
 
             ActionRow = new FlexContainer

--- a/Quaver.Shared/Screens/V2/Main/UI/MainMenuNewsCard.cs
+++ b/Quaver.Shared/Screens/V2/Main/UI/MainMenuNewsCard.cs
@@ -197,8 +197,8 @@ namespace Quaver.Shared.Screens.V2.Main.UI
 
             public float ApplyWidth(float width)
             {
-                var height = Content.Image?.Width > 0 && Content.Image.Height > 0
-                    ? width * Content.Image.Height / Content.Image.Width
+                var height = Content.Image?.Width > 0 && Content.ImageHeight > 0
+                    ? width * Content.ImageHeight / Content.ImageWidth
                     : HeightValue;
 
                 Size = new ScalableVector2(width, height);

--- a/Quaver.Shared/Screens/V2/UI/ScreenNavigation.cs
+++ b/Quaver.Shared/Screens/V2/UI/ScreenNavigation.cs
@@ -432,7 +432,7 @@ namespace Quaver.Shared.Screens.V2.UI
                     : new Sprite { Image = texture };
             }
 
-            var aspectRatio = (float) ApplicationLogo.Image.Width / ApplicationLogo.Image.Height;
+            var aspectRatio = (float) ApplicationLogo.ImageWidth / ApplicationLogo.ImageHeight;
             var width = Config.Logo.Height * aspectRatio;
             ApplicationLogo.Size = new ScalableVector2(width, Config.Logo.Height);
             ApplicationLogo.Alignment = Alignment.MidLeft;

--- a/Quaver.Shared/Screens/V2/UI/TintableLogo.cs
+++ b/Quaver.Shared/Screens/V2/UI/TintableLogo.cs
@@ -62,8 +62,8 @@ namespace Quaver.Shared.Screens.V2.UI
         {
             foreach (var layer in Layers)
             {
-                var widthRatio = (float) layer.Image.Width / Image.Width;
-                var heightRatio = (float) layer.Image.Height / Image.Height;
+                var widthRatio = (float) layer.ImageWidth / ImageWidth;
+                var heightRatio = (float) layer.ImageHeight / ImageHeight;
                 layer.Size = new ScalableVector2(
                     size.X.Value * widthRatio,
                     size.Y.Value * heightRatio,

--- a/Quaver.Shared/Skinning/SkinKeys.cs
+++ b/Quaver.Shared/Skinning/SkinKeys.cs
@@ -27,6 +27,7 @@ using Quaver.Shared.Screens.Gameplay.UI.Health;
 using Wobble;
 using Wobble.Logging;
 using Quaver.Shared.Screens.Gameplay.UI;
+using Wobble.Graphics.Sprites;
 
 
 namespace Quaver.Shared.Skinning
@@ -409,90 +410,90 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteMines { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteMines { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteMineBodies { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteMineBodies { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> NoteMineEnds { get; } = new List<Texture2D>();
+        internal List<TextureRegion> NoteMineEnds { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteMineStarts { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteMineStarts { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteHitObjects { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteHitObjects { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteHoldHitObjects { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteHoldHitObjects { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<List<Texture2D>> NoteHoldBodies { get; } = new List<List<Texture2D>>();
+        internal List<List<TextureRegion>> NoteHoldBodies { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> NoteHoldEnds { get; } = new List<Texture2D>();
+        internal List<TextureRegion> NoteHoldEnds { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteHitObjects { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteHitObjects { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteHoldBodies { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteHoldBodies { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteHoldEnds { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteHoldEnds { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteMines { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteMines { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteMineBodies { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteMineBodies { get; } = [];
 
         /// <summary>
         /// </summary>
-        internal List<Texture2D> EditorLayerNoteMineEnds { get; } = new List<Texture2D>();
+        internal List<TextureRegion> EditorLayerNoteMineEnds { get; } = [];
 
         // ----- Receptors ----- //
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> NoteReceptorsUp { get; } = new List<Texture2D>();
+        internal List<TextureRegion> NoteReceptorsUp { get; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> NoteReceptorsDown { get; } = new List<Texture2D>();
+        internal List<TextureRegion> NoteReceptorsDown { get; } = [];
 
         // ----- Hitlighting ----- //
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> HitLighting { get; private set; } = new List<Texture2D>();
+        internal List<TextureRegion> HitLighting { get; private set; } = [];
 
         /// <summary>
         ///
         /// </summary>
-        internal List<Texture2D> HoldLighting { get; private set; } = new List<Texture2D>();
+        internal List<TextureRegion> HoldLighting { get; private set; } = [];
 
         // ----- Lane Covers ----- //
 
@@ -793,6 +794,31 @@ namespace Quaver.Shared.Skinning
         }
 
         /// <summary>
+        ///     Loads an individual skin element.
+        /// </summary>
+        /// <param name="folder"></param>
+        /// <param name="element"></param>
+        /// <param name="shared">If the resource is shared between key modes.</param>
+        /// <param name="extension"></param>
+        /// <returns></returns>
+        private TextureRegion LoadTexture(SkinKeysFolder folder, string element, TextureRegion? fallback, bool shared, string extension = ".png")
+        {
+            string resource;
+            if (shared)
+            {
+                resource = $"Quaver.Resources/Textures/Skins/Shared/{folder.ToString()}/{element}.png";
+            }
+            else
+            {
+                resource = $"Quaver.Resources/Textures/Skins/{DefaultSkin}/{ModeString(Mode)}/{folder.ToString()}" +
+                           $"/{GetResourcePath(element)}.png";
+            }
+
+            var folderName = shared ? folder.ToString() : $"/{ModeShorthand(Mode).ToLower()}/{folder.ToString()}";
+            return Store.LoadSingleTexture($"{Store.Dir}/{folderName}/{element}", resource, fallback);
+        }
+
+        /// <summary>
         ///     Loads a spritesheet
         /// </summary>
         /// <param name="folder"></param>
@@ -802,7 +828,7 @@ namespace Quaver.Shared.Skinning
         /// <param name="columns"></param>
         /// <param name="extension"></param>
         /// <returns></returns>
-        private List<Texture2D> LoadSpritesheet(SkinKeysFolder folder, string element, List<Texture2D>? fallback, bool shared, int rows, int columns, bool noResource = false)
+        private List<TextureRegion> LoadSpritesheet(SkinKeysFolder folder, string element, List<TextureRegion>? fallback, bool shared, int rows, int columns, bool noResource = false)
         {
             string resource = null;
             if (!noResource)
@@ -825,7 +851,7 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     Pads a snap texture list to the expected snap count.
         /// </summary>
-        private static List<Texture2D> PadSnapTextures(List<Texture2D> textures, int snapCount)
+        private static List<TextureRegion> PadSnapTextures(List<TextureRegion> textures, int snapCount)
         {
             var paddedTextures = textures.ToList();
 
@@ -862,12 +888,12 @@ namespace Quaver.Shared.Skinning
         /// <param name="element"></param>
         /// <param name="lane"></param>
         /// <returns></returns>
-        private void LoadHitObjects(IList<List<Texture2D>> hitObjects, string element, int lane, IList<List<Texture2D>>? fallback, List<int> fallbackIndicies)
+        private void LoadHitObjects(IList<List<TextureRegion>> hitObjects, string element, int lane, IList<List<TextureRegion>>? fallback, List<int> fallbackIndicies)
         {
             // First load the beginning HitObject element that doesn't require snapping.
             var fallbackTexture = fallback?[fallbackIndicies[lane]]?[0];
 
-            var objectsList = new List<Texture2D> { LoadTexture(SkinKeysFolder.HitObjects, element, fallbackTexture, false) };
+            var objectsList = new List<TextureRegion> { LoadTexture(SkinKeysFolder.HitObjects, element, fallbackTexture, false) };
 
             // Don't bother looking for snap objects if the skin config doesn't permit it.
             if (!ColorObjectsBySnapDistance)
@@ -880,7 +906,9 @@ namespace Quaver.Shared.Skinning
             // It HAS to be loaded in an incremental fashion.
             // So you can't have 1/48, but not have 1/3, etc.
             // If it can find the appropriate files, load them.
-            objectsList.AddRange(SnapSuffixes.Select((snap, snapIndex) => LoadTexture(SkinKeysFolder.HitObjects, $"{element}-{snap}", fallback?[fallbackIndicies[lane]]?[snapIndex + 1], false)));
+            objectsList.AddRange(SnapSuffixes.Select((snap, snapIndex) =>
+                LoadTexture(SkinKeysFolder.HitObjects, $"{element}-{snap}",
+                    fallback?[fallbackIndicies[lane]]?[snapIndex + 1], false)));
             hitObjects.Insert(lane, objectsList);
         }
 
@@ -936,13 +964,13 @@ namespace Quaver.Shared.Skinning
                         NoteMines.Add(mines);
 
                         // LoadSpriteSheet returns one UserInterface.BlankBox on error
-                        if (holdobjects.Any() && holdobjects[0] != UserInterface.BlankBox)
+                        if (holdobjects.Any() && holdobjects[0].Texture != UserInterface.BlankBox)
                             NoteHoldHitObjects.Add(holdobjects);
                         else
                             NoteHoldHitObjects.Add(hitobjects);
 
                         // LoadSpriteSheet returns one UserInterface.BlankBox on error
-                        if (mineStarts.Any() && mineStarts[0] != UserInterface.BlankBox)
+                        if (mineStarts.Any() && mineStarts[0].Texture != UserInterface.BlankBox)
                             NoteMineStarts.Add(mineStarts);
                         else
                             NoteMineStarts.Add(mines);

--- a/Quaver.Shared/Skinning/SkinStore.cs
+++ b/Quaver.Shared/Skinning/SkinStore.cs
@@ -28,6 +28,7 @@ using SkiaSharp;
 using Wobble;
 using Wobble.Assets;
 using Wobble.Audio.Samples;
+using Wobble.Graphics.Sprites;
 using Wobble.Graphics.UI.Form;
 using Wobble.Logging;
 
@@ -146,12 +147,12 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     The health bar displayed in the background. (Non-Moving one.)
         /// </summary>
-        internal List<Texture2D> HitBubblesBackground { get; private set; }
+        internal List<TextureRegion> HitBubblesBackground { get; private set; }
 
         /// <summary>
         ///     Judgement animation elements
         /// </summary>
-        internal Dictionary<Judgement, List<Texture2D>> Judgements { get; } = new Dictionary<Judgement, List<Texture2D>>();
+        internal Dictionary<Judgement, List<TextureRegion>> Judgements { get; } = [];
 
         /// <summary>
         ///     The numbers that display the user's current score.
@@ -256,17 +257,17 @@ namespace Quaver.Shared.Skinning
         /// <summary>
         ///     The health bar displayed in the background. (Non-Moving one.)
         /// </summary>
-        internal List<Texture2D> HealthBarBackground { get; private set; }
+        internal List<TextureRegion> HealthBarBackground { get; private set; }
 
         /// <summary>
         ///     The health bar displayed in the foreground (Moving)
         /// </summary>
-        internal List<Texture2D> HealthBarForeground { get; private set; }
+        internal List<TextureRegion> HealthBarForeground { get; private set; }
 
         /// <summary>
         ///     Skip animation when user is on a break.
         /// </summary>
-        internal List<Texture2D> Skip { get; private set; }
+        internal List<TextureRegion> Skip { get; private set; }
 
         /// <summary>
         ///     Displayed when the user achieves high combos
@@ -489,6 +490,44 @@ namespace Quaver.Shared.Skinning
         }
 
         /// <summary>
+        ///     Loads a single texture element.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="resource"></param>
+        /// <param name="extension"></param>
+        internal TextureRegion LoadSingleTexture(string path, string resource, TextureRegion? fallback, string extension = ".png")
+        {
+            path += extension;
+
+            try
+            {
+                byte[] buffer;
+                if (File.Exists(path))
+                {
+                    buffer = File.ReadAllBytes(path);
+                }
+                else
+                {
+                    if (fallback.HasValue)
+                    {
+                        return fallback.Value;
+                    }
+                    buffer = GameBase.Game.Resources.Get(resource);
+                    if (buffer == null)
+                    {
+                        return UserInterface.BlankBox;
+                    }
+                }
+                return GetTextureFromCacheOr(buffer, AssetLoader.LoadTexture2D);
+            }
+            catch (Exception)
+            {
+                Logger.Warning($"Failed to load: {resource}. Using default!", LogType.Runtime, false);
+                return UserInterface.BlankBox;
+            }
+        }
+
+        /// <summary>
         ///
         /// </summary>
         /// <param name="folder"></param>
@@ -498,7 +537,7 @@ namespace Quaver.Shared.Skinning
         /// <param name="columns"></param>
         /// <param name="extension"></param>
         /// <returns></returns>
-        internal List<Texture2D> LoadSpritesheet(string folder, string element, string resource, int rows, int columns, List<Texture2D>? fallback = null)
+        internal List<TextureRegion> LoadSpritesheet(string folder, string element, string resource, int rows, int columns, List<TextureRegion>? fallback = null)
         {
             try
             {
@@ -521,14 +560,14 @@ namespace Quaver.Shared.Skinning
                             // Load it up if so.
                             var texture = GetTextureFromCacheOr(file, AssetLoader.LoadTexture2D);
 
-                            return AssetLoader.LoadSpritesheetFromTexture(texture, int.Parse(match.Groups[1].Value),
+                            return AssetLoader.SpritesheetToRegions(texture, int.Parse(match.Groups[1].Value),
                                 int.Parse(match.Groups[2].Value));
                         }
 
                         // Otherwise check to see if that base element (without animations) actually exists.
                         // if so, load it singularly into a list.
                         if (Path.GetFileNameWithoutExtension(f) == element)
-                            return new List<Texture2D> { AssetLoader.LoadTexture2DFromFile(f) };
+                            return [AssetLoader.LoadTexture2DFromFile(f)];
                     }
                 }
 
@@ -540,21 +579,21 @@ namespace Quaver.Shared.Skinning
                 // If we end up getting down here, that means we need to load the spritesheet from our resources.
                 // if 0x0 is specified for the default, then it'll simply load the element without rowsxcolumns
                 if (rows == 0 && columns == 0)
-                    return new List<Texture2D> { LoadSingleTexture($"{dir}/{element}", resource + ".png", null) };
+                    return [LoadSingleTexture($"{dir}/{element}", resource + ".png", null)];
 
                 if (resource == null)
-                    return new List<Texture2D> { UserInterface.BlankBox };
+                    return [UserInterface.BlankBox];
 
                 var buffer = GameBase.Game.Resources.Get($"{resource}@{rows}x{columns}.png");
                 if (buffer == null)
-                    return new List<Texture2D> { UserInterface.BlankBox };
+                    return [UserInterface.BlankBox];
 
-                return AssetLoader.LoadSpritesheetFromTexture(AssetLoader.LoadTexture2D(buffer), rows, columns);
+                return AssetLoader.SpritesheetToRegions(AssetLoader.LoadTexture2D(buffer), rows, columns);
             }
             catch (Exception e)
             {
                 Logger.Error(e, LogType.Runtime);
-                return new List<Texture2D> { UserInterface.BlankBox };
+                return [UserInterface.BlankBox];
             }
         }
 


### PR DESCRIPTION
Requires https://github.com/Quaver/Wobble/pull/229

This reduces the loading time by a bit

Before:

<img width="902" height="309" alt="image" src="https://github.com/user-attachments/assets/51e7dbfb-f4bd-44a4-977a-ed0590c27bee" />

After:

<img width="902" height="309" alt="image" src="https://github.com/user-attachments/assets/4e5809ae-b5e0-4ccd-b160-484fceec75e0" />
