### PR TITLE
fix broken select screen double click leaving result screen

### DIFF
--- a/Quaver.Shared/Input/Global/GlobalInputHandler.cs
+++ b/Quaver.Shared/Input/Global/GlobalInputHandler.cs
@@ -46,7 +46,11 @@ public class GlobalInputHandler : IInputHandler<GlobalKeybindActions>
     public void HandleAction(GlobalKeybindActions action, bool isKeyPress = true,
         bool isRelease = false)
     {
-        var scopes = GlobalInputManager.ScopeTokens.AsEnumerable().Reverse().ToList();
+        List<GlobalInputScopeToken> scopes;
+        lock (GlobalInputManager.ScopeTokensLock)
+            scopes = new List<GlobalInputScopeToken>(GlobalInputManager.ScopeTokens);
+        scopes.Reverse();
+
         var consumed = false;
         foreach (var scope in scopes)
         {

--- a/Quaver.Shared/Input/Global/GlobalInputManager.cs
+++ b/Quaver.Shared/Input/Global/GlobalInputManager.cs
@@ -6,6 +6,12 @@ public class GlobalInputManager : InputManager<GlobalKeybindActions>
 {
     public static List<GlobalInputScopeToken> ScopeTokens { get; } = [];
 
+    /// <summary>
+    ///     Screens can be built on a background thread while still loading so this lock keeps
+    ///     <see cref="ScopeTokens"/> safe to use from both that thread and the main thread's input handling.
+    /// </summary>
+    internal static readonly object ScopeTokensLock = new();
+
     private GlobalInputManager(GlobalInputConfig globalInputConfig) : base(
         globalInputConfig, new GlobalInputHandler())
     {

--- a/Quaver.Shared/Input/Global/GlobalInputScopeToken.cs
+++ b/Quaver.Shared/Input/Global/GlobalInputScopeToken.cs
@@ -12,13 +12,15 @@ public abstract class GlobalInputScopeToken : IDisposable
 
     protected GlobalInputScopeToken()
     {
-        GlobalInputManager.ScopeTokens.Add(this);
+        lock (GlobalInputManager.ScopeTokensLock)
+            GlobalInputManager.ScopeTokens.Add(this);
     }
 
     /// <inheritdoc />
     public void Dispose()
     {
-        GlobalInputManager.ScopeTokens.Remove(this);
+        lock (GlobalInputManager.ScopeTokensLock)
+            GlobalInputManager.ScopeTokens.Remove(this);
         GC.SuppressFinalize(this);
     }
 }

--- a/Quaver.Shared/Screens/QuaverScreenManager.cs
+++ b/Quaver.Shared/Screens/QuaverScreenManager.cs
@@ -38,6 +38,12 @@ namespace Quaver.Shared.Screens
         /// </summary>
         private static TaskHandler<ScreenChangeRequest, QuaverScreen> ScreenLoadTask { get; set; }
 
+        /// <summary>
+        ///     Incremented on every requested screen change. If a screen finishes loading with an
+        ///     outdated version it's been replaced by a newer request and gets destroyed instead of shown.
+        /// </summary>
+        private static long ScreenChangeVersion;
+
         public static void Initialize()
         {
             QuaverScreenFactory.Initialize(ConfigManager.UseNewScreens.Value);
@@ -52,15 +58,17 @@ namespace Quaver.Shared.Screens
         /// <param name="switchImmediately"></param>
         /// <param name="delay"></param>
         /// <param name="transitionMode"></param>
-        public static void ScheduleScreenChange(Func<QuaverScreen> newScreen, bool switchImmediately = false,
-            int delay = 0, ScreenTransitionMode transitionMode = ScreenTransitionMode.Auto)
+        public static void ScheduleScreenChange(Func<QuaverScreen> newScreen, bool switchImmediately = false, int delay = 0, ScreenTransitionMode transitionMode = ScreenTransitionMode.Auto)
         {
-            Logger.Important($"Scheduled Screen Change", LogType.Runtime);
-
             var game = (QuaverGame)GameBase.Game;
 
             if (game.CurrentScreen != null)
                 LastScreen = game.CurrentScreen.Type;
+
+            // This request replaces any screen load that's still in progress
+            var version = Interlocked.Increment(ref ScreenChangeVersion);
+
+            Logger.Important($"Scheduled Screen Change", LogType.Runtime);
 
             if (LastScreen == QuaverScreenType.None || switchImmediately)
             {
@@ -72,7 +80,7 @@ namespace Quaver.Shared.Screens
                 return;
             }
 
-            ScreenLoadTask.Run(new ScreenChangeRequest(newScreen, transitionMode), delay);
+            ScreenLoadTask.Run(new ScreenChangeRequest(newScreen, transitionMode, version), delay);
         }
 
         /// <summary>
@@ -84,9 +92,20 @@ namespace Quaver.Shared.Screens
         private static QuaverScreen LoadScreen(ScreenChangeRequest request, CancellationToken token)
         {
             var screen = request.NewScreen();
-            token.ThrowIfCancellationRequested();
 
-            Logger.Important($"Screen `{screen.Type}` has been loaded proceeding to switch.", LogType.Runtime);
+            if (token.IsCancellationRequested)
+            {
+                // A newer screen change came in while this was still loading. Destroy the screen we
+                // just built so it doesn't leak input scopes or event subscriptions.
+                Logger.Important(
+                    $"Screen `{screen.Type}` (version: {request.Version}) was cancelled mid-load, destroying it.",
+                    LogType.Runtime);
+                var game = (QuaverGame)GameBase.Game;
+                game.ScheduleRenderTargetDraw(() => screen.Destroy());
+                token.ThrowIfCancellationRequested();
+            }
+
+            Logger.Important($"Screen `{screen.Type}` (version: {request.Version}) has been loaded proceeding to switch.", LogType.Runtime);
             return screen;
         }
 
@@ -98,6 +117,17 @@ namespace Quaver.Shared.Screens
         private static void OnCompleted(object sender, TaskCompleteEventArgs<ScreenChangeRequest, QuaverScreen> e)
         {
             var game = (QuaverGame)GameBase.Game;
+
+            // A newer screen change came in while this one was still loading. Throw this screen away instead of showing it
+            if (Interlocked.Read(ref ScreenChangeVersion) != e.Input.Version)
+            {
+                Logger.Important(
+                    $"Discarding loaded screen `{e.Result.Type}` (version: {e.Input.Version}) - superseded by version {Interlocked.Read(ref ScreenChangeVersion)} before fade.",
+                    LogType.Runtime);
+                game.ScheduleRenderTargetDraw(() => e.Result.Destroy());
+                return;
+            }
+
             var retainedElements = GetRetainedElements(game.CurrentScreen, e.Result);
             var foregroundElements = GetTransitionForegroundElements(e.Input.TransitionMode, retainedElements);
 
@@ -114,7 +144,19 @@ namespace Quaver.Shared.Screens
                     LogType.Runtime);
 
             // Run this on the next game loop on the main thread.
-            game.ScheduleRenderTargetDraw(() => ChangeScreen(e.Result, retainedElements, false));
+            game.ScheduleRenderTargetDraw(() =>
+            {
+                if (Interlocked.Read(ref ScreenChangeVersion) != e.Input.Version)
+                {
+                    Logger.Important(
+                        $"Discarding faded-in screen `{e.Result.Type}` (version: {e.Input.Version}) - superseded by version {Interlocked.Read(ref ScreenChangeVersion)} after fade.",
+                        LogType.Runtime);
+                    e.Result.Destroy();
+                    return;
+                }
+
+                ChangeScreen(e.Result, retainedElements, false);
+            });
         }
 
         private static IReadOnlyCollection<string> GetRetainedElements(QuaverScreen currentScreen,
@@ -171,10 +213,13 @@ namespace Quaver.Shared.Screens
 
             public ScreenTransitionMode TransitionMode { get; }
 
-            public ScreenChangeRequest(Func<QuaverScreen> newScreen, ScreenTransitionMode transitionMode)
+            public long Version { get; }
+
+            public ScreenChangeRequest(Func<QuaverScreen> newScreen, ScreenTransitionMode transitionMode, long version)
             {
                 NewScreen = newScreen;
                 TransitionMode = transitionMode;
+                Version = version;
             }
         }
     }


### PR DESCRIPTION
Made by TDMG
this fixes the broken select screen that could show up when pressing escape twice fast on the results screen. a second screen change could race the first one and show a half loaded select screen instead of properly moving on breaking the leaderboard, audio, and escape key. now the older outdated screen change gets thrown away instead of being shown.