### PR TITLE
export option only visible when you rightclick the selected map and keyboard navigation closes the right click tab

### DIFF
--- a/Quaver.Shared/Screens/Selection/SelectionScreen.cs
+++ b/Quaver.Shared/Screens/Selection/SelectionScreen.cs
@@ -154,6 +154,8 @@ namespace Quaver.Shared.Screens.Selection
             MapManager.MapUpdated += OnMapUpdated;
             MapManager.SongRequestPlayed += OnSongRequestPlayed;
             MapManager.Selected.ValueChanged += OnSelectedMapChangedForStreamerFiles;
+            MapManager.Selected.ValueChanged += OnSelectedMapChangedCloseRightClickOptions;
+            ActiveScrollContainer.ValueChanged += OnActiveScrollContainerChangedCloseRightClickOptions;
             ConfigManager.AutoLoadOsuBeatmaps.ValueChanged += OnAutoLoadOsuBeatmapsChanged;
 
             MapLoadingScreen.QueueStreamerFilesWrite();
@@ -207,6 +209,8 @@ namespace Quaver.Shared.Screens.Selection
             MapManager.MapUpdated -= OnMapUpdated;
             MapManager.SongRequestPlayed -= OnSongRequestPlayed;
             MapManager.Selected.ValueChanged -= OnSelectedMapChangedForStreamerFiles;
+            MapManager.Selected.ValueChanged -= OnSelectedMapChangedCloseRightClickOptions;
+            ActiveScrollContainer.ValueChanged -= OnActiveScrollContainerChangedCloseRightClickOptions;
             SkinManager.StopWatching();
 
             // ReSharper disable once DelegateSubtraction
@@ -986,6 +990,24 @@ namespace Quaver.Shared.Screens.Selection
         /// <param name="e"></param>
         private void OnSelectedMapChangedForStreamerFiles(object sender, BindableValueChangedEventArgs<Map> e)
             => MapLoadingScreen.QueueStreamerFilesWrite(250);
+
+        /// <summary>
+        ///     Closes the right-click menu on keyboard map navigation
+        /// </summary>
+        private void OnSelectedMapChangedCloseRightClickOptions(object sender, BindableValueChangedEventArgs<Map> e)
+        {
+            if (ActiveRightClickOptions != null && ActiveRightClickOptions.Opened)
+                ActiveRightClickOptions.Close();
+        }
+
+        /// <summary>
+        ///     Closes the right-click menu on keyboard scroll container navigation
+        /// </summary>
+        private void OnActiveScrollContainerChangedCloseRightClickOptions(object sender,BindableValueChangedEventArgs<SelectScrollContainerType> e)
+        {
+            if (ActiveRightClickOptions != null && ActiveRightClickOptions.Opened)
+                ActiveRightClickOptions.Close();
+        }
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Selection/UI/Maps/MapRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Maps/MapRightClickOptions.cs
@@ -65,7 +65,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         private const string DeleteMapset = "Delete Mapset";
         /// <summary>
         /// </summary>
