### PR TITLE
disabling keybind manager in gameplay when f8 / f9 is open

### DIFF
--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -693,7 +693,8 @@ namespace Quaver.Shared.Screens.Gameplay
                         return GlobalInputHandleResult.Consumed;
                     break;
                 case GlobalKeybindActions.GameplayQuickExit:
-                    if (!IsPlayComplete && !IsCalibratingOffset || IsMultiplayerGame || IsSongSelectPreview)
+                    if (!OnlineChat.Instance.IsOpen &&
+                        (!IsPlayComplete && !IsCalibratingOffset || IsMultiplayerGame || IsSongSelectPreview))
                     {
                         HandleQuickExit();
                         return GlobalInputHandleResult.Consumed;

--- a/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
+++ b/Quaver.Shared/Screens/Gameplay/GameplayScreen.cs
@@ -630,6 +630,9 @@ namespace Quaver.Shared.Screens.Gameplay
             if (Exiting)
                 return GlobalInputHandleResult.Pass;
 
+            if (OnlineChat.Instance.IsOpen)
+                return GlobalInputHandleResult.Pass;
+
             if (IsSongSelectPreview && !IsSongSelectPreviewDisplayed)
                 return GlobalInputHandleResult.Pass;
 
@@ -693,8 +696,7 @@ namespace Quaver.Shared.Screens.Gameplay
                         return GlobalInputHandleResult.Consumed;
                     break;
                 case GlobalKeybindActions.GameplayQuickExit:
-                    if (!OnlineChat.Instance.IsOpen &&
-                        (!IsPlayComplete && !IsCalibratingOffset || IsMultiplayerGame || IsSongSelectPreview))
+                    if (!IsPlayComplete && !IsCalibratingOffset || IsMultiplayerGame || IsSongSelectPreview)
                     {
                         HandleQuickExit();
                         return GlobalInputHandleResult.Consumed;


### PR DESCRIPTION
this pr has been made to prevent accidental leaves of the multi lobby within the gameplay if you want to chat when you've already failed/given up the map (for example if quick exit has been bound to backspace). it now disables everything from the keybind manager.