### PR TITLE
Fix delay between screen transitions

### DIFF
--- a/Quaver.Shared/Screens/QuaverScreenManager.cs
+++ b/Quaver.Shared/Screens/QuaverScreenManager.cs
@@ -66,13 +66,15 @@ namespace Quaver.Shared.Screens
             {
                 var screen = newScreen();
                 var retainedElements = GetRetainedElements(game.CurrentScreen, screen);
-                Transitioner.SetForegroundElements(GetTransitionForegroundElements(transitionMode,
-                    retainedElements));
+                Transitioner.SetForegroundElements(GetTransitionForegroundElements(transitionMode, retainedElements));
                 ChangeScreen(screen, retainedElements, true);
                 return;
             }
 
-            ScreenLoadTask.Run(new ScreenChangeRequest(newScreen, transitionMode), delay);
+            var currentKeys = game.CurrentScreen is IPersistentScreen persistent ? persistent.PersistentElementKeys : Array.Empty<string>();
+            var initialForegroundKeys = GetTransitionForegroundElements(transitionMode, currentKeys);
+
+            ScreenLoadTask.Run(new ScreenChangeRequest(newScreen, transitionMode, initialForegroundKeys), delay);
         }
 
         /// <summary>
@@ -83,6 +85,17 @@ namespace Quaver.Shared.Screens
         /// <returns></returns>
         private static QuaverScreen LoadScreen(ScreenChangeRequest request, CancellationToken token)
         {
+            Transitioner.FadeIn(request.ForegroundKeys);
+            // Wait for the transitioner to fully fade to black.
+            var waitStarted = Environment.TickCount64;
+            while (Transitioner.IsAnimating &&
+                   Environment.TickCount64 - waitStarted < TransitionWaitTimeout)
+                Thread.Sleep(16);
+
+            if (Transitioner.IsAnimating)
+                Logger.Warning("Screen transition fade-in timed out; forcing the screen switch and recovery fade.",
+                    LogType.Runtime);
+
             var screen = request.NewScreen();
             token.ThrowIfCancellationRequested();
 
@@ -100,18 +113,9 @@ namespace Quaver.Shared.Screens
             var game = (QuaverGame)GameBase.Game;
             var retainedElements = GetRetainedElements(game.CurrentScreen, e.Result);
             var foregroundElements = GetTransitionForegroundElements(e.Input.TransitionMode, retainedElements);
-
-            Transitioner.FadeIn(foregroundElements);
-
-            // Wait for the transitioner to fully fade to black.
-            var waitStarted = Environment.TickCount64;
-            while (Transitioner.IsAnimating &&
-                   Environment.TickCount64 - waitStarted < TransitionWaitTimeout)
-                Thread.Sleep(16);
-
-            if (Transitioner.IsAnimating)
-                Logger.Warning("Screen transition fade-in timed out; forcing the screen switch and recovery fade.",
-                    LogType.Runtime);
+            
+            // Replace elements 
+            Transitioner.SetForegroundElements(foregroundElements);
 
             // Run this on the next game loop on the main thread.
             game.ScheduleRenderTargetDraw(() => ChangeScreen(e.Result, retainedElements, false));
@@ -171,10 +175,13 @@ namespace Quaver.Shared.Screens
 
             public ScreenTransitionMode TransitionMode { get; }
 
-            public ScreenChangeRequest(Func<QuaverScreen> newScreen, ScreenTransitionMode transitionMode)
+            public IReadOnlyCollection<string> ForegroundKeys {  get; }
+
+            public ScreenChangeRequest(Func<QuaverScreen> newScreen, ScreenTransitionMode transitionMode, IReadOnlyCollection<string> foregroundKeys)
             {
                 NewScreen = newScreen;
                 TransitionMode = transitionMode;
+                ForegroundKeys = foregroundKeys;
             }
         }
     }


### PR DESCRIPTION
With the implementation of skin editor and new screen handler, the fade in animation to switch between screen started playing right after everything has already been ready to be loaded and basically was useless. This pr aims to fix it so that the fade in animation start as soon as the change screen request is recieved