-        public MapRightClickOptions(DrawableMap drawableMap) : base(GetOptions(), OptionsSize, FontSize)
+        public MapRightClickOptions(DrawableMap drawableMap) : base(GetOptions(drawableMap.Item == MapManager.Selected.Value), OptionsSize, FontSize)
         {
             DrawableMap = drawableMap;
             Map = DrawableMap.Item;
@@ -76,7 +76,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         /// <summary>
         /// </summary>
         /// <param name="drawableMapset"></param>
-        public MapRightClickOptions(DrawableMapset drawableMapset) : base(GetOptions(), OptionsSize, FontSize)
+        public MapRightClickOptions(DrawableMapset drawableMapset) : base(GetOptions(drawableMapset.Item.Maps.First() == MapManager.Selected.Value), OptionsSize, FontSize)
         {
             DrawableMapset = drawableMapset;
             Map = DrawableMapset.Item.Maps.First();
@@ -178,17 +178,25 @@ namespace Quaver.Shared.Screens.Selection.UI.Maps
         ///     Returns the options to select
         /// </summary>
         /// <returns></returns>
-        private static Dictionary<string, Color> GetOptions() => new Dictionary<string, Color>()
+        private static Dictionary<string, Color> GetOptions(bool includeExport)
         {
-            {Play, Color.White},
-            {Edit, ColorHelper.HexToColor("#F2994A")},
-            {AddToPlaylist, ColorHelper.HexToColor("#27B06E")},
-            {Delete, ColorHelper.HexToColor($"#FF6868")},
-            {DeleteMapset, ColorHelper.HexToColor($"#FF6868")},
-            {DeleteLocalScores, ColorHelper.HexToColor($"#FF6868")},
-            {Export, ColorHelper.HexToColor("#0787E3")},
-            {OpenMapsetFolder, ColorHelper.HexToColor("#9B51E0")},
-            {ViewOnlineListing, ColorHelper.HexToColor("#FFE76B")},
-        };
+            var options = new Dictionary<string, Color>()
+            {
+                {Play, Color.White},
+                {Edit, ColorHelper.HexToColor("#F2994A")},
+                {AddToPlaylist, ColorHelper.HexToColor("#27B06E")},
+                {Delete, ColorHelper.HexToColor($"#FF6868")},
+                {DeleteMapset, ColorHelper.HexToColor($"#FF6868")},
+                {DeleteLocalScores, ColorHelper.HexToColor($"#FF6868")},
+            };
+            
+            if (includeExport)
+                options.Add(Export, ColorHelper.HexToColor("#0787E3"));
+
+            options.Add(OpenMapsetFolder, ColorHelper.HexToColor("#9B51E0"));
+            options.Add(ViewOnlineListing, ColorHelper.HexToColor("#FFE76B"));
+
+            return options;
+        }
     }
 }

--- a/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
+++ b/Quaver.Shared/Screens/Selection/UI/Mapsets/MapsetRightClickOptions.cs
@@ -41,16 +41,7 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
 
         /// <summary>
         /// </summary>
-        public MapsetRightClickOptions(DrawableMapset drawableMapset) : base(new Dictionary<string, Color>()
-        {
-            {Play, Color.White},
-            {Edit, ColorHelper.HexToColor("#F2994A")},
-            {AddToPlaylist, ColorHelper.HexToColor("#27B06E")},
-            {Delete, ColorHelper.HexToColor($"#FF6868")},
-            {Export, ColorHelper.HexToColor("#0787E3")},
-            {OpenMapsetFolder, ColorHelper.HexToColor("#9B51E0")},
-            {ViewOnlineListing, ColorHelper.HexToColor("#FFE76B")},
-        }, new ScalableVector2(200, 40), 18)
+        public MapsetRightClickOptions(DrawableMapset drawableMapset) : base(GetOptions(drawableMapset.Item.Maps.Contains(MapManager.Selected.Value)), new ScalableVector2(200, 40), 18)
         {
             DrawableMapset = drawableMapset;
             Mapset = DrawableMapset.Item;
@@ -113,6 +104,25 @@ namespace Quaver.Shared.Screens.Selection.UI.Mapsets
                         break;
                 }
             };
+        }
+        
+        private static Dictionary<string, Color> GetOptions(bool includeExport)
+        {
+            var options = new Dictionary<string, Color>()
+            {
+                {Play, Color.White},
+                {Edit, ColorHelper.HexToColor("#F2994A")},
+                {AddToPlaylist, ColorHelper.HexToColor("#27B06E")},
+                {Delete, ColorHelper.HexToColor($"#FF6868")},
+            };
+
+            if (includeExport)
+                options.Add(Export, ColorHelper.HexToColor("#0787E3"));
+
+            options.Add(OpenMapsetFolder, ColorHelper.HexToColor("#9B51E0"));
+            options.Add(ViewOnlineListing, ColorHelper.HexToColor("#FFE76B"));
+
+            return options;
         }
 
         /// <summary>


### PR DESCRIPTION
this PR is made to create it that you arent able to see the export option when you rightclick a map that is not the current selected one (requested by a6). This fixes the issue of the message saying a completely different map then the one that is exported. this PR also fixes it that the tab wont stay open if you use the keyboard navigation after you've first opened it with your mouse. 