### PR TITLE
Crash after spamming space while loading into a map

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -193,7 +193,7 @@ namespace Quaver.Shared.Screens.Gameplay
         /// <summary>
         ///     If the play is finished.
         /// </summary>
-        public bool IsPlayComplete => Ruleset.HitObjectManager.IsComplete;
+        public bool IsPlayComplete => Ruleset?.HitObjectManager?.IsComplete ?? false;
 
         /// <summary>
         ///     If the user quit the game themselves.
@@ -423,8 +423,6 @@ namespace Quaver.Shared.Screens.Gameplay
             bool isCalibratingOffset = false, SpectatorClient spectatorClient = null, TournamentPlayerOptions options = null, bool isSongSelectPreview = false,
             bool isTestPlayingInNewEditor = false, bool useExistingAudioTime = false, bool shouldShowEpilepsyWarning = true)
         {
-            GlobalInputToken = new Token(this);
-
             if (isPlayTesting && !isSongSelectPreview)
             {
                 var testingQua = map.DeepClone();
@@ -517,6 +515,8 @@ namespace Quaver.Shared.Screens.Gameplay
                 IsMultiplayerGameStarted = true;
                 HasStarted = true;
             }
+
+            GlobalInputToken = new Token(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Made by TDMG
this fixes a crash from pressing space too fast while a map is loading. the game builds the gameplay screen in the background while it loads, but it was letting that screen react to key presses before it was actually ready. now it waits until the screen is fully ready before it can respond to key presses and added a backup check so it can't crash this way even if something similar happens again.

tested before and after using this map: https://quavergame.com/mapset/map/68380 (the bug is easier to perform on a big map)