### PR TITLE
Map offset could be changed while in multi lobby

### DIFF
--- a/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
+++ b/Quaver.Shared/Screens/Multi/MultiplayerGameScreen.cs
@@ -301,13 +301,6 @@ namespace Quaver.Shared.Screens.Multi
                 return GlobalInputHandleResult.Consumed;
             }
 
-            if ((action.BaseWithLayer()) == GlobalKeybindActions.IncreaseOffset &&
-                MapManager.Selected.Value != null)
-            {
-                GlobalInputHandler.HandleOffsetAction(action);
-                return GlobalInputHandleResult.Consumed;
-            }
-
             return GlobalInputHandleResult.Pass;
         }
 


### PR DESCRIPTION
this pr "fixes" it so like before you can only change the map local offset while ingame. this because it was now overlapping inputs like changing the speed rate