### PR TITLE
Add playback control to plugin state #2 (honk shoo honk shoo)

### DIFF
--- a/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorActionManager.cs
@@ -786,6 +786,16 @@ namespace Quaver.Shared.Screens.Edit.Actions
                 Perform(new EditorActionChangeTimingGroupColor(this, WorkingMap, timingGroup, color), fromLua);
         }
 
+        public void StartPlayback(bool fromLua = false)
+        {
+            EditScreen.Track.Play();
+        }
+
+        public void StopPlayback(bool fromLua = false)
+        {
+            EditScreen.Track.Stop();
+        }
+
         /// <summary>
         /// </summary>
         /// <param name="input"></param>

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -209,6 +209,14 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
+        public void StartPlayback() => ActionManager.StartPlayback();
+
+        /// <summary>
+        /// </summary>
+        public void StopPlayback() => ActionManager.StopPlayback();
+
+        /// <summary>
+        /// </summary>
         /// <param name="input"></param>
         public void GoToObjects(string input) => ActionManager.GoToObjects(input, true);
 

--- a/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
+++ b/Quaver.Shared/Screens/Edit/Actions/EditorPluginActionManager.cs
@@ -209,11 +209,11 @@ namespace Quaver.Shared.Screens.Edit.Actions
 
         /// <summary>
         /// </summary>
-        public void StartPlayback() => ActionManager.StartPlayback();
+        public void StartPlayback() => ActionManager.StartPlayback(true);
 
         /// <summary>
         /// </summary>
-        public void StopPlayback() => ActionManager.StopPlayback();
+        public void StopPlayback() => ActionManager.StopPlayback(true);
 
         /// <summary>
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
@@ -20,6 +20,8 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// </summary>
         public double SongTime => EditorPluginUtils.EditScreen.Track.Time;
 
+        public bool IsPlaying => EditorPluginUtils.EditScreen.Track.IsPlaying;
+
         /// <summary>
         ///     The objects that are currently selected by the user
         /// </summary>
@@ -38,7 +40,7 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         ///     Current scroll group we're working on
         /// </summary>
         public ScrollGroup SelectedScrollGroup => EditorPluginUtils.EditScreen.SelectedScrollGroup;
-        
+
         /// <summary>
         ///     The current scroll velocity in the map
         /// </summary>

--- a/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
+++ b/Quaver.Shared/Screens/Edit/Plugins/EditorPluginState.cs
@@ -18,7 +18,11 @@ namespace Quaver.Shared.Screens.Edit.Plugins
         /// <summary>
         ///     The current time in the song
         /// </summary>
-        public double SongTime => EditorPluginUtils.EditScreen.Track.Time;
+        public double SongTime
+        {
+            get => EditorPluginUtils.EditScreen.Track.Time;
+            set => EditorPluginUtils.EditScreen.Track.Seek(value);
+        }
 
         public bool IsPlaying => EditorPluginUtils.EditScreen.Track.IsPlaying;
 


### PR DESCRIPTION
Test plugin: [temp.zip](https://github.com/user-attachments/files/31869488/temp.zip)

Adds new field, `state.IsPlaying`, which returns a boolean corresponding to the editor playback status.
Now allows `state.SongTime` to be set, which allows the plugin developer to skip `actions.GoToObjects` regex manipulation.
Added two new functions, `actions.StartPlayback()` and `actions.StopPlayback()`. Both of these functions were tested to make sure that calling the same one twice does not cause any issues.

absolutely no other changes were performed at any moment in time