### PR TITLE
Add quaver://editor/<map-id>/<selection> route

### DIFF
--- a/Quaver.Shared/IPC/QuaverIpcHandler.cs
+++ b/Quaver.Shared/IPC/QuaverIpcHandler.cs
@@ -101,11 +101,43 @@ namespace Quaver.Shared.IPC
             message = message.Replace("%7C", "|");
 
             var game = GameBase.Game as QuaverGame;
+            var screen = game?.CurrentScreen as EditScreen;
 
-            if (game?.CurrentScreen is EditScreen screen)
-                screen.GoToObjects(message);
-            else
-                NotificationManager.Show(NotificationLevel.Warning, "You must be in the editor to use this function!");
+            // Check for map id
+            var mapIdEndIndex = message.IndexOf('/');
+            if (mapIdEndIndex == -1)
+            {
+                // Format : quaver://editor/<selection>
+                if (screen != null)
+                    screen.GoToObjects(message);
+                else
+                    NotificationManager.Show(NotificationLevel.Warning, "You must be in the editor to use this function!");
+                return;
+            }
+
+            // Format: quaver://editor/<map-id>/<selection>
+            if (!int.TryParse(message.Substring(0, mapIdEndIndex), out var mapId))
+            {
+                NotificationManager.Show(NotificationLevel.Error, "The provided map id was not valid.");
+                return;
+            }
+
+            var map = MapManager.FindMapFromOnlineId(mapId);
+            if (map == null)
+            {
+                NotificationManager.Show(NotificationLevel.Warning, "This map must be downloaded before it can be opened in the editor.");
+                return;
+            }
+
+            var selection = message.Length > mapIdEndIndex ? message.Substring(mapIdEndIndex + 1) : null;
+            if (screen != null && mapId == screen.Map.MapId && selection != null)
+            {
+                screen.GoToObjects(selection);
+                return;
+            }
+
+            MapManager.Selected.Value = map;
+            game?.CurrentScreen?.Exit(() => new EditScreen(map, AudioEngine.LoadMapAudioTrack(map), initialSelection: selection));
         }
 
         /// <summary>

--- a/Quaver.Shared/Screens/Edit/EditScreen.cs
+++ b/Quaver.Shared/Screens/Edit/EditScreen.cs
@@ -368,20 +368,26 @@ namespace Quaver.Shared.Screens.Edit
         private PaulToulColorGenerator ColorGenerator { get; } = new();
 
         /// <summary>
+        ///     Initial note to be selected once the editor has loaded
         /// </summary>
-        public EditScreen(Map map, IAudioTrack track = null, EditorVisualTestBackground visualTestBackground = null) : this(map, track, visualTestBackground, false)
+        private string InitialSelection { get; }
+
+        /// <summary>
+        /// </summary>
+        public EditScreen(Map map, IAudioTrack track = null, EditorVisualTestBackground visualTestBackground = null, string initialSelection = null) : this(map, track, visualTestBackground, false, initialSelection)
         {
         }
 
-        private EditScreen(Map map, bool loadAudioTrackFromMapFile) : this(map, null, null, loadAudioTrackFromMapFile)
+        private EditScreen(Map map, bool loadAudioTrackFromMapFile) : this(map, null, null, loadAudioTrackFromMapFile, null)
         {
         }
 
-        private EditScreen(Map map, IAudioTrack track, EditorVisualTestBackground visualTestBackground, bool loadAudioTrackFromMapFile)
+        private EditScreen(Map map, IAudioTrack track, EditorVisualTestBackground visualTestBackground, bool loadAudioTrackFromMapFile, string initialSelection)
         {
             EditorPluginUtils.EditScreen = this;
             Map = map;
             BackgroundStore = visualTestBackground;
+            InitialSelection = initialSelection;
 
             try
             {
@@ -479,6 +485,9 @@ namespace Quaver.Shared.Screens.Edit
                 DialogManager.Show(new EditorMetadataDialog(this));
                 Map.NewlyCreated = false;
             }
+
+            if(!string.IsNullOrWhiteSpace(InitialSelection))
+                GoToObjects(InitialSelection);
 
             base.OnFirstUpdate();
         }


### PR DESCRIPTION
This is a big request QOL from RS and mappers that will allow them to open the game directly to a specific map to review modding stuff.
The final goal of this is to also have it be implemented on the website, so that any modding uses this format now. Old format (quaver/editor/<selection> is and will have to be supported in the future)

how do you test this ?
Basically, manually create an url (i for example used quaver://editor/139198/5016%7C4,5357%7C3,5697%7C2), open the dev build and execute the uri. No matter where you are in the game, as long as you have the map (so [139198](https://quavergame.com/mapset/map/139198) in this case), you should have the map opening and having 3 notes selected.
You can test with any other maps, just make sure that it is submitted online. For the selection part just use the go to function and replace | by %7C. You can also just open a map editor by doing quaver://editor/139198/ for